### PR TITLE
Make function dependencies explicit

### DIFF
--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -77,27 +77,27 @@ export async function build(
 
   // Build Next.js app
   printHeader("Building Next.js app");
-  setStandaloneBuildMode(config, options);
-  buildNextjsApp(config, options);
+  setStandaloneBuildMode(options);
+  buildNextjsApp(options);
 
   // Generate deployable bundle
   printHeader("Generating bundle");
   initOutputDir(tempDir, options);
 
   // Compile cache.ts
-  compileCache(config, options);
+  compileCache(options);
 
   // Compile middleware
-  await createMiddleware(config, options);
+  await createMiddleware(options);
 
   createStaticAssets(options);
-  await createCacheAssets(config, options);
+  await createCacheAssets(options);
 
-  await createServerBundle(config, options);
-  await createRevalidationBundle(config, options);
-  await createImageOptimizationBundle(config, options);
-  await createWarmerBundle(config, options);
-  await generateOutput(config, options);
+  await createServerBundle(options);
+  await createRevalidationBundle(options);
+  await createImageOptimizationBundle(options);
+  await createWarmerBundle(options);
+  await generateOutput(options);
   logger.info("OpenNext build complete.");
 }
 
@@ -134,15 +134,15 @@ function checkRunningInsideNextjsApp(options: BuildOptions) {
   }
 }
 
