### PR TITLE
use a literal path to import the config

### DIFF
--- a/packages/open-next/src/core/createGenericHandler.ts
+++ b/packages/open-next/src/core/createGenericHandler.ts
@@ -35,8 +35,7 @@ export async function createGenericHandler<
   E extends BaseEventOrResult = InternalEvent,
   R extends BaseEventOrResult = InternalResult,
 >(handler: GenericHandler<Type, E, R>) {
-  //First we load the config
-  // @ts-expect-error
+  // @ts-expect-error `./open-next.config.mjs` exists only in the build output
   const config: OpenNextConfig = await import("./open-next.config.mjs").then(
     (m) => m.default,
   );

--- a/packages/open-next/src/core/createMainHandler.ts
+++ b/packages/open-next/src/core/createMainHandler.ts
@@ -30,10 +30,10 @@ declare global {
 }
 
 export async function createMainHandler() {
-  //First we load the config
-  const config: OpenNextConfig = await import(
-    process.cwd() + "/open-next.config.mjs"
-  ).then((m) => m.default);
+  // @ts-expect-error `./open-next.config.mjs` exists only in the build output
+  const config: OpenNextConfig = await import("./open-next.config.mjs").then(
+    (m) => m.default,
+  );
 
   const thisFunction = globalThis.fnName
     ? config.functions![globalThis.fnName]


### PR DESCRIPTION
This will help with Cloudflare were paths are resolved at build time.

Tested in both flat and monorepo setup.