### PR TITLE
fix(middleware): respect host protocol

### DIFF
--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -54,9 +54,11 @@ export async function handleMiddleware(
   // We bypass the middleware if the request is internal
   if (internalEvent.headers["x-isr"]) return internalEvent;
 
+  const protocol = new URL(internalEvent.url).protocol;
   const host = internalEvent.headers.host
-    ? `https://${internalEvent.headers.host}`
+    ? `${protocol}//${internalEvent.headers.host}`
     : "http://localhost:3000";
+
   const initialUrl = new URL(normalizedPath, host);
   initialUrl.search = convertToQueryString(query);
   const url = initialUrl.toString();

--- a/packages/tests-unit/tests/core/routing/util.test.ts
+++ b/packages/tests-unit/tests/core/routing/util.test.ts
@@ -146,11 +146,11 @@ describe("getUrlParts", () => {
 
   describe("external", () => {
     it("throws for empty url", () => {
-      expect(() => getUrlParts("", true)).toThrowError();
+      expect(() => getUrlParts("", true)).toThrow();
     });
 
     it("throws for invalid url", () => {
-      expect(() => getUrlParts("/relative", true)).toThrowError();
+      expect(() => getUrlParts("/relative", true)).toThrow();
     });
 
     it("returns url parts for /", () => {
@@ -581,7 +581,7 @@ describe("revalidateIfRequired", () => {
     const headers: Record<string, string> = {};
     await revalidateIfRequired("localhost", "/path", headers);
 
-    expect(sendMock).not.toBeCalled();
+    expect(sendMock).not.toHaveBeenCalled();
   });
 
   it("should send to queue when x-nextjs-cache is STALE", async () => {
@@ -590,7 +590,7 @@ describe("revalidateIfRequired", () => {
     };
     await revalidateIfRequired("localhost", "/path", headers);
 
-    expect(sendMock).toBeCalledWith({
+    expect(sendMock).toHaveBeenCalledWith({
       MessageBody: { host: "localhost", url: "/path" },
       MessageDeduplicationId: expect.any(String),
       MessageGroupId: expect.any(String),
@@ -604,7 +604,7 @@ describe("revalidateIfRequired", () => {
     sendMock.mockRejectedValueOnce(new Error("Failed to send"));
     await revalidateIfRequired("localhost", "/path", headers);
 
-    expect(sendMock).toBeCalledWith({
+    expect(sendMock).toHaveBeenCalledWith({
       MessageBody: { host: "localhost", url: "/path" },
       MessageDeduplicationId: expect.any(String),
       MessageGroupId: expect.any(String),


### PR DESCRIPTION
The middleware handler default to https and it's causing troubles with the cloudflare dev server (wrangler dev) which uses http by default.

It is possible to force wrangler dev to use https (--local-protocol https) but the browser then shows a warning because the dev certificate is not secure.

