### PR TITLE
feat(middleware): add ability to force single build pass

### DIFF
--- a/.changeset/yellow-phones-juggle.md
+++ b/.changeset/yellow-phones-juggle.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+feat(middleware): add ability to force single build pass

--- a/packages/open-next/src/build/createMiddleware.ts
+++ b/packages/open-next/src/build/createMiddleware.ts
@@ -14,8 +14,12 @@ import { installDependencies } from "./installDeps.js";
  * Compiles the middleware bundle.
  *
  * @param options Build Options.
+ * @param forceOnlyBuildOnce force to build only once.
  */
-export async function createMiddleware(options: buildHelper.BuildOptions) {
+export async function createMiddleware(
+  options: buildHelper.BuildOptions,
+  { forceOnlyBuildOnce = false } = {},
+) {
   logger.info(`Bundling middleware function...`);
 
   const { appBuildOutputPath, config, outputDir } = options;
@@ -57,6 +61,7 @@ export async function createMiddleware(options: buildHelper.BuildOptions) {
       defaultConverter: "aws-cloudfront",
       includeCache: config.dangerous?.enableCacheInterception,
       additionalExternals: config.edgeExternals,
+      onlyBuildOnce: forceOnlyBuildOnce === true,
     });
 
     installDependencies(outputPath, config.middleware?.install);


### PR DESCRIPTION
This is the second (and last) hack required for the middleware bundle on cloudflare.

For us the second build pass is hanlded by wrangler. This PR adds an option to disable that pass.
