### PR TITLE
lazily initialize lite client

### DIFF
--- a/.changeset/dull-lobsters-hope.md
+++ b/.changeset/dull-lobsters-hope.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+lazily initialize lite client

--- a/packages/open-next/src/cache/incremental/s3-lite.ts
+++ b/packages/open-next/src/cache/incremental/s3-lite.ts
@@ -30,7 +30,7 @@ const awsFetch = async (key: string, options: RequestInit) => {
   const { CACHE_BUCKET_REGION, CACHE_BUCKET_NAME } = process.env;
   const client = getAwsClient();
   const url = `https://${CACHE_BUCKET_NAME}.s3.${CACHE_BUCKET_REGION}.amazonaws.com/${key}`;
-  return customFetchClient(client)(url, options).finally(console.log);
+  return customFetchClient(client)(url, options);
 };
 
 function buildS3Key(key: string, extension: Extension) {
@@ -75,7 +75,6 @@ const incrementalCache: IncrementalCache = {
       },
     );
     if (response.status !== 200) {
-      console.log(response);
       throw new RecoverableError(`Failed to set cache: ${response.status}`);
     }
   },

--- a/packages/open-next/src/cache/incremental/s3-lite.ts
+++ b/packages/open-next/src/cache/incremental/s3-lite.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { AwsClient } from "aws4fetch";
 import path from "path";
 import { IgnorableError, RecoverableError } from "utils/error";
@@ -7,24 +8,33 @@ import { parseNumberFromEnv } from "../../adapters/util";
 import { Extension } from "../next-types";
 import { IncrementalCache } from "./types";
 
-const {
-  CACHE_BUCKET_REGION,
-  CACHE_BUCKET_KEY_PREFIX,
-  NEXT_BUILD_ID,
-  CACHE_BUCKET_NAME,
-} = process.env;
+let awsClient: AwsClient | null = null;
 
-const awsClient = new AwsClient({
-  accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-  sessionToken: process.env.AWS_SESSION_TOKEN,
-  region: CACHE_BUCKET_REGION,
-  retries: parseNumberFromEnv(process.env.AWS_SDK_S3_MAX_ATTEMPTS),
-});
+const getAwsClient = () => {
+  const { CACHE_BUCKET_REGION } = process.env;
+  if (awsClient) {
+    return awsClient;
+  } else {
+    awsClient = new AwsClient({
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      sessionToken: process.env.AWS_SESSION_TOKEN,
+      region: CACHE_BUCKET_REGION,
+      retries: parseNumberFromEnv(process.env.AWS_SDK_S3_MAX_ATTEMPTS),
+    });
+    return awsClient;
+  }
+};
 
