### PR TITLE
fix: add more reliable sources to the revalidate e2e test

### DIFF
--- a/examples/app-router/app/revalidate-path/page.tsx
+++ b/examples/app-router/app/revalidate-path/page.tsx
@@ -1,26 +1,19 @@
 export default async function Page() {
-  const timeInParis = await fetch(
-    "https://www.timeapi.io/api/time/current/zone?timeZone=Europe%2FParis",
-    {
-      next: {
-        tags: ["path"],
-      },
+  const responseSST = await fetch("https://sst.dev", {
+    next: {
+      tags: ["path"],
     },
-  );
+  });
   // This one doesn't have a tag
-  const timeInLondon = await fetch(
-    "https://www.timeapi.io/api/time/current/zone?timeZone=Europe%2FLondon",
-  );
-  const timeInParisJson = await timeInParis.json();
-  const parisTime = timeInParisJson.dateTime;
-  const timeInLondonJson = await timeInLondon.json();
-  const londonTime = timeInLondonJson.dateTime;
+  const responseOpenNext = await fetch("https://opennext.js.org");
+  const reqIdSst = responseSST.headers.get("x-amz-cf-id");
+  const dateInOpenNext = responseOpenNext.headers.get("date");
   return (
     <div>
-      <h1>Time in Paris</h1>
-      <p>Paris: {parisTime}</p>
-      <h1>Time in London</h1>
-      <p>London: {londonTime}</p>
+      <h1>Request id from SST</h1>
+      <p>RequestID: {reqIdSst}</p>
+      <h1>Date from from OpenNext</h1>
+      <p>Date: {dateInOpenNext}</p>
     </div>
   );
 }

--- a/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
+++ b/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
@@ -73,11 +73,11 @@ test("Revalidate tag", async ({ page, request }) => {
 test("Revalidate path", async ({ page, request }) => {
   await page.goto("/revalidate-path");
 
-  let elLayout = page.getByText("Paris:");
-  const initialParis = await elLayout.textContent();
+  let elLayout = page.getByText("RequestID:");
+  const initialReqId = await elLayout.textContent();
 
-  elLayout = page.getByText("London:");
-  const initialLondon = await elLayout.textContent();
+  elLayout = page.getByText("Date:");
+  const initialDate = await elLayout.textContent();
 
   // Send revalidate path request
   const result = await request.get("/api/revalidate-path");
@@ -86,11 +86,11 @@ test("Revalidate path", async ({ page, request }) => {
   expect(text).toEqual("ok");
 
   await page.goto("/revalidate-path");
-  elLayout = page.getByText("Paris:");
-  const newParis = await elLayout.textContent();
-  expect(newParis).not.toEqual(initialParis);
+  elLayout = page.getByText("RequestID:");
+  const newReqId = await elLayout.textContent();
+  expect(newReqId).not.toEqual(initialReqId);
 
-  elLayout = page.getByText("London:");
-  const newLondon = await elLayout.textContent();
-  expect(newLondon).not.toEqual(initialLondon);
+  elLayout = page.getByText("Date:");
+  const newDate = await elLayout.textContent();
+  expect(newDate).not.toEqual(initialDate);
 });


### PR DESCRIPTION
This PR adds more reliable sources to the fetches in `revalidateTag.test.ts` e2e