### PR TITLE
remove any deps to @open-next/utils

### DIFF
--- a/packages/tests-e2e/package.json
+++ b/packages/tests-e2e/package.json
@@ -9,7 +9,6 @@
   "dependencies": {},
   "devDependencies": {
     "@playwright/test": "1.37.0",
-    "@open-next/utils": "workspace:*",
     "start-server-and-test": "2.0.0",
     "ts-node": "10.9.1"
   },

--- a/packages/tests-e2e/tests/appPagesRouter/isr.test.ts
+++ b/packages/tests-e2e/tests/appPagesRouter/isr.test.ts
@@ -1,5 +1,6 @@
-import { wait } from "@open-next/utils";
 import { expect, test } from "@playwright/test";
+
+import { wait } from "../utils";
 
 test("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(60000);

--- a/packages/tests-e2e/tests/appPagesRouter/pages_isr.test.ts
+++ b/packages/tests-e2e/tests/appPagesRouter/pages_isr.test.ts
@@ -1,5 +1,6 @@
-import { wait } from "@open-next/utils";
 import { expect, test } from "@playwright/test";
+
+import { wait } from "../utils";
 
 test("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(60000);

--- a/packages/tests-e2e/tests/appPagesRouter/pages_ssr.test.ts
+++ b/packages/tests-e2e/tests/appPagesRouter/pages_ssr.test.ts
@@ -1,5 +1,6 @@
-import { wait } from "@open-next/utils";
 import { expect, test } from "@playwright/test";
+
+import { wait } from "../utils";
 
 test("Server Side Render", async ({ page }) => {
   await page.goto("/");

--- a/packages/tests-e2e/tests/appPagesRouter/ssr.test.ts
+++ b/packages/tests-e2e/tests/appPagesRouter/ssr.test.ts
@@ -1,5 +1,6 @@
-import { wait } from "@open-next/utils";
 import { expect, test } from "@playwright/test";
+
+import { wait } from "../utils";
 
 test("Server Side Render", async ({ page }) => {
   await page.goto("/");

--- a/packages/tests-e2e/tests/appRouter/isr.test.ts
+++ b/packages/tests-e2e/tests/appRouter/isr.test.ts
@@ -1,5 +1,6 @@
-import { wait } from "@open-next/utils";
 import { expect, test } from "@playwright/test";
+
+import { wait } from "../utils";
 
 test("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(45000);

--- a/packages/tests-e2e/tests/appRouter/sse.test.ts
+++ b/packages/tests-e2e/tests/appRouter/sse.test.ts
@@ -1,8 +1,9 @@
 // NOTE: loading.tsx is currently broken on open - next
 //  This works locally but not on deployed apps
 
-import { wait } from "@open-next/utils";
 import { expect, test } from "@playwright/test";
+
+import { wait } from "../utils";
 
 // NOTE: We don't await page load b/c we want to see the Loading page
 test("Server Sent Events", async ({ page }) => {

--- a/packages/tests-e2e/tests/appRouter/ssr.test.ts
+++ b/packages/tests-e2e/tests/appRouter/ssr.test.ts
@@ -1,8 +1,9 @@
 // NOTE: loading.tsx is currently broken on open - next
 //  This works locally but not on deployed apps
 
-import { wait } from "@open-next/utils";
 import { expect, test } from "@playwright/test";
+
+import { wait } from "../utils";
 
 // NOTE: We don't await page load b/c we want to see the Loading page
 test("Server Side Render and loading.tsx", async ({ page }) => {

--- a/packages/tests-e2e/tests/pagesRouter/isr.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/isr.test.ts
@@ -1,5 +1,6 @@
-import { wait } from "@open-next/utils";
 import { expect, test } from "@playwright/test";
+
+import { wait } from "../utils";
 
 test("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(45000);

--- a/packages/tests-e2e/tests/pagesRouter/ssr.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/ssr.test.ts
@@ -1,5 +1,6 @@
-import { wait } from "@open-next/utils";
 import { expect, test } from "@playwright/test";
+
+import { wait } from "../utils";
 
 test("Server Side Render", async ({ page }) => {
   await page.goto("/");

--- a/packages/tests-e2e/tests/utils.ts
+++ b/packages/tests-e2e/tests/utils.ts
@@ -1,0 +1,3 @@
+export function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/tests-unit/package.json
+++ b/packages/tests-unit/package.json
@@ -8,7 +8,6 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "@open-next/utils": "workspace:*",
     "@opennextjs/aws": "workspace:*"
   },
   "devDependencies": {

--- a/packages/tests-unit/tests/binary.test.ts
+++ b/packages/tests-unit/tests/binary.test.ts
@@ -1,4 +1,4 @@
-import { isBinaryContentType } from "@open-next/utils";
+import { isBinaryContentType } from "@opennextjs/aws/adapters/binary.js";
 
 describe("isBinaryContentType", () => {
   const tests = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,9 +232,6 @@ importers:
 
   packages/tests-e2e:
     devDependencies:
-      '@open-next/utils':
-        specifier: workspace:*
-        version: link:../utils
       '@playwright/test':
         specifier: 1.37.0
         version: 1.37.0
@@ -247,9 +244,6 @@ importers:
 
   packages/tests-unit:
     dependencies:
-      '@open-next/utils':
-        specifier: workspace:*
-        version: link:../utils
       '@opennextjs/aws':
         specifier: workspace:*
         version: link:../open-next


### PR DESCRIPTION
For some reason, pnpm doesn't seem to want to make `@open-next/utils` work anymore.
Since it's barely used at the moment, i just removed it from deps everywhere.