-function setStandaloneBuildMode(config: OpenNextConfig, options: BuildOptions) {
+function setStandaloneBuildMode(options: BuildOptions) {
   // Equivalent to setting `output: "standalone"` in next.config.js
   process.env.NEXT_PRIVATE_STANDALONE = "true";
   // Equivalent to setting `experimental.outputFileTracingRoot` in next.config.js
   process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT = options.monorepoRoot;
 }
 
-function buildNextjsApp(config: OpenNextConfig, options: BuildOptions) {
-  const { packager } = options;
+function buildNextjsApp(options: BuildOptions) {
+  const { config, packager } = options;
   const command =
     config.buildCommand ??
     (["bun", "npm"].includes(packager)
@@ -205,13 +205,10 @@ function initOutputDir(srcTempDir: string, options: BuildOptions) {
   }
 }
 
-async function createWarmerBundle(
-  config: OpenNextConfig,
-  options: BuildOptions,
-) {
+async function createWarmerBundle(options: BuildOptions) {
   logger.info(`Bundling warmer function...`);
 
-  const { outputDir } = options;
+  const { config, outputDir } = options;
 
   // Create output folder
   const outputPath = path.join(outputDir, "warmer-function");
@@ -251,13 +248,10 @@ async function createWarmerBundle(
   );
 }
 
-async function createRevalidationBundle(
-  config: OpenNextConfig,
-  options: BuildOptions,
-) {
+async function createRevalidationBundle(options: BuildOptions) {
   logger.info(`Bundling revalidation function...`);
 
-  const { appBuildOutputPath, outputDir } = options;
+  const { appBuildOutputPath, config, outputDir } = options;
 
   // Create output folder
   const outputPath = path.join(outputDir, "revalidation-function");
@@ -293,13 +287,10 @@ async function createRevalidationBundle(
   );
 }
 
-async function createImageOptimizationBundle(
-  config: OpenNextConfig,
-  options: BuildOptions,
-) {
+async function createImageOptimizationBundle(options: BuildOptions) {
   logger.info(`Bundling image optimization function...`);
 
-  const { appPath, appBuildOutputPath, outputDir } = options;
+  const { appPath, appBuildOutputPath, config, outputDir } = options;
 
   // Create output folder
   const outputPath = path.join(outputDir, "image-optimization-function");
@@ -454,10 +445,8 @@ function createStaticAssets(options: BuildOptions) {
   }
 }
 
-async function createCacheAssets(
-  config: OpenNextConfig,
-  options: BuildOptions,
-) {
+async function createCacheAssets(options: BuildOptions) {
+  const { config } = options;
   if (config.dangerous?.disableIncrementalCache) return;
 
   logger.info(`Bundling cache assets...`);
@@ -666,10 +655,10 @@ async function createCacheAssets(
 /***************************/
 
 export function compileCache(
-  config: OpenNextConfig,
   options: BuildOptions,
   format: "cjs" | "esm" = "cjs",
 ) {
+  const { config } = options;
   const ext = format === "cjs" ? "cjs" : "mjs";
   const outfile = path.join(options.outputDir, ".build", `cache.${ext}`);
 
@@ -699,10 +688,10 @@ export function compileCache(
   return outfile;
 }
 
-async function createMiddleware(config: OpenNextConfig, options: BuildOptions) {
+async function createMiddleware(options: BuildOptions) {
   console.info(`Bundling middleware function...`);
 
-  const { appBuildOutputPath, outputDir } = options;
+  const { appBuildOutputPath, config, outputDir } = options;
 
   // Get middleware manifest
   const middlewareManifest = JSON.parse(

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -44,7 +44,7 @@ export async function createServerBundle(
     defaultFn.runtime === "deno" ||
     functions.some(([, fn]) => fn.runtime === "deno")
   ) {
-    compileCache("esm");
+    compileCache(config, options, "esm");
   }
 
   const promises = functions.map(async ([name, fnOptions]) => {

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -30,10 +30,8 @@ import {
 const require = topLevelCreateRequire(import.meta.url);
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
-export async function createServerBundle(
-  config: OpenNextConfig,
-  options: BuildOptions,
-) {
+export async function createServerBundle(options: BuildOptions) {
+  const { config } = options;
   const foundRoutes = new Set<string>();
   // Get all functions to build
   const defaultFn = config.default;
@@ -44,7 +42,7 @@ export async function createServerBundle(
     defaultFn.runtime === "deno" ||
     functions.some(([, fn]) => fn.runtime === "deno")
   ) {
-    compileCache(config, options, "esm");
+    compileCache(options, "esm");
   }
 
   const promises = functions.map(async ([name, fnOptions]) => {

--- a/packages/open-next/src/build/generateOutput.ts
+++ b/packages/open-next/src/build/generateOutput.ts
@@ -11,7 +11,7 @@ import {
   OverrideOptions,
 } from "types/open-next";
 
-import { getBuildId } from "./helper.js";
+import { type BuildOptions, getBuildId } from "./helper.js";
 
 type BaseFunction = {
   handler: string;
@@ -165,9 +165,10 @@ function prefixPattern(basePath: string) {
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export async function generateOutput(
-  outputPath: string,
   config: OpenNextConfig,
+  options: BuildOptions,
 ) {
+  const { appBuildOutputPath } = options;
   const edgeFunctions: OpenNextOutput["edgeFunctions"] = {};
   const isExternalMiddleware = config.middleware?.external ?? false;
   if (isExternalMiddleware) {
@@ -197,7 +198,7 @@ export async function generateOutput(
   //Load required-server-files.json
   const requiredServerFiles = JSON.parse(
     fs.readFileSync(
-      path.join(outputPath, ".next", "required-server-files.json"),
+      path.join(appBuildOutputPath, ".next", "required-server-files.json"),
       "utf-8",
     ),
   ).config as NextConfig;
@@ -298,7 +299,9 @@ export async function generateOutput(
     const patterns = "patterns" in value ? value.patterns : ["*"];
     patterns.forEach((pattern) => {
       behaviors.push({
-        pattern: prefixer(pattern.replace(/BUILD_ID/, getBuildId(outputPath))),
+        pattern: prefixer(
+          pattern.replace(/BUILD_ID/, getBuildId(appBuildOutputPath)),
+        ),
         origin: value.placement === "global" ? undefined : key,
         edgeFunction:
           value.placement === "global"
@@ -323,7 +326,7 @@ export async function generateOutput(
   });
 
   //Compute behaviors for assets files
-  const assetPath = path.join(outputPath, ".open-next", "assets");
+  const assetPath = path.join(appBuildOutputPath, ".open-next", "assets");
   fs.readdirSync(assetPath).forEach((item) => {
     if (fs.statSync(path.join(assetPath, item)).isDirectory()) {
       behaviors.push({
@@ -341,7 +344,9 @@ export async function generateOutput(
   // Check if we produced a dynamodb provider output
   const isTagCacheDisabled =
     config.dangerous?.disableTagCache ||
-    !fs.existsSync(path.join(outputPath, ".open-next", "dynamodb-provider"));
+    !fs.existsSync(
+      path.join(appBuildOutputPath, ".open-next", "dynamodb-provider"),
+    );
 
   const output: OpenNextOutput = {
     edgeFunctions,
@@ -369,7 +374,7 @@ export async function generateOutput(
     },
   };
   fs.writeFileSync(
-    path.join(outputPath, ".open-next", "open-next.output.json"),
+    path.join(appBuildOutputPath, ".open-next", "open-next.output.json"),
     JSON.stringify(output),
   );
 }

--- a/packages/open-next/src/build/generateOutput.ts
+++ b/packages/open-next/src/build/generateOutput.ts
@@ -7,7 +7,6 @@ import {
   DefaultOverrideOptions,
   FunctionOptions,
   LazyLoadedOverride,
-  OpenNextConfig,
   OverrideOptions,
 } from "types/open-next";
 
@@ -164,11 +163,8 @@ function prefixPattern(basePath: string) {
 }
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-export async function generateOutput(
-  config: OpenNextConfig,
-  options: BuildOptions,
-) {
-  const { appBuildOutputPath } = options;
+export async function generateOutput(options: BuildOptions) {
+  const { appBuildOutputPath, config } = options;
   const edgeFunctions: OpenNextOutput["edgeFunctions"] = {};
   const isExternalMiddleware = config.middleware?.external ?? false;
   if (isExternalMiddleware) {

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -40,17 +40,18 @@ export function normalizeOptions(config: OpenNextConfig) {
   }
 
   return {
-    openNextVersion: getOpenNextVersion(),
-    nextVersion: getNextVersion(appPath),
+    appBuildOutputPath: buildOutputPath,
     appPackageJsonPath,
     appPath,
-    appBuildOutputPath: buildOutputPath,
     appPublicPath: path.join(appPath, "public"),
-    outputDir,
-    tempDir: path.join(outputDir, ".build"),
+    config,
     debug: Boolean(process.env.OPEN_NEXT_DEBUG) ?? false,
     monorepoRoot,
+    nextVersion: getNextVersion(appPath),
+    openNextVersion: getOpenNextVersion(),
+    outputDir,
     packager,
+    tempDir: path.join(outputDir, ".build"),
   };
 }
 


### PR DESCRIPTION
We (opennext-cloudflare) plan to reuse code from opennext-aws.

For that we would like to extract code out of `build.ts` so that we can call those functions from our own `build.ts`.

As a first step, this PR explicit function dependencies.

The PR contains multiple commits to ease the review.