### PR TITLE
fix: cloudflare geolocation

### DIFF
--- a/packages/open-next/src/overrides/wrappers/cloudflare.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare.ts
@@ -6,7 +6,7 @@ import type { MiddlewareOutputEvent } from "../../core/routingHandler";
 const cfPropNameToHeaderName = {
   city: "x-open-next-city",
   country: "x-open-next-country",
-  region: "x-open-next-region",
+  regionCode: "x-open-next-region",
   latitude: "x-open-next-latitude",
   longitude: "x-open-next-longitude",
 };


### PR DESCRIPTION
Use the code rather than the fullname.
See https://vercel.com/guides/geo-ip-headers-geolocation-vercel-functions#geolocation-headers

_(cloudfront correctly uses `cloudfront-viewer-region` vs `cloudfront-viewer-region-name`)_