### PR TITLE
feature(edge): add a way for convertTo to return a Request

### DIFF
--- a/.changeset/fluffy-peas-live.md
+++ b/.changeset/fluffy-peas-live.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+feature(edge): add a way for convertTo to return a Request


### PR DESCRIPTION
This is a temporary "hack" for the cloudflare adapter.

Why we need this:
- It is not possible to fetch a worker in the same zone
- Our first implementation will bundle the middleware and the server in a single worker

We will work on a better architecture later but this will unblock cloudflare for now and does not add overhead/code to the current edge converter. The alternative would be to fork the edge converter but it would be harder to keep the implemenations in sync.