-const awsFetch = customFetchClient(awsClient);
+const awsFetch = async (key: string, options: RequestInit) => {
+  const { CACHE_BUCKET_REGION, CACHE_BUCKET_NAME } = process.env;
+  const client = getAwsClient();
+  const url = `https://${CACHE_BUCKET_NAME}.s3.${CACHE_BUCKET_REGION}.amazonaws.com/${key}`;
+  return customFetchClient(client)(url, options).finally(console.log);
+};
 
 function buildS3Key(key: string, extension: Extension) {
+  const { CACHE_BUCKET_KEY_PREFIX, NEXT_BUILD_ID } = process.env;
   return path.posix.join(
     CACHE_BUCKET_KEY_PREFIX ?? "",
     extension === "fetch" ? "__fetch" : "",
@@ -36,10 +46,7 @@ function buildS3Key(key: string, extension: Extension) {
 const incrementalCache: IncrementalCache = {
   async get(key, isFetch) {
     const result = await awsFetch(
-      `https://${CACHE_BUCKET_NAME}.s3.${CACHE_BUCKET_REGION}.amazonaws.com/${buildS3Key(
-        key,
-        isFetch ? "fetch" : "cache",
-      )}`,
+      buildS3Key(key, isFetch ? "fetch" : "cache"),
       {
         method: "GET",
       },
@@ -61,29 +68,21 @@ const incrementalCache: IncrementalCache = {
   },
   async set(key, value, isFetch): Promise<void> {
     const response = await awsFetch(
-      `https://${CACHE_BUCKET_NAME}.s3.${CACHE_BUCKET_REGION}.amazonaws.com/${buildS3Key(
-        key,
-        isFetch ? "fetch" : "cache",
-      )}`,
+      buildS3Key(key, isFetch ? "fetch" : "cache"),
       {
         method: "PUT",
         body: JSON.stringify(value),
       },
     );
     if (response.status !== 200) {
+      console.log(response);
       throw new RecoverableError(`Failed to set cache: ${response.status}`);
     }
   },
   async delete(key): Promise<void> {
-    const response = await awsFetch(
-      `https://${CACHE_BUCKET_NAME}.s3.${CACHE_BUCKET_REGION}.amazonaws.com/${buildS3Key(
-        key,
-        "cache",
-      )}`,
-      {
-        method: "DELETE",
-      },
-    );
+    const response = await awsFetch(buildS3Key(key, "cache"), {
+      method: "DELETE",
+    });
     if (response.status !== 204) {
       throw new RecoverableError(`Failed to delete cache: ${response.status}`);
     }

--- a/packages/open-next/src/queue/sqs-lite.ts
+++ b/packages/open-next/src/queue/sqs-lite.ts
@@ -5,34 +5,48 @@ import { customFetchClient } from "utils/fetch";
 import { error } from "../adapters/logger";
 import { Queue } from "./types";
 
-// Expected environment variables
-const { REVALIDATION_QUEUE_REGION, REVALIDATION_QUEUE_URL } = process.env;
+let awsClient: AwsClient | null = null;
 
-const awsClient = new AwsClient({
-  accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-  sessionToken: process.env.AWS_SESSION_TOKEN,
-  region: REVALIDATION_QUEUE_REGION,
-});
-const awsFetch = customFetchClient(awsClient);
+const getAwsClient = () => {
+  if (awsClient) {
+    return awsClient;
+  } else {
+    awsClient = new AwsClient({
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      sessionToken: process.env.AWS_SESSION_TOKEN,
+      region: process.env.REVALIDATION_QUEUE_REGION,
+    });
+    return awsClient;
+  }
+};
+
+const awsFetch = (body: RequestInit["body"]) => {
+  const { REVALIDATION_QUEUE_REGION } = process.env;
+  const client = getAwsClient();
+  return customFetchClient(client)(
+    `https://sqs.${REVALIDATION_QUEUE_REGION ?? "us-east-1"}.amazonaws.com`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-amz-json-1.0",
+        "X-Amz-Target": "AmazonSQS.SendMessage",
+      },
+      body,
+    },
+  );
+};
 const queue: Queue = {
   send: async ({ MessageBody, MessageDeduplicationId, MessageGroupId }) => {
     try {
+      const { REVALIDATION_QUEUE_URL } = process.env;
       const result = await awsFetch(
-        `https://sqs.${REVALIDATION_QUEUE_REGION ?? "us-east-1"}.amazonaws.com`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-amz-json-1.0",
-            "X-Amz-Target": "AmazonSQS.SendMessage",
-          },
-          body: JSON.stringify({
-            QueueUrl: REVALIDATION_QUEUE_URL,
-            MessageBody: JSON.stringify(MessageBody),
-            MessageDeduplicationId,
-            MessageGroupId,
-          }),
-        },
+        JSON.stringify({
+          QueueUrl: REVALIDATION_QUEUE_URL,
+          MessageBody: JSON.stringify(MessageBody),
+          MessageDeduplicationId,
+          MessageGroupId,
+        }),
       );
       if (result.status !== 200) {
         throw new RecoverableError(`Failed to send message: ${result.status}`);


### PR DESCRIPTION
In some cases the env variable are not populated at import time, this make the lite client being able to handle this.

This also allow for some other use cases such as being able to use different region or different table/bucket/queue, by defining these env variable at runtime.