### PR TITLE
fix: proxy resolves once the full stream has been completed.

### DIFF
--- a/.changeset/green-insects-roll.md
+++ b/.changeset/green-insects-roll.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fixes proxy handling of encoded request/responses, previously responses could be cut off.

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -251,7 +251,7 @@ export async function proxyRequest(
           res.end();
           reject(e);
         });
-        _res.on("end", () => {
+        res.on("finish", () => {
           resolve();
         });
       },


### PR DESCRIPTION
Currently if a request with the Accept-Encoding head is proxied e.g. with NextJs rewrites the response resolves before the full response has been processed. 