### PR TITLE
fix: make plugins logs consistent

### DIFF
--- a/packages/open-next/src/build/createMiddleware.ts
+++ b/packages/open-next/src/build/createMiddleware.ts
@@ -62,6 +62,7 @@ export async function createMiddleware(
       includeCache: config.dangerous?.enableCacheInterception,
       additionalExternals: config.edgeExternals,
       onlyBuildOnce: forceOnlyBuildOnce === true,
+      name: "middleware",
     });
 
     installDependencies(outputPath, config.middleware?.install);
@@ -76,6 +77,7 @@ export async function createMiddleware(
       middlewareInfo,
       options,
       onlyBuildOnce: true,
+      name: "middleware",
     });
   }
 }

--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -29,6 +29,7 @@ interface BuildEdgeBundleOptions {
   includeCache?: boolean;
   additionalExternals?: string[];
   onlyBuildOnce?: boolean;
+  name: string;
 }
 
 export async function buildEdgeBundle({
@@ -42,6 +43,7 @@ export async function buildEdgeBundle({
   includeCache,
   additionalExternals,
   onlyBuildOnce,
+  name,
 }: BuildEdgeBundleOptions) {
   const isInCloudfare =
     typeof overrides?.wrapper === "string"
@@ -84,6 +86,7 @@ export async function buildEdgeBundle({
                 }
               : {}),
           },
+          fnName: name,
         }),
         openNextReplacementPlugin({
           name: "externalMiddlewareOverrides",
@@ -222,5 +225,6 @@ export async function generateEdgeBundle(
     options,
     overrides: fnOptions.override,
     additionalExternals: options.config.edgeExternals,
+    name,
   });
 }

--- a/packages/open-next/src/plugins/edge.ts
+++ b/packages/open-next/src/plugins/edge.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
+import chalk from "chalk";
 import type { Plugin } from "esbuild";
 import type { MiddlewareInfo } from "types/next-types.js";
 
@@ -14,6 +15,7 @@ import {
   loadPrerenderManifest,
   loadRoutesManifest,
 } from "../adapters/config/util.js";
+import logger from "../logger.js";
 
 export interface IPluginSettings {
   nextDir: string;
@@ -51,6 +53,7 @@ export function openNextEdgePlugins({
   return {
     name: "opennext-edge",
     setup(build) {
+      logger.debug(chalk.blue("OpenNext Edge plugin"));
       if (edgeFunctionHandlerPath) {
         // If we bundle the routing, we need to resolve the middleware
         build.onResolve({ filter: /\.\/middleware.mjs/g }, () => {

--- a/packages/open-next/src/plugins/replacement.ts
+++ b/packages/open-next/src/plugins/replacement.ts
@@ -67,7 +67,7 @@ export function openNextReplacementPlugin({
               `\/\/#override (${id})\n([\\s\\S]*?)\/\/#endOverride`,
             );
             logger.debug(
-              chalk.blue(`Open-next replacement plugin ${name}`),
+              chalk.blue(`OpenNext Replacement plugin ${name}`),
               ` -- Deleting override for ${id}`,
             );
             contents = contents.replace(pattern, "");

--- a/packages/open-next/src/plugins/resolve.ts
+++ b/packages/open-next/src/plugins/resolve.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 
+import chalk from "chalk";
 import type { Plugin } from "esbuild";
 import type {
   DefaultOverrideOptions,
@@ -75,7 +76,10 @@ export function openNextResolvePlugin({
   return {
     name: "opennext-resolve",
     setup(build) {
-      logger.debug(`OpenNext Resolve plugin for ${fnName}`);
+      logger.debug(
+        chalk.blue("OpenNext Resolve plugin"),
+        fnName ? `for ${fnName}` : "",
+      );
       build.onLoad({ filter: /core(\/|\\)resolve\.js/g }, async (args) => {
         let contents = readFileSync(args.path, "utf-8");
         const overridesEntries = Object.entries(overrides ?? {});


### PR DESCRIPTION
Before

![image](https://github.com/user-attachments/assets/54a551f7-45a3-482c-9516-35f23d2711c1)

After

![image](https://github.com/user-attachments/assets/20cfee0d-8e70-418c-81f8-e7783f9f14a9)
