### PR TITLE
fix 500 error page being cached

### DIFF
--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -288,6 +288,9 @@ export function fixCacheHeaderForHtmlPages(
 ) {
   // We don't want to cache error pages
   if (rawPath === "/404" || rawPath === "/500") {
+    if (process.env.OPEN_NEXT_DANGEROUSLY_SET_ERROR_HEADERS === "true") {
+      return;
+    }
     headers[CommonHeaders.CACHE_CONTROL] =
       "private, no-cache, no-store, max-age=0, must-revalidate";
     return;

--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -390,12 +390,15 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
   // For some reason, next returns the 500 error page with some cache-control headers
   // We need to fix that
   private fixHeadersForError() {
+    if(process.env.OPEN_NEXT_DANGEROUSLY_SET_ERROR_HEADERS === 'true') {
+      return;
+    }
     // We only check for 404 and 500 errors
     // The rest should be errors that are handled by the user and they should set the cache headers themselves
     if (this.statusCode === 404 || this.statusCode === 500) {
-      this.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-      this.setHeader("Pragma", "no-cache");
-      this.setHeader("Expires", "0");
+      // For some reason calling this.setHeader("Cache-Control", "no-cache, no-store, must-revalidate") does not work here
+      // The function is not even called, i'm probably missing something obvious
+      this.headers["cache-control"] = "private, no-cache, no-store, max-age=0, must-revalidate";
     }
   }
 }

--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -390,7 +390,7 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
   // For some reason, next returns the 500 error page with some cache-control headers
   // We need to fix that
   private fixHeadersForError() {
-    if(process.env.OPEN_NEXT_DANGEROUSLY_SET_ERROR_HEADERS === 'true') {
+    if (process.env.OPEN_NEXT_DANGEROUSLY_SET_ERROR_HEADERS === "true") {
       return;
     }
     // We only check for 404 and 500 errors
@@ -398,7 +398,8 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
     if (this.statusCode === 404 || this.statusCode === 500) {
       // For some reason calling this.setHeader("Cache-Control", "no-cache, no-store, must-revalidate") does not work here
       // The function is not even called, i'm probably missing something obvious
-      this.headers["cache-control"] = "private, no-cache, no-store, max-age=0, must-revalidate";
+      this.headers["cache-control"] =
+        "private, no-cache, no-store, max-age=0, must-revalidate";
     }
   }
 }


### PR DESCRIPTION
It seems that sometimes the 500 error page gets cached for some reason.
We don't want that to happen.

Update: 

This can happen for page router if your 500 (or 404) page use `getStaticProps`. 
For every route in page router that throws an exception, the cache-control gets overwritten and set as if it was an SSG route. The problem is that it doesn't remove the previous header that was set (including set-cookie). This could lead to session leakage.

Haven't tested in Next 15, this is probably fixed there since they don't override your cache-control anymore ( It might still happen if you don't set any cache-control for the route )

I added an env variable `OPEN_NEXT_DANGEROUSLY_SET_ERROR_HEADERS` that if set to true will disable the cache-control override that we do