### PR TITLE
Feat: Allow overriding the proxying for external rewrite

### DIFF
--- a/.changeset/strong-keys-ring.md
+++ b/.changeset/strong-keys-ring.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Feat: Allow overriding the proxying for external rewrite

--- a/packages/open-next/src/adapters/middleware.ts
+++ b/packages/open-next/src/adapters/middleware.ts
@@ -6,6 +6,7 @@ import { createGenericHandler } from "../core/createGenericHandler";
 import {
   resolveIncrementalCache,
   resolveOriginResolver,
+  resolveProxyRequest,
   resolveQueue,
   resolveTagCache,
 } from "../core/resolve";
@@ -17,6 +18,10 @@ globalThis.__openNextAls = new AsyncLocalStorage();
 const defaultHandler = async (internalEvent: InternalEvent) => {
   const originResolver = await resolveOriginResolver(
     globalThis.openNextConfig.middleware?.originResolver,
+  );
+
+  const externalRequestProxy = await resolveProxyRequest(
+    globalThis.openNextConfig.middleware?.override?.proxyExternalRequest,
   );
 
   //#override includeCacheInMiddleware
@@ -43,14 +48,15 @@ const defaultHandler = async (internalEvent: InternalEvent) => {
         let origin: Origin | false = false;
         if (!result.isExternalRewrite) {
           origin = await originResolver.resolve(result.internalEvent.rawPath);
+          return {
+            type: "middleware",
+            internalEvent: result.internalEvent,
+            isExternalRewrite: result.isExternalRewrite,
+            origin,
+            isISR: result.isISR,
+          };
         }
-        return {
-          type: "middleware",
-          internalEvent: result.internalEvent,
-          isExternalRewrite: result.isExternalRewrite,
-          origin,
-          isISR: result.isISR,
-        };
+        return externalRequestProxy.proxy(result.internalEvent);
       }
 
       debug("Middleware response", result);

--- a/packages/open-next/src/adapters/middleware.ts
+++ b/packages/open-next/src/adapters/middleware.ts
@@ -45,9 +45,10 @@ const defaultHandler = async (internalEvent: InternalEvent) => {
       const result = await routingHandler(internalEvent);
       if ("internalEvent" in result) {
         debug("Middleware intercepted event", internalEvent);
-        let origin: Origin | false = false;
         if (!result.isExternalRewrite) {
-          origin = await originResolver.resolve(result.internalEvent.rawPath);
+          const origin = await originResolver.resolve(
+            result.internalEvent.rawPath,
+          );
           return {
             type: "middleware",
             internalEvent: result.internalEvent,

--- a/packages/open-next/src/adapters/middleware.ts
+++ b/packages/open-next/src/adapters/middleware.ts
@@ -69,7 +69,8 @@ const defaultHandler = async (internalEvent: InternalEvent) => {
               url: "/500",
               method: "GET",
             },
-            isExternalRewrite: result.isExternalRewrite,
+            // On error we need to rewrite to the 500 page which is an internal rewrite
+            isExternalRewrite: false,
             origin: false,
             isISR: result.isISR,
           };

--- a/packages/open-next/src/build/createMiddleware.ts
+++ b/packages/open-next/src/build/createMiddleware.ts
@@ -57,7 +57,10 @@ export async function createMiddleware(
       outfile: path.join(outputPath, "handler.mjs"),
       middlewareInfo,
       options,
-      overrides: config.middleware?.override,
+      overrides: {
+        ...config.middleware.override,
+        originResolver: config.middleware.originResolver,
+      },
       defaultConverter: "aws-cloudfront",
       includeCache: config.dangerous?.enableCacheInterception,
       additionalExternals: config.edgeExternals,

--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -91,6 +91,10 @@ export async function buildEdgeBundle({
                       : "sqs-lite",
                 }
               : {}),
+            originResolver:
+              typeof overrides?.originResolver === "string"
+                ? overrides.originResolver
+                : "pattern-env",
           },
           fnName: name,
         }),

--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -95,6 +95,10 @@ export async function buildEdgeBundle({
               typeof overrides?.originResolver === "string"
                 ? overrides.originResolver
                 : "pattern-env",
+            proxyExternalRequest:
+              typeof overrides?.proxyExternalRequest === "string"
+                ? overrides.proxyExternalRequest
+                : "node",
           },
           fnName: name,
         }),

--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -6,11 +6,14 @@ import { build } from "esbuild";
 import type { MiddlewareInfo, MiddlewareManifest } from "types/next-types";
 import type {
   IncludedConverter,
+  IncludedOriginResolver,
+  LazyLoadedOverride,
   OverrideOptions,
   RouteTemplate,
   SplittedFunctionOptions,
 } from "types/open-next";
 
+import type { OriginResolver } from "types/overrides.js";
 import logger from "../../logger.js";
 import { openNextEdgePlugins } from "../../plugins/edge.js";
 import { openNextReplacementPlugin } from "../../plugins/replacement.js";
@@ -23,7 +26,11 @@ interface BuildEdgeBundleOptions {
   entrypoint: string;
   outfile: string;
   options: BuildOptions;
-  overrides?: OverrideOptions;
+  overrides?: OverrideOptions & {
+    originResolver?:
+      | LazyLoadedOverride<OriginResolver>
+      | IncludedOriginResolver;
+  };
   defaultConverter?: IncludedConverter;
   additionalInject?: string;
   includeCache?: boolean;

--- a/packages/open-next/src/build/validateConfig.ts
+++ b/packages/open-next/src/build/validateConfig.ts
@@ -18,6 +18,7 @@ const compatibilityMatrix: Record<IncludedWrapper, IncludedConverter[]> = {
   "aws-lambda-streaming": ["aws-apigw-v2"],
   cloudflare: ["edge"],
   node: ["node"],
+  dummy: [],
 };
 
 function validateFunctionOptions(fnOptions: FunctionOptions) {

--- a/packages/open-next/src/core/createMainHandler.ts
+++ b/packages/open-next/src/core/createMainHandler.ts
@@ -6,6 +6,7 @@ import { openNextHandler } from "./requestHandler";
 import {
   resolveConverter,
   resolveIncrementalCache,
+  resolveProxyRequest,
   resolveQueue,
   resolveTagCache,
   resolveWrapper,
@@ -32,6 +33,10 @@ export async function createMainHandler() {
   );
 
   globalThis.tagCache = await resolveTagCache(thisFunction.override?.tagCache);
+
+  globalThis.proxyExternalRequest = await resolveProxyRequest(
+    thisFunction.override?.proxyExternalRequest,
+  );
 
   globalThis.lastModified = {};
 

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -70,10 +70,29 @@ export async function openNextHandler(
         "isExternalRewrite" in preprocessResult &&
         preprocessResult.isExternalRewrite
       ) {
-        const proxyResult = await globalThis.proxyExternalRequest.proxy(
-          preprocessResult.internalEvent,
-        );
-        preprocessResult = proxyResult;
+        try {
+          const proxyResult = await globalThis.proxyExternalRequest.proxy(
+            preprocessResult.internalEvent,
+          );
+          preprocessResult = proxyResult;
+        } catch (e) {
+          error("External request failed.", e);
+          preprocessResult = {
+            internalEvent: {
+              type: "core",
+              rawPath: "/500",
+              method: "GET",
+              headers: {},
+              url: "/500",
+              query: {},
+              cookies: {},
+              remoteAddress: "",
+            },
+            isExternalRewrite: false,
+            isISR: false,
+            origin: false,
+          };
+        }
       }
 
       if ("type" in preprocessResult) {

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -67,6 +67,7 @@ export async function openNextHandler(
       }
 
       if (
+        "isExternalRewrite" in preprocessResult &&
         preprocessResult.isExternalRewrite === true
       ) {
         try {

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -71,10 +71,9 @@ export async function openNextHandler(
         preprocessResult.isExternalRewrite
       ) {
         try {
-          const proxyResult = await globalThis.proxyExternalRequest.proxy(
+          preprocessResult = await globalThis.proxyExternalRequest.proxy(
             preprocessResult.internalEvent,
           );
-          preprocessResult = proxyResult;
         } catch (e) {
           error("External request failed.", e);
           preprocessResult = {

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -87,6 +87,7 @@ export async function openNextHandler(
               cookies: {},
               remoteAddress: "",
             },
+            // On error we need to rewrite to the 500 page which is an internal rewrite
             isExternalRewrite: false,
             isISR: false,
             origin: false,

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -67,8 +67,7 @@ export async function openNextHandler(
       }
 
       if (
-        "isExternalRewrite" in preprocessResult &&
-        preprocessResult.isExternalRewrite
+        preprocessResult.isExternalRewrite === true
       ) {
         try {
           preprocessResult = await globalThis.proxyExternalRequest.proxy(

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -7,7 +7,8 @@ import { runWithOpenNextRequestContext } from "utils/promise";
 
 import { debug, error, warn } from "../adapters/logger";
 import { patchAsyncStorage } from "./patchAsyncStorage";
-import { convertRes, createServerResponse, proxyRequest } from "./routing/util";
+import { resolveProxyRequest } from "./resolve";
+import { convertRes, createServerResponse } from "./routing/util";
 import type { MiddlewareOutputEvent } from "./routingHandler";
 import routingHandler, {
   MIDDLEWARE_HEADER_PREFIX,
@@ -65,6 +66,16 @@ export async function openNextHandler(
         delete headers[rawKey];
       }
 
+      if (
+        "isExternalRewrite" in preprocessResult &&
+        preprocessResult.isExternalRewrite
+      ) {
+        const proxyResult = await globalThis.proxyExternalRequest.proxy(
+          preprocessResult.internalEvent,
+        );
+        preprocessResult = proxyResult;
+      }
+
       if ("type" in preprocessResult) {
         // response is used only in the streaming case
         if (responseStreaming) {
@@ -110,7 +121,6 @@ export async function openNextHandler(
         store.mergeHeadersPriority = mergeHeadersPriority;
       }
 
-      const preprocessedResult = preprocessResult as MiddlewareOutputEvent;
       const req = new IncomingMessage(reqProps);
       const res = createServerResponse(
         preprocessedEvent,
@@ -118,12 +128,7 @@ export async function openNextHandler(
         responseStreaming,
       );
 
-      await processRequest(
-        req,
-        res,
-        preprocessedEvent,
-        preprocessedResult.isExternalRewrite,
-      );
+      await processRequest(req, res, preprocessedEvent);
 
       const {
         statusCode,
@@ -155,7 +160,6 @@ async function processRequest(
   req: IncomingMessage,
   res: OpenNextNodeResponse,
   internalEvent: InternalEvent,
-  isExternalRewrite?: boolean,
 ) {
   // @ts-ignore
   // Next.js doesn't parse body if the property exists
@@ -163,13 +167,6 @@ async function processRequest(
   delete req.body;
 
   try {
-    // `serverHandler` is replaced at build time depending on user's
-    // nextjs version to patch Nextjs 13.4.x and future breaking changes.
-
-    if (isExternalRewrite) {
-      return proxyRequest(internalEvent, res);
-    }
-
     //#override applyNextjsPrebundledReact
     setNextjsPrebundledReact(internalEvent.rawPath);
     //#endOverride

--- a/packages/open-next/src/core/resolve.ts
+++ b/packages/open-next/src/core/resolve.ts
@@ -1,22 +1,15 @@
 import type {
   BaseEventOrResult,
   DefaultOverrideOptions,
-  IncludedProxyExternalRequest,
-  IncludedWarmer,
   InternalEvent,
   InternalResult,
-  LazyLoadedOverride,
+  OpenNextConfig,
   OverrideOptions,
 } from "types/open-next";
-import type {
-  Converter,
-  ImageLoader,
-  OriginResolver,
-  ProxyExternalRequest,
-  TagCache,
-  Warmer,
-  Wrapper,
-} from "types/overrides";
+import type { Converter, TagCache, Wrapper } from "types/overrides";
+
+// Just a little utility type to remove undefined from a type
+type RemoveUndefined<T> = T extends undefined ? never : T;
 
 export async function resolveConverter<
   E extends BaseEventOrResult = InternalEvent,
@@ -98,7 +91,7 @@ export async function resolveIncrementalCache(
  * @__PURE__
  */
 export async function resolveImageLoader(
-  imageLoader: LazyLoadedOverride<ImageLoader> | string,
+  imageLoader: RemoveUndefined<OpenNextConfig["imageOptimization"]>["loader"],
 ) {
   if (typeof imageLoader === "function") {
     return imageLoader();
@@ -112,7 +105,9 @@ export async function resolveImageLoader(
  * @__PURE__
  */
 export async function resolveOriginResolver(
-  originResolver?: LazyLoadedOverride<OriginResolver> | string,
+  originResolver: RemoveUndefined<
+    OpenNextConfig["middleware"]
+  >["originResolver"],
 ) {
   if (typeof originResolver === "function") {
     return originResolver();
@@ -125,7 +120,7 @@ export async function resolveOriginResolver(
  * @__PURE__
  */
 export async function resolveWarmerInvoke(
-  warmer?: LazyLoadedOverride<Warmer> | IncludedWarmer,
+  warmer: RemoveUndefined<OpenNextConfig["warmer"]>["invokeFunction"],
 ) {
   if (typeof warmer === "function") {
     return warmer();
@@ -138,9 +133,7 @@ export async function resolveWarmerInvoke(
  * @__PURE__
  */
 export async function resolveProxyRequest(
-  proxyRequest?:
-    | LazyLoadedOverride<ProxyExternalRequest>
-    | IncludedProxyExternalRequest,
+  proxyRequest: OverrideOptions["proxyExternalRequest"],
 ) {
   if (typeof proxyRequest === "function") {
     return proxyRequest();

--- a/packages/open-next/src/core/resolve.ts
+++ b/packages/open-next/src/core/resolve.ts
@@ -2,6 +2,7 @@ import type {
   BaseEventOrResult,
   DefaultOverrideOptions,
   IncludedProxyExternalRequest,
+  IncludedWarmer,
   InternalEvent,
   InternalResult,
   LazyLoadedOverride,
@@ -124,7 +125,7 @@ export async function resolveOriginResolver(
  * @__PURE__
  */
 export async function resolveWarmerInvoke(
-  warmer?: LazyLoadedOverride<Warmer> | "aws-lambda",
+  warmer?: LazyLoadedOverride<Warmer> | IncludedWarmer,
 ) {
   if (typeof warmer === "function") {
     return warmer();

--- a/packages/open-next/src/core/resolve.ts
+++ b/packages/open-next/src/core/resolve.ts
@@ -1,6 +1,7 @@
 import type {
   BaseEventOrResult,
   DefaultOverrideOptions,
+  IncludedProxyExternalRequest,
   InternalEvent,
   InternalResult,
   LazyLoadedOverride,
@@ -10,6 +11,7 @@ import type {
   Converter,
   ImageLoader,
   OriginResolver,
+  ProxyExternalRequest,
   TagCache,
   Warmer,
   Wrapper,
@@ -128,5 +130,20 @@ export async function resolveWarmerInvoke(
     return warmer();
   }
   const m_1 = await import("../overrides/warmer/aws-lambda.js");
+  return m_1.default;
+}
+
+/**
+ * @__PURE__
+ */
+export async function resolveProxyRequest(
+  proxyRequest?:
+    | LazyLoadedOverride<ProxyExternalRequest>
+    | IncludedProxyExternalRequest,
+) {
+  if (typeof proxyRequest === "function") {
+    return proxyRequest();
+  }
+  const m_1 = await import("../overrides/proxyExternalRequest/node.js");
   return m_1.default;
 }

--- a/packages/open-next/src/overrides/converters/aws-cloudfront.ts
+++ b/packages/open-next/src/overrides/converters/aws-cloudfront.ts
@@ -18,7 +18,6 @@ import {
   convertToQuery,
   convertToQueryString,
   createServerResponse,
-  proxyRequest,
 } from "../../core/routing/util";
 import type { MiddlewareOutputEvent } from "../../core/routingHandler";
 
@@ -159,26 +158,7 @@ async function convertToCloudFrontRequestResult(
     const responseHeaders = result.internalEvent.headers;
 
     // Handle external rewrite
-    if (result.isExternalRewrite) {
-      const serverResponse = createServerResponse(result.internalEvent, {});
-      await proxyRequest(result.internalEvent, serverResponse);
-      const externalResult = convertRes(serverResponse);
-      const body = await fromReadableStream(
-        externalResult.body,
-        externalResult.isBase64Encoded,
-      );
-      const cloudfrontResult = {
-        status: externalResult.statusCode.toString(),
-        statusDescription: "OK",
-        headers: convertToCloudfrontHeaders(externalResult.headers, true),
-        bodyEncoding: externalResult.isBase64Encoded
-          ? ("base64" as const)
-          : ("text" as const),
-        body,
-      };
-      debug("externalResult", cloudfrontResult);
-      return cloudfrontResult;
-    }
+
     let customOrigin = origin?.custom as CloudFrontCustomOrigin;
     let host = responseHeaders.host ?? responseHeaders.Host;
     if (result.origin) {

--- a/packages/open-next/src/overrides/proxyExternalRequest/dummy.ts
+++ b/packages/open-next/src/overrides/proxyExternalRequest/dummy.ts
@@ -1,0 +1,10 @@
+import type { ProxyExternalRequest } from "types/overrides";
+
+const DummyProxyExternalRequest: ProxyExternalRequest = {
+  name: "dummy",
+  proxy: async (_event) => {
+    throw new Error("This is a dummy implementation");
+  },
+};
+
+export default DummyProxyExternalRequest;

--- a/packages/open-next/src/overrides/proxyExternalRequest/fetch.ts
+++ b/packages/open-next/src/overrides/proxyExternalRequest/fetch.ts
@@ -1,0 +1,28 @@
+import type { ProxyExternalRequest } from "types/overrides";
+import { emptyReadableStream } from "utils/stream";
+
+const fetchProxy: ProxyExternalRequest = {
+  name: "fetch-proxy",
+  // @ts-ignore
+  proxy: async (internalEvent) => {
+    const { url, headers, method, body } = internalEvent;
+    const response = await fetch(url, {
+      method,
+      headers,
+      body,
+    });
+    const responseHeaders: Record<string, string | string[]> = {};
+    response.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+    return {
+      type: "core",
+      headers: responseHeaders,
+      statusCode: response.status,
+      isBase64Encoded: true,
+      body: response.body ?? emptyReadableStream(),
+    };
+  },
+};
+
+export default fetchProxy;

--- a/packages/open-next/src/overrides/proxyExternalRequest/node.ts
+++ b/packages/open-next/src/overrides/proxyExternalRequest/node.ts
@@ -18,13 +18,16 @@ function filterHeadersForProxy(
     "content-encoding",
     "content-length",
   ];
-  Object.entries(headers).forEach(([key, value]) => {
-    const lowerKey = key.toLowerCase();
-    if (disallowedHeaders.includes(lowerKey) || lowerKey.startsWith("x-amz"))
-      return;
-
-    filteredHeaders[key] = value?.toString() ?? "";
-  });
+  Object.entries(headers)
+    .filter(([key, _]) => {
+      const lowerKey = key.toLowerCase();
+      return !(
+        disallowedHeaders.includes(lowerKey) || lowerKey.startsWith("x-amz")
+      );
+    })
+    .forEach(([key, value]) => {
+      filteredHeaders[key] = value?.toString() ?? "";
+    });
   return filteredHeaders;
 }
 

--- a/packages/open-next/src/overrides/proxyExternalRequest/node.ts
+++ b/packages/open-next/src/overrides/proxyExternalRequest/node.ts
@@ -1,0 +1,83 @@
+import { debug, error } from "node:console";
+import { request } from "node:https";
+import { Readable } from "node:stream";
+import type { InternalEvent, InternalResult } from "types/open-next";
+import type { ProxyExternalRequest } from "types/overrides";
+import { isBinaryContentType } from "../../adapters/binary";
+
+function filterHeadersForProxy(
+  headers: Record<string, string | string[] | undefined>,
+) {
+  const filteredHeaders: Record<string, string | string[]> = {};
+  const disallowedHeaders = [
+    "host",
+    "connection",
+    "via",
+    "x-cache",
+    "transfer-encoding",
+    "content-encoding",
+    "content-length",
+  ];
+  Object.entries(headers).forEach(([key, value]) => {
+    const lowerKey = key.toLowerCase();
+    if (disallowedHeaders.includes(lowerKey) || lowerKey.startsWith("x-amz"))
+      return;
+
+    filteredHeaders[key] = value?.toString() ?? "";
+  });
+  return filteredHeaders;
+}
+
+const nodeProxy: ProxyExternalRequest = {
+  name: "node-proxy",
+  proxy: (internalEvent: InternalEvent) => {
+    const { url, headers, method, body } = internalEvent;
+    debug("proxyRequest", url);
+    return new Promise<InternalResult>((resolve, reject) => {
+      const filteredHeaders = filterHeadersForProxy(headers);
+      debug("filteredHeaders", filteredHeaders);
+      const req = request(
+        url,
+        {
+          headers: filteredHeaders,
+          method,
+          rejectUnauthorized: false,
+        },
+        (_res) => {
+          const nodeReadableStream =
+            _res.headers["content-encoding"] === "br"
+              ? _res.pipe(require("node:zlib").createBrotliDecompress())
+              : _res.headers["content-encoding"] === "gzip"
+                ? _res.pipe(require("node:zlib").createGunzip())
+                : _res;
+
+          const isBase64Encoded =
+            isBinaryContentType(headers["content-type"]) ||
+            !!headers["content-encoding"];
+          const result: InternalResult = {
+            type: "core",
+            headers: filterHeadersForProxy(_res.headers),
+            statusCode: _res.statusCode ?? 200,
+            // TODO: check base64 encoding
+            isBase64Encoded,
+            body: Readable.toWeb(nodeReadableStream),
+          };
+
+          resolve(result);
+
+          _res.on("error", (e) => {
+            error("proxyRequest error", e);
+            reject(e);
+          });
+        },
+      );
+
+      if (body && method !== "GET" && method !== "HEAD") {
+        req.write(body);
+      }
+      req.end();
+    });
+  },
+};
+
+export default nodeProxy;

--- a/packages/open-next/src/plugins/resolve.ts
+++ b/packages/open-next/src/plugins/resolve.ts
@@ -3,27 +3,20 @@ import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import type { Plugin } from "esbuild";
 import type {
-  DefaultOverrideOptions,
   IncludedImageLoader,
   IncludedOriginResolver,
-  IncludedProxyExternalRequest,
   IncludedWarmer,
   LazyLoadedOverride,
   OverrideOptions,
 } from "types/open-next";
-import type {
-  ImageLoader,
-  OriginResolver,
-  ProxyExternalRequest,
-  Warmer,
-} from "types/overrides";
+import type { ImageLoader, OriginResolver, Warmer } from "types/overrides";
 
 import logger from "../logger.js";
 
 export interface IPluginSettings {
   overrides?: {
-    wrapper?: DefaultOverrideOptions<any, any>["wrapper"];
-    converter?: DefaultOverrideOptions<any, any>["converter"];
+    wrapper?: OverrideOptions["wrapper"];
+    converter?: OverrideOptions["converter"];
     tagCache?: OverrideOptions["tagCache"];
     queue?: OverrideOptions["queue"];
     incrementalCache?: OverrideOptions["incrementalCache"];
@@ -32,9 +25,7 @@ export interface IPluginSettings {
       | LazyLoadedOverride<OriginResolver>
       | IncludedOriginResolver;
     warmer?: LazyLoadedOverride<Warmer> | IncludedWarmer;
-    proxyExternalRequest?:
-      | LazyLoadedOverride<ProxyExternalRequest>
-      | IncludedProxyExternalRequest;
+    proxyExternalRequest?: OverrideOptions["proxyExternalRequest"];
   };
   fnName?: string;
 }

--- a/packages/open-next/src/plugins/resolve.ts
+++ b/packages/open-next/src/plugins/resolve.ts
@@ -6,11 +6,17 @@ import type {
   DefaultOverrideOptions,
   IncludedImageLoader,
   IncludedOriginResolver,
+  IncludedProxyExternalRequest,
   IncludedWarmer,
   LazyLoadedOverride,
   OverrideOptions,
 } from "types/open-next";
-import type { ImageLoader, OriginResolver, Warmer } from "types/overrides";
+import type {
+  ImageLoader,
+  OriginResolver,
+  ProxyExternalRequest,
+  Warmer,
+} from "types/overrides";
 
 import logger from "../logger.js";
 
@@ -26,6 +32,9 @@ export interface IPluginSettings {
       | LazyLoadedOverride<OriginResolver>
       | IncludedOriginResolver;
     warmer?: LazyLoadedOverride<Warmer> | IncludedWarmer;
+    proxyExternalRequest?:
+      | LazyLoadedOverride<ProxyExternalRequest>
+      | IncludedProxyExternalRequest;
   };
   fnName?: string;
 }
@@ -50,6 +59,7 @@ const nameToFolder = {
   imageLoader: "imageLoader",
   originResolver: "originResolver",
   warmer: "warmer",
+  proxyExternalRequest: "proxyExternalRequest",
 };
 
 const defaultOverrides = {
@@ -61,6 +71,7 @@ const defaultOverrides = {
   imageLoader: "s3",
   originResolver: "pattern-env",
   warmer: "aws-lambda",
+  proxyExternalRequest: "node",
 };
 
 /**

--- a/packages/open-next/src/plugins/resolve.ts
+++ b/packages/open-next/src/plugins/resolve.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import type { Plugin } from "esbuild";
 import type {
+  DefaultOverrideOptions,
   IncludedImageLoader,
   IncludedOriginResolver,
   IncludedWarmer,
@@ -15,8 +16,8 @@ import logger from "../logger.js";
 
 export interface IPluginSettings {
   overrides?: {
-    wrapper?: OverrideOptions["wrapper"];
-    converter?: OverrideOptions["converter"];
+    wrapper?: DefaultOverrideOptions<any, any>["wrapper"];
+    converter?: DefaultOverrideOptions<any, any>["converter"];
     tagCache?: OverrideOptions["tagCache"];
     queue?: OverrideOptions["queue"];
     incrementalCache?: OverrideOptions["incrementalCache"];

--- a/packages/open-next/src/types/global.ts
+++ b/packages/open-next/src/types/global.ts
@@ -1,7 +1,12 @@
 import type { AsyncLocalStorage } from "node:async_hooks";
 import type { OutgoingHttpHeaders } from "node:http";
 
-import type { IncrementalCache, Queue, TagCache } from "types/overrides";
+import type {
+  IncrementalCache,
+  ProxyExternalRequest,
+  Queue,
+  TagCache,
+} from "types/overrides";
 
 import type { DetachedPromiseRunner } from "../utils/promise";
 import type { OpenNextConfig } from "./open-next";
@@ -194,4 +199,11 @@ declare global {
    * Defined in `createMainHandler` or in `adapter/middleware.ts`.
    */
   var queue: Queue;
+
+  /**
+   * The function that is used when resolving external rewrite requests.
+   * Only available in main functions
+   * Defined in `createMainHandler`.
+   */
+  var proxyExternalRequest: ProxyExternalRequest;
 }

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -309,7 +309,7 @@ export interface OpenNextConfig {
    * @default undefined
    */
   warmer?: DefaultFunctionOptions<WarmerEvent, WarmerResponse> & {
-    invokeFunction: IncludedWarmer | LazyLoadedOverride<Warmer>;
+    invokeFunction?: IncludedWarmer | LazyLoadedOverride<Warmer>;
   };
 
   /**

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -80,7 +80,8 @@ export type IncludedWrapper =
   | "aws-lambda"
   | "aws-lambda-streaming"
   | "node"
-  | "cloudflare";
+  | "cloudflare"
+  | "dummy";
 
 export type IncludedConverter =
   | "aws-apigw-v2"
@@ -91,19 +92,19 @@ export type IncludedConverter =
   | "sqs-revalidate"
   | "dummy";
 
-export type IncludedQueue = "sqs" | "sqs-lite";
+export type IncludedQueue = "sqs" | "sqs-lite" | "dummy";
 
-export type IncludedIncrementalCache = "s3" | "s3-lite";
+export type IncludedIncrementalCache = "s3" | "s3-lite" | "dummy";
 
-export type IncludedTagCache = "dynamodb" | "dynamodb-lite";
+export type IncludedTagCache = "dynamodb" | "dynamodb-lite" | "dummy";
 
-export type IncludedImageLoader = "s3" | "host";
+export type IncludedImageLoader = "s3" | "host" | "dummy";
 
-export type IncludedOriginResolver = "pattern-env";
+export type IncludedOriginResolver = "pattern-env" | "dummy";
 
-export type IncludedWarmer = "aws-lambda";
+export type IncludedWarmer = "aws-lambda" | "dummy";
 
-export type IncludedProxyExternalRequest = "node" | "fetch";
+export type IncludedProxyExternalRequest = "node" | "fetch" | "dummy";
 
 export interface DefaultOverrideOptions<
   E extends BaseEventOrResult = InternalEvent,

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -6,6 +6,7 @@ import type {
   ImageLoader,
   IncrementalCache,
   OriginResolver,
+  ProxyExternalRequest,
   Queue,
   TagCache,
   Warmer,
@@ -102,6 +103,8 @@ export type IncludedOriginResolver = "pattern-env";
 
 export type IncludedWarmer = "aws-lambda";
 
+export type IncludedProxyExternalRequest = "node" | "fetch";
+
 export interface DefaultOverrideOptions<
   E extends BaseEventOrResult = InternalEvent,
   R extends BaseEventOrResult = InternalResult,
@@ -145,6 +148,14 @@ export interface OverrideOptions extends DefaultOverrideOptions {
    * @default "sqs"
    */
   queue?: IncludedQueue | LazyLoadedOverride<Queue>;
+
+  /**
+   * Add possibility to override the default proxy for external rewrite
+   * @default "node"
+   */
+  proxyExternalRequest?:
+    | IncludedProxyExternalRequest
+    | LazyLoadedOverride<ProxyExternalRequest>;
 }
 
 export interface InstallOptions {

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -135,3 +135,7 @@ export type ImageLoader = BaseOverride & {
 export type OriginResolver = BaseOverride & {
   resolve: (path: string) => Promise<Origin | false>;
 };
+
+export type ProxyExternalRequest = BaseOverride & {
+  proxy: (event: InternalEvent) => Promise<InternalResult>;
+};


### PR DESCRIPTION
This PR add an option to override the old `proxyRequest` fn that was used for external rewrites.
It also automatically make the proxying when used in the external middleware, no need to do it in a converter or the wrapper.

By default it is the same as before, but it could use `fetch` for the proxying

@vicb PTAL, i haven't tested the fetch part, i'd appreciate some feedback on this