### PR TITLE
New option to install packages

### DIFF
--- a/.changeset/chilled-frogs-draw.md
+++ b/.changeset/chilled-frogs-draw.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": minor
+---
+
+Add a new option to install native dependencies on every lambda

--- a/packages/open-next/src/build/compileTagCacheProvider.ts
+++ b/packages/open-next/src/build/compileTagCacheProvider.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 
 import { openNextResolvePlugin } from "../plugins/resolve.js";
 import * as buildHelper from "./helper.js";
+import { installDependencies } from "./installDeps.js";
 
 export async function compileTagCacheProvider(
   options: buildHelper.BuildOptions,
@@ -29,5 +30,10 @@ export async function compileTagCacheProvider(
       ],
     },
     options,
+  );
+
+  installDependencies(
+    providerPath,
+    options.config.initializationFunction?.install,
   );
 }

--- a/packages/open-next/src/build/createImageOptimizationBundle.ts
+++ b/packages/open-next/src/build/createImageOptimizationBundle.ts
@@ -15,7 +15,7 @@ export async function createImageOptimizationBundle(
 ) {
   logger.info(`Bundling image optimization function...`);
 
-  const { appPath, appBuildOutputPath, config, outputDir } = options;
+  const { appBuildOutputPath, config, outputDir } = options;
 
   // Create output folder
   const outputPath = path.join(outputDir, "image-optimization-function");

--- a/packages/open-next/src/build/createMiddleware.ts
+++ b/packages/open-next/src/build/createMiddleware.ts
@@ -5,6 +5,7 @@ import logger from "../logger.js";
 import { type MiddlewareManifest } from "../types/next-types.js";
 import { buildEdgeBundle } from "./edge/createEdgeBundle.js";
 import * as buildHelper from "./helper.js";
+import { installDependencies } from "./installDeps.js";
 
 export async function createMiddleware(options: buildHelper.BuildOptions) {
   logger.info(`Bundling middleware function...`);
@@ -58,6 +59,8 @@ export async function createMiddleware(options: buildHelper.BuildOptions) {
       includeCache: config.dangerous?.enableCacheInterception,
       additionalExternals: config.edgeExternals,
     });
+
+    installDependencies(outputPath, config.middleware?.install);
   } else {
     await buildEdgeBundle({
       entrypoint: path.join(

--- a/packages/open-next/src/build/createRevalidationBundle.ts
+++ b/packages/open-next/src/build/createRevalidationBundle.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import logger from "../logger.js";
 import { openNextResolvePlugin } from "../plugins/resolve.js";
 import * as buildHelper from "./helper.js";
+import { installDependencies } from "./installDeps.js";
 
 export async function createRevalidationBundle(
   options: buildHelper.BuildOptions,
@@ -40,6 +41,8 @@ export async function createRevalidationBundle(
     },
     options,
   );
+
+  installDependencies(outputPath, config.revalidate?.install);
 
   // Copy over .next/prerender-manifest.json file
   fs.copyFileSync(

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -17,6 +17,7 @@ import { compileCache } from "./compileCache.js";
 import { copyTracedFiles } from "./copyTracedFiles.js";
 import { generateEdgeBundle } from "./edge/createEdgeBundle.js";
 import * as buildHelper from "./helper.js";
+import { installDependencies } from "./installDeps.js";
 
 const require = createRequire(import.meta.url);
 
@@ -266,6 +267,8 @@ async function generateBundle(
   if (isMonorepo) {
     addMonorepoEntrypoint(outputPath, packagePath);
   }
+
+  installDependencies(outputPath, fnOptions.install);
 
   if (fnOptions.minify) {
     await minifyServerBundle(outputPath);

--- a/packages/open-next/src/build/createWarmerBundle.ts
+++ b/packages/open-next/src/build/createWarmerBundle.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import logger from "../logger.js";
 import { openNextResolvePlugin } from "../plugins/resolve.js";
 import * as buildHelper from "./helper.js";
+import { installDependencies } from "./installDeps.js";
 
 export async function createWarmerBundle(options: buildHelper.BuildOptions) {
   logger.info(`Bundling warmer function...`);
@@ -48,4 +49,6 @@ export async function createWarmerBundle(options: buildHelper.BuildOptions) {
     },
     options,
   );
+
+  installDependencies(outputPath, config.warmer?.install);
 }

--- a/packages/open-next/src/build/installDeps.ts
+++ b/packages/open-next/src/build/installDeps.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
-import * as fs from "fs";
-import * as os from "os";
-import * as path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { InstallOptions } from "types/open-next";
 
 import logger from "../logger.js";

--- a/packages/open-next/src/build/installDeps.ts
+++ b/packages/open-next/src/build/installDeps.ts
@@ -1,7 +1,8 @@
-import { execSync } from "child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+import { execSync } from "child_process";
 import { InstallOptions } from "types/open-next";
 
 import logger from "../logger.js";

--- a/packages/open-next/src/build/installDeps.ts
+++ b/packages/open-next/src/build/installDeps.ts
@@ -1,0 +1,50 @@
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { InstallOptions } from "types/open-next";
+
+import logger from "../logger.js";
+
+export function installDependencies(
+  outputDir: string,
+  installOptions?: InstallOptions,
+) {
+  try {
+    if (!installOptions) {
+      return;
+    }
+    const name = outputDir.split("/").pop();
+    // First we create a tempDir
+    const tempInstallDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), `open-next-install-${name}`),
+    );
+    logger.info(`Installing dependencies for ${name}...`);
+    // We then need to run install in the tempDir
+    // We don't install in the output dir directly because it could contain a package.json, and npm would then try to reinstall not complete deps from tracing the files
+    const installCommand = `npm install --arch=${installOptions.arch ?? "arm64"} --platform=linux --target=${installOptions.nodeVersion ?? "18"} --libc=${installOptions.libc ?? "glibc"} ${installOptions.packages.join(" ")}`;
+    execSync(installCommand, {
+      stdio: "pipe",
+      cwd: tempInstallDir,
+      env: {
+        ...process.env,
+        SHARP_IGNORE_GLOBAL_LIBVIPS: "1",
+      },
+    });
+
+    // Copy the node_modules to the outputDir
+    fs.cpSync(
+      path.join(tempInstallDir, "node_modules"),
+      path.join(outputDir, "node_modules"),
+
+      { recursive: true, force: true, dereference: true },
+    );
+
+    // Cleanup tempDir
+    fs.rmSync(tempInstallDir, { recursive: true, force: true });
+    logger.info(`Dependencies installed for ${name}`);
+  } catch (e: any) {
+    logger.error(e.stdout.toString());
+    logger.error("Could not install dependencies");
+  }
+}

--- a/packages/open-next/src/build/installDeps.ts
+++ b/packages/open-next/src/build/installDeps.ts
@@ -22,7 +22,11 @@ export function installDependencies(
     logger.info(`Installing dependencies for ${name}...`);
     // We then need to run install in the tempDir
     // We don't install in the output dir directly because it could contain a package.json, and npm would then try to reinstall not complete deps from tracing the files
-    const installCommand = `npm install --arch=${installOptions.arch ?? "arm64"} --platform=linux --target=${installOptions.nodeVersion ?? "18"} --libc=${installOptions.libc ?? "glibc"} ${installOptions.packages.join(" ")}`;
+    const installCommand = `npm install --arch=${
+      installOptions.arch ?? "arm64"
+    } --platform=linux --target=${installOptions.nodeVersion ?? "18"} --libc=${
+      installOptions.libc ?? "glibc"
+    } ${installOptions.packages.join(" ")}`;
     execSync(installCommand, {
       stdio: "pipe",
       cwd: tempInstallDir,

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -184,6 +184,31 @@ export interface OverrideOptions extends DefaultOverrideOptions {
   queue?: IncludedQueue | LazyLoadedOverride<Queue>;
 }
 
+export interface InstallOptions {
+  /**
+   * List of packages to install
+   * @example
+   * ```ts
+   * install: {
+   *  packages: ["sharp@0.32"]
+   * }
+   * ```
+   */
+  packages: string[];
+  /**
+   * @default "arm64"
+   */
+  arch?: "x64" | "arm64";
+  /**
+   * @default "18"
+   */
+  nodeVersion?: "18" | "20" | "22";
+  /**
+   * @default "glibc"
+   */
+  libc?: "glibc" | "musl";
+}
+
 export interface DefaultFunctionOptions<
   E extends BaseEventOrResult = InternalEvent,
   R extends BaseEventOrResult = InternalResult,
@@ -202,6 +227,14 @@ export interface DefaultFunctionOptions<
    * Enable overriding the default lambda.
    */
   override?: DefaultOverrideOptions<E, R>;
+
+  /**
+   * Install options for the function.
+   * This is used to install additional packages to this function.
+   * For image optimization, it will install sharp by default.
+   * @default undefined
+   */
+  install?: InstallOptions;
 }
 
 export interface FunctionOptions extends DefaultFunctionOptions {
@@ -318,15 +351,6 @@ export interface OpenNextConfig {
      * @default "s3"
      */
     loader?: IncludedImageLoader | LazyLoadedOverride<ImageLoader>;
-    /**
-     * @default "arm64"
-     */
-    arch?: "x64" | "arm64";
-    /**
-     * @default "18"
-     */
-
-    nodeVersion?: "18" | "20";
   };
 
   /**


### PR DESCRIPTION
This PR fix #571 

#### How to use

In any of the function in `open-next.config.ts` you can now add a new option that will install dependencies that may not be included (For example sharp): 
```ts
install : {
  packages: ["sharp@0.33"],
  arch: "x64", // or arm64
  nodeVersion: "18", // or 20 or 22
  libc: "glibc" // or musl
}
```
Install itself is optional, and everything in it is optional besides packages