### PR TITLE
Basic PPR

### DIFF
--- a/.changeset/angry-meals-suffer.md
+++ b/.changeset/angry-meals-suffer.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Basic support for PPR

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -237,6 +237,7 @@ export default class S3Cache {
               rscData: Buffer.from(cacheData.rsc),
               status: meta?.status,
               headers: meta?.headers,
+              postponed: meta?.postponed,
             },
           } as CacheHandlerValue;
         }

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -523,8 +523,12 @@ async function createCacheAssets(monorepoRoot: string) {
     () => true,
     (filepath) => {
       const ext = path.extname(filepath);
-      const newFilePath =
+      let newFilePath =
         ext !== "" ? filepath.replace(ext, ".cache") : `${filepath}.cache`;
+      // Handle prefetch cache files for partial prerendering
+      if (newFilePath.endsWith(".prefetch.cache")) {
+        newFilePath = newFilePath.replace(".prefetch.cache", ".cache");
+      }
       switch (ext) {
         case ".meta":
         case ".html":

--- a/packages/open-next/src/cache/next-types.ts
+++ b/packages/open-next/src/cache/next-types.ts
@@ -73,4 +73,5 @@ export type Extension = "cache" | "fetch";
 export interface Meta {
   status?: number;
   headers?: Record<string, undefined | string | string[]>;
+  postponed?: string;
 }


### PR DESCRIPTION
This PR add basic support for PPR.

This is the PPR built into next standalone, this mean that nothing can be served from the CDN (except the prefetched rsc).

The html are served from the server every time