### PR TITLE
Add protobuf to common binary formats

### DIFF
--- a/.changeset/honest-keys-protect.md
+++ b/.changeset/honest-keys-protect.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Add protobuf to common binary formats

--- a/packages/open-next/src/adapters/binary.ts
+++ b/packages/open-next/src/adapters/binary.ts
@@ -54,6 +54,8 @@ const commonBinaryMimeTypes = new Set([
   "application/x-tar",
   "application/x-zip",
   "application/zip",
+  // Serialized data
+  "application/x-protobuf",
 ]);
 
 export function isBinaryContentType(contentType?: string | null) {

--- a/packages/utils/src/binary.ts
+++ b/packages/utils/src/binary.ts
@@ -54,6 +54,8 @@ const commonBinaryMimeTypes = new Set([
   "application/x-tar",
   "application/x-zip",
   "application/zip",
+  // Serialized data
+  "application/x-protobuf",
 ]);
 
 export function isBinaryContentType(contentType?: string | null) {


### PR DESCRIPTION
Came across an issue where `open-next` seems to be encoding `application/x-protobuf` in utf8 corrupting the binary.