### PR TITLE
Fix cloudflare env

### DIFF
--- a/.changeset/weak-hotels-thank.md
+++ b/.changeset/weak-hotels-thank.md
@@ -1,0 +1,8 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix cloudflare env
+Fix an issue with cookies and the node wrapper
+Fix some issue with cookies being not properly set when set both in the routing layer and the route itself
+Added option for headers priority

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -761,6 +761,7 @@ async function createMiddleware() {
       entrypoint: path.join(__dirname, "core", "edgeFunctionHandler.js"),
       outfile: path.join(outputDir, ".build", "middleware.mjs"),
       ...commonMiddlewareOptions,
+      onlyBuildOnce: true,
     });
   }
 }

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -754,6 +754,7 @@ async function createMiddleware() {
       overrides: config.middleware?.override,
       defaultConverter: "aws-cloudfront",
       includeCache: config.dangerous?.enableCacheInterception,
+      additionalExternals: config.edgeExternals,
     });
   } else {
     await buildEdgeBundle({

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -51,7 +51,7 @@ export async function createServerBundle(
     const routes = fnOptions.routes;
     routes.forEach((route) => foundRoutes.add(route));
     if (fnOptions.runtime === "edge") {
-      await generateEdgeBundle(name, options, fnOptions);
+      await generateEdgeBundle(name, config, options, fnOptions);
     } else {
       await generateBundle(name, config, options, fnOptions);
     }

--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -32,6 +32,7 @@ interface BuildEdgeBundleOptions {
   additionalInject?: string;
   includeCache?: boolean;
   additionalExternals?: string[];
+  onlyBuildOnce?: boolean;
 }
 
 export async function buildEdgeBundle({
@@ -45,6 +46,7 @@ export async function buildEdgeBundle({
   additionalInject,
   includeCache,
   additionalExternals,
+  onlyBuildOnce,
 }: BuildEdgeBundleOptions) {
   const isInCloudfare =
     typeof overrides?.wrapper === "string"
@@ -143,20 +145,22 @@ globalThis.AsyncLocalStorage = AsyncLocalStorage;
     options,
   );
 
-  await build({
-    entryPoints: [outfile],
-    outfile,
-    allowOverwrite: true,
-    bundle: true,
-    minify: true,
-    platform: "node",
-    format: "esm",
-    conditions: ["workerd", "worker", "browser"],
-    external: ["node:*", ...(additionalExternals ?? [])],
-    banner: {
-      js: 'import * as process from "node:process";',
-    },
-  });
+  if (!onlyBuildOnce) {
+    await build({
+      entryPoints: [outfile],
+      outfile,
+      allowOverwrite: true,
+      bundle: true,
+      minify: true,
+      platform: "node",
+      format: "esm",
+      conditions: ["workerd", "worker", "browser"],
+      external: ["node:*", ...(additionalExternals ?? [])],
+      banner: {
+        js: 'import * as process from "node:process";',
+      },
+    });
+  }
 }
 
 export function copyMiddlewareAssetsAndWasm({}) {}

--- a/packages/open-next/src/core/createMainHandler.ts
+++ b/packages/open-next/src/core/createMainHandler.ts
@@ -25,6 +25,7 @@ declare global {
     requestId: string;
     pendingPromiseRunner: DetachedPromiseRunner;
     isISRRevalidation?: boolean;
+    mergeHeadersPriority?: "middleware" | "handler";
   }>;
 }
 

--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -176,10 +176,6 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
       };
     }
     this.fixHeaders(this.headers);
-    if (this._cookies.length > 0) {
-      // For cookies we cannot do the same as for other headers
-      this.headers[SET_COOKIE_HEADER] = this._cookies;
-    }
 
     if (this.streamCreator) {
       this.responseStream = this.streamCreator?.writeHeaders({

--- a/packages/open-next/src/plugins/edge.ts
+++ b/packages/open-next/src/plugins/edge.ts
@@ -92,16 +92,8 @@ export function openNextEdgePlugins({
         contents = `
 globalThis._ENTRIES = {};
 globalThis.self = globalThis;
-if(!globalThis.process){
-  globalThis.process = {env: {}};
-}
 globalThis._ROUTES = ${JSON.stringify(routes)};
 
-import {Buffer} from "node:buffer";
-globalThis.Buffer = Buffer;
-
-import {AsyncLocalStorage} from "node:async_hooks";
-globalThis.AsyncLocalStorage = AsyncLocalStorage;
 ${
   isInCloudfare
     ? ``

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -49,6 +49,14 @@ export interface DangerousOptions {
    * @default false
    */
   enableCacheInterception?: boolean;
+  /**
+   * Function to determine which headers or cookies takes precedence.
+   * By default, the middleware headers and cookies will override the handler headers and cookies.
+   * This is executed for every request and after next config headers and middleware has executed.
+   */
+  headersAndCookiesPriority?: (
+    event: InternalEvent,
+  ) => "middleware" | "handler";
 }
 
 export type BaseOverride = {

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -83,6 +83,7 @@ export type Wrapper<
 > = BaseOverride & {
   wrapper: WrapperHandler<E, R>;
   supportStreaming: boolean;
+  edgeRuntime?: boolean;
 };
 
 export type Warmer = BaseOverride & {

--- a/packages/open-next/src/wrappers/aws-lambda-streaming.ts
+++ b/packages/open-next/src/wrappers/aws-lambda-streaming.ts
@@ -35,8 +35,6 @@ const handler: WrapperHandler = async (handler, converter) =>
         return;
       }
 
-      let headersWritten = false;
-
       const internalEvent = await converter.convertFrom(event);
 
       //Handle compression
@@ -84,14 +82,12 @@ const handler: WrapperHandler = async (handler, converter) =>
             "application/vnd.awslambda.http-integration-response",
           );
           _prelude.headers["content-encoding"] = contentEncoding;
-          // We need to remove the set-cookie header as otherwise it will be set twice, once with the cookies in the prelude, and a second time with the set-cookie headers
-          delete _prelude.headers["set-cookie"];
+
           const prelude = JSON.stringify(_prelude);
 
           responseStream.write(prelude);
 
           responseStream.write(new Uint8Array(8));
-          headersWritten = true;
 
           return compressedStream ?? responseStream;
         },

--- a/packages/open-next/src/wrappers/cloudflare.ts
+++ b/packages/open-next/src/wrappers/cloudflare.ts
@@ -12,8 +12,16 @@ const handler: WrapperHandler<
 > =
   async (handler, converter) =>
   async (event: Request, env: Record<string, string>): Promise<Response> => {
-    //@ts-expect-error - process is not defined in cloudflare workers
-    globalThis.process = { env };
+    globalThis.process = process;
+
+    // Set the environment variables
+    // Cloudlare suggests to not override the process.env object but instead apply the values to it
+    for (const [key, value] of Object.entries(env)) {
+      if (typeof value === "string") {
+        process.env[key] = value;
+      }
+    }
+
     const internalEvent = await converter.convertFrom(event);
 
     const response = await handler(internalEvent);
@@ -27,4 +35,5 @@ export default {
   wrapper: handler,
   name: "cloudflare",
   supportStreaming: true,
+  edgeRuntime: true,
 };

--- a/packages/open-next/src/wrappers/node.ts
+++ b/packages/open-next/src/wrappers/node.ts
@@ -12,6 +12,7 @@ const wrapper: WrapperHandler = async (handler, converter) => {
       writeHeaders: (prelude) => {
         res.setHeader("Set-Cookie", prelude.cookies);
         res.writeHead(prelude.statusCode, prelude.headers);
+        res.flushHeaders();
         res.uncork();
         return res;
       },

--- a/packages/open-next/src/wrappers/node.ts
+++ b/packages/open-next/src/wrappers/node.ts
@@ -10,6 +10,7 @@ const wrapper: WrapperHandler = async (handler, converter) => {
     const internalEvent = await converter.convertFrom(req);
     const _res: StreamCreator = {
       writeHeaders: (prelude) => {
+        res.setHeader("Set-Cookie", prelude.cookies);
         res.writeHead(prelude.statusCode, prelude.headers);
         res.uncork();
         return res;


### PR DESCRIPTION
This PR fix an issue with cloudflare env variable being undefined if the middleware does not run.
This was breaking `enableCacheInterception` with the middleware in cloudflare.

This PR also fix some issue with cookies being not properly set when set both in the routing layer (i.e. middleware or next.config) and the route itself.
It also fix an issue with cookies and the `node` wrapper