### PR TITLE
Don't force args for install

### DIFF
--- a/packages/open-next/src/build/createImageOptimizationBundle.ts
+++ b/packages/open-next/src/build/createImageOptimizationBundle.ts
@@ -114,6 +114,9 @@ export async function createImageOptimizationBundle(
     outputPath,
     config.imageOptimization?.install ?? {
       packages: [`sharp@${sharpVersion}`],
+      arch: "arm64",
+      nodeVersion: "18",
+      libc: "glibc",
     },
   );
 }

--- a/packages/open-next/src/build/installDeps.ts
+++ b/packages/open-next/src/build/installDeps.ts
@@ -23,11 +23,18 @@ export function installDependencies(
     logger.info(`Installing dependencies for ${name}...`);
     // We then need to run install in the tempDir
     // We don't install in the output dir directly because it could contain a package.json, and npm would then try to reinstall not complete deps from tracing the files
-    const installCommand = `npm install --arch=${
-      installOptions.arch ?? "arm64"
-    } --platform=linux --target=${installOptions.nodeVersion ?? "18"} --libc=${
-      installOptions.libc ?? "glibc"
-    } ${installOptions.packages.join(" ")}`;
+    const archOption = installOptions.arch
+      ? `--arch=${installOptions.arch}`
+      : "";
+    const targetOption = installOptions.nodeVersion
+      ? `--target=${installOptions.nodeVersion}`
+      : "";
+    const libcOption = installOptions.libc
+      ? `--libc=${installOptions.libc}`
+      : "";
+
+    const additionalArgs = installOptions.additionalArgs ?? "";
+    const installCommand = `npm install --platform=linux ${archOption} ${targetOption} ${libcOption} ${additionalArgs} ${installOptions.packages.join(" ")}`;
     execSync(installCommand, {
       stdio: "pipe",
       cwd: tempInstallDir,

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -200,17 +200,22 @@ export interface InstallOptions {
    */
   packages: string[];
   /**
-   * @default "arm64"
+   * @default undefined
    */
   arch?: "x64" | "arm64";
   /**
-   * @default "18"
+   * @default undefined
    */
-  nodeVersion?: "18" | "20" | "22";
+  nodeVersion?: string;
   /**
-   * @default "glibc"
+   * @default undefined
    */
   libc?: "glibc" | "musl";
+  /**
+   * @default undefined
+   * Additional arguments to pass to the install command (i.e. npm install)
+   */
+  additionalArgs?: string;
 }
 
 export interface DefaultFunctionOptions<


### PR DESCRIPTION
For some libs it seems that the default args that we used doesn't work, we can make all of them optional