### PR TITLE
fix all the various examples eslint warnings

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,6 +32,14 @@ module.exports = {
 
     "@typescript-eslint/no-non-null-assertion": "warn",
   },
+  overrides: [
+    {
+      files: ["examples/**/*"],
+      rules: {
+        "unused-imports/no-unused-vars": "off",
+      },
+    },
+  ],
   parserOptions: {
     project: ["./tsconfig.eslint.json", "./**/tsconfig.json"],
   },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -34,7 +34,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ["examples/**/*"],
+      files: ["example/**/*", "examples/**/*"],
       rules: {
         "unused-imports/no-unused-vars": "off",
       },

--- a/examples/app-pages-router/middleware.ts
+++ b/examples/app-pages-router/middleware.ts
@@ -21,15 +21,15 @@ export function middleware(request: NextRequest) {
         "content-type": "application/json",
       },
     });
+  } else {
+    const rHeaders = new Headers(request.headers);
+    const r = NextResponse.next({
+      request: {
+        headers: rHeaders,
+      },
+    });
+    return r;
   }
-
-  const rHeaders = new Headers(request.headers);
-  const r = NextResponse.next({
-    request: {
-      headers: rHeaders,
-    },
-  });
-  return r;
 }
 
 export const config = {

--- a/examples/app-router/middleware.ts
+++ b/examples/app-router/middleware.ts
@@ -20,56 +20,56 @@ export function middleware(request: NextRequest) {
         "content-type": "application/json",
       },
     });
-  }
-
-  const requestHeaders = new Headers();
-  // Setting the Request Headers, this should be available in RSC
-  requestHeaders.set("request-header", "request-header");
-  requestHeaders.set(
-    "search-params",
-    `mw/${request.nextUrl.searchParams.get("searchParams") || ""}`,
-  );
-  const responseHeaders = new Headers();
-  // Response headers should show up in the client's response headers
-  responseHeaders.set("response-header", "response-header");
-
-  // Set the cache control header with custom swr
-  // For: isr.test.ts
-  if (path === "/isr" && !request.headers.get("x-prerender-revalidate")) {
-    responseHeaders.set(
-      "cache-control",
-      "max-age=10, stale-while-revalidate=999",
+  } else {
+    const requestHeaders = new Headers();
+    // Setting the Request Headers, this should be available in RSC
+    requestHeaders.set("request-header", "request-header");
+    requestHeaders.set(
+      "search-params",
+      `mw/${request.nextUrl.searchParams.get("searchParams") || ""}`,
     );
+    const responseHeaders = new Headers();
+    // Response headers should show up in the client's response headers
+    responseHeaders.set("response-header", "response-header");
+
+    // Set the cache control header with custom swr
+    // For: isr.test.ts
+    if (path === "/isr" && !request.headers.get("x-prerender-revalidate")) {
+      responseHeaders.set(
+        "cache-control",
+        "max-age=10, stale-while-revalidate=999",
+      );
+    }
+
+    // It is so that cloudfront doesn't cache the response
+    if (
+      path.startsWith("/revalidate-tag") ||
+      path.startsWith("/revalidate-path")
+    ) {
+      responseHeaders.set(
+        "cache-control",
+        "private, no-cache, no-store, max-age=0, must-revalidate",
+      );
+    }
+
+    const r = NextResponse.next({
+      headers: responseHeaders,
+      request: {
+        headers: requestHeaders,
+      },
+    });
+
+    // Set cookies in middleware
+    // For: middleware.cookies.test.ts
+    r.cookies.set("from", "middleware", {
+      expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
+    });
+    r.cookies.set("with", "love", {
+      expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
+    });
+
+    return r;
   }
-
-  // It is so that cloudfront doesn't cache the response
-  if (
-    path.startsWith("/revalidate-tag") ||
-    path.startsWith("/revalidate-path")
-  ) {
-    responseHeaders.set(
-      "cache-control",
-      "private, no-cache, no-store, max-age=0, must-revalidate",
-    );
-  }
-
-  const r = NextResponse.next({
-    headers: responseHeaders,
-    request: {
-      headers: requestHeaders,
-    },
-  });
-
-  // Set cookies in middleware
-  // For: middleware.cookies.test.ts
-  r.cookies.set("from", "middleware", {
-    expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
-  });
-  r.cookies.set("with", "love", {
-    expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
-  });
-
-  return r;
 }
 
 export const config = {


### PR DESCRIPTION
I've noticed that every PR is getting eslint warnings coming from the `examples` directory, so I figured I could open a quick PR to address them 🙂 

For example: https://github.com/opennextjs/opennextjs-aws/pull/543/files