### PR TITLE
fix content-length incorrectly set in proxyRequest

### DIFF
--- a/.changeset/mjwbenton.md
+++ b/.changeset/mjwbenton.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix content-length incorrectly set in proxyRequest

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -183,6 +183,7 @@ function filterHeadersForProxy(
     "x-cache",
     "transfer-encoding",
     "content-encoding",
+    "content-length",
   ];
   Object.entries(headers).forEach(([key, value]) => {
     const lowerKey = key.toLowerCase();


### PR DESCRIPTION
As discussed on Discord here: https://discord.com/channels/1283128968140161065/1286094576788177059/1291327268450467893

Using rewrites with an external server currently has an issue when the server responds with a compressed response. `proxyRequest` decompresses the response, and suitably filters out the `content-encoding` header from the response to indicate that it is not compressed. However currently it still passes through the `content-length` header untouched. This means that downstream the response gets truncated to the length of the compressed response even though a decompressed response is being sent.

This PR filters out the optional `content-length` header such that the content does not get truncated.

Thanks!