### PR TITLE
fix(assets): check if favicon.ico is a file

### DIFF
--- a/.changeset/tender-chicken-deliver.md
+++ b/.changeset/tender-chicken-deliver.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+When copying over assets, check to see if favicon.ico is a file. In some cases favicon.ico is a folder that can contain a route handler.

--- a/packages/open-next/src/build/createAssets.ts
+++ b/packages/open-next/src/build/createAssets.ts
@@ -44,7 +44,9 @@ export function createStaticAssets(options: buildHelper.BuildOptions) {
 
   const faviconPath = path.join(appPath, appSrcPath, "favicon.ico");
 
-  if (fs.existsSync(faviconPath)) {
+  // We need to check if the favicon is either a file or directory.
+  // If it's a directory, we assume it's a route handler and ignore it.
+  if (fs.existsSync(faviconPath) && fs.lstatSync(faviconPath).isFile()) {
     fs.copyFileSync(faviconPath, path.join(outputPath, "favicon.ico"));
   }
 }


### PR DESCRIPTION
## What/why?

In the case a Next.js application has a route handler for the `favicon.ico` path, we need to check to see if it's a file before copying it over to the output directory.

Example:
```ts
// /app/favicon.ico/route.ts
export const GET = async () => {
  const favicon = await fetch('https://somecms.com').then((res) => res.arrayBuffer());

  return new Response(favicon, {
    headers: {
      'Content-Type': 'image/x-icon',
    },
  });
};

export const dynamic = 'force-static';
```