### PR TITLE
Update vulnerable path-to-regexp dependency

### DIFF
--- a/.changeset/sixty-parents-stare.md
+++ b/.changeset/sixty-parents-stare.md
@@ -1,5 +1,5 @@
 ---
-"open-next": patch
+"@opennextjs/aws": patch
 ---
 
 Update vulnerable path-to-regexp dependency

--- a/.changeset/sixty-parents-stare.md
+++ b/.changeset/sixty-parents-stare.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Update vulnerable path-to-regexp dependency

--- a/package.json
+++ b/package.json
@@ -17,14 +17,13 @@
     "version": "./.changeset/version",
     "release": "./.changeset/release",
     "release-snapshot": "./.changeset/snapshot"
-    
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.4",
     "@changesets/cli": "^2.22.0",
     "@sladg/eslint-config-base": "1.4.1",
     "eslint": "^8.47.0",
-     "turbo": "1.10.12"
+    "turbo": "1.10.12"
   },
   "engines": {
     "node": ">=16",

--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -45,7 +45,7 @@
     "aws4fetch": "^1.0.18",
     "chalk": "^5.3.0",
     "esbuild": "0.19.2",
-    "path-to-regexp": "^6.2.1",
+    "path-to-regexp": "^6.3.0",
     "promise.series": "^0.2.0",
     "urlpattern-polyfill": "^10.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,8 +277,8 @@ importers:
         specifier: 0.19.2
         version: 0.19.2
       path-to-regexp:
-        specifier: ^6.2.1
-        version: 6.2.1
+        specifier: ^6.3.0
+        version: 6.3.0
       promise.series:
         specifier: ^0.2.0
         version: 0.2.0
@@ -13276,8 +13276,8 @@ packages:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
     dev: true
 
-  /path-to-regexp@6.2.1:
-    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
+  /path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
     dev: false
 
   /path-type@4.0.0:


### PR DESCRIPTION
Updates `path-to-regexp` to resolve https://github.com/advisories/GHSA-9wv6-86v2-598j