### PR TITLE
update opennextjs-aws repository base

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -41,7 +41,7 @@ We need your help keeping it up to date and feature complete. Make sure to [**jo
 
 ## Features
 
-OpenNext aims to support all Next.js 14 features. Some features are work in progress. Please open a [new issue](https://github.com/sst/open-next/issues/new) to let us know!
+OpenNext aims to support all Next.js 14 features. Some features are work in progress. Please open a [new issue](https://github.com/opennextjs/opennextjs-aws/issues/new) to let us know!
 
 - [x] App & Pages Router
 - [x] API routes

--- a/docs/pages/inner_workings/components/server/node.mdx
+++ b/docs/pages/inner_workings/components/server/node.mdx
@@ -41,7 +41,7 @@ The Incremental Cache is a cache that is used to store the results of the ISR **
 By default, OpenNext uses S3 as the default incremental cache.
 
 You can override the default cache by setting the `override.incrementalCache` property in the `open-next.config.ts` file.
-You can look at the expected types [here](https://github.com/sst/open-next/blob/f1b2b78ce622ceae496ee566abf74f07018619f4/packages/open-next/src/cache/incremental/types.ts#L38)
+You can look at the expected types [here](https://github.com/opennextjs/opennextjs-aws/blob/f1b2b78ce622ceae496ee566abf74f07018619f4/packages/open-next/src/cache/incremental/types.ts#L38)
 
 ##### Default S3 Incremental Cache
 
@@ -65,7 +65,7 @@ The Tag Cache is a cache that is used to store the tags for the ISR/SSG pages as
 By default, OpenNext uses DynamoDB as the default incremental cache.
 
 You can override the default cache by setting the `override.tagCache` property in the `open-next.config.ts` file.
-You can look at the expected types [here](https://github.com/sst/open-next/blob/f1b2b78ce622ceae496ee566abf74f07018619f4/packages/open-next/src/cache/tag/types.ts#L1)
+You can look at the expected types [here](https://github.com/opennextjs/opennextjs-aws/blob/f1b2b78ce622ceae496ee566abf74f07018619f4/packages/open-next/src/cache/tag/types.ts#L1)
 
 ##### Default DynamoDB Tag Cache
 

--- a/docs/pages/v2.mdx
+++ b/docs/pages/v2.mdx
@@ -8,4 +8,4 @@ import { Callout } from 'nextra/components'
 
 ### Latest Releases
 
-- OpenNext [2.3.9](https://github.com/sst/open-next/releases/tag/v2.3.9)
+- OpenNext [2.3.9](https://github.com/opennextjs/opennextjs-aws/releases/tag/v2.3.9)

--- a/docs/pages/v2/common_issues/bundle_size.mdx
+++ b/docs/pages/v2/common_issues/bundle_size.mdx
@@ -3,7 +3,7 @@ import {Callout} from 'nextra/components'
 
 #### Reducing Bundle Size
 
-Serverless environments are sensitive to bundle size, since it has to download and unzip the contents. To help reduce cold start times as much as possible, you should remove any unnecessary files in the node_modules or report offending dev libraries in this [PR](https://github.com/sst/open-next/pull/242)
+Serverless environments are sensitive to bundle size, since it has to download and unzip the contents. To help reduce cold start times as much as possible, you should remove any unnecessary files in the node_modules or report offending dev libraries in this [PR](https://github.com/opennextjs/opennextjs-aws/pull/242)
 
 
 <Callout type="info" emoji="ℹ️">
@@ -21,7 +21,7 @@ du -hs .open-next/server-function/node_modules/* | sort -rh
 If your app requires the offending library, then consider moving your business logic of the `api` to its own lambda, eg: `/api/v2` => `Api Lambda`
 
 <Callout type="info" emoji="ℹ️">
-  There is a [PR](https://github.com/sst/open-next/pull/242) to remove some dev dependency from the output node_modules but that requires more testing before it can merge.
+  There is a [PR](https://github.com/opennextjs/opennextjs-aws/pull/242) to remove some dev dependency from the output node_modules but that requires more testing before it can merge.
 </Callout>
 
 #### Common issues

--- a/docs/theme.config.jsx
+++ b/docs/theme.config.jsx
@@ -5,7 +5,7 @@ import Logo from "./components/Logo.svg";
 
 export default {
   logo: <Logo />,
-  docsRepositoryBase: "https://github.com/sst/open-next/tree/main/docs",
+  docsRepositoryBase: "https://github.com/opennextjs/opennextjs-aws/tree/main/docs",
   project: {
     link: "https://github.com/sst/open-next",
   },
@@ -20,7 +20,7 @@ export default {
     next: false,
   },
   feedback: {
-    useLink: () => "https://github.com/sst/open-next/issues/new",
+    useLink: () => "https://github.com/opennextjs/opennextjs-aws/issues/new",
   },
   head: (
     <>

--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -57,7 +57,7 @@
     "typescript": "^4.9.3"
   },
   "bugs": {
-    "url": "https://github.com/sst/open-next/issues"
+    "url": "https://github.com/opennextjs/opennextjs-aws/issues"
   },
   "repository": {
     "type": "git",

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -314,7 +314,7 @@ function addDenoJson(outputPath: string, packagePath: string) {
   );
 }
 
-//TODO: check if this PR is still necessary https://github.com/sst/open-next/pull/341
+//TODO: check if this PR is still necessary https://github.com/opennextjs/opennextjs-aws/pull/341
 function addMonorepoEntrypoint(outputPath: string, packagePath: string) {
   // Note: in the monorepo case, the handler file is output to
   //       `.next/standalone/package/path/index.mjs`, but we want


### PR DESCRIPTION
I've noticed that in a few places the repo base is outdated

this seems generally fine as github just redirects to this repository, but it's not really that polished and can break tools such as `pkg.pr.new` that can rely on the package.json's repository to be correct (see https://github.com/opennextjs/opennextjs-aws/pull/536#issuecomment-2403509138, the PR package there doesn't work properly because of the incorrect repo in the package.json)