### PR TITLE
add: pnpm catalog

### DIFF
--- a/examples/app-pages-router/package.json
+++ b/examples/app-pages-router/package.json
@@ -21,9 +21,9 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "autoprefixer": "10.4.15",
-    "postcss": "8.4.27",
-    "tailwindcss": "3.3.3",
-    "typescript": "^4.9.3"
+    "autoprefixer": "catalog:",
+    "postcss": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/examples/app-pages-router/package.json
+++ b/examples/app-pages-router/package.json
@@ -12,15 +12,15 @@
   },
   "dependencies": {
     "@example/shared": "workspace:*",
-    "next": "15.0.1",
+    "next": "catalog:",
     "@opennextjs/aws": "workspace:*",
-    "react": "19.0.0-rc-69d4b800-20241021",
-    "react-dom": "19.0.0-rc-69d4b800-20241021"
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
-    "@types/node": "20.5.0",
-    "@types/react": "npm:types-react@19.0.0-rc.1",
-    "@types/react-dom": "npm:types-react-dom@19.0.0-rc.1",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
     "autoprefixer": "10.4.15",
     "postcss": "8.4.27",
     "tailwindcss": "3.3.3",

--- a/examples/app-router/package.json
+++ b/examples/app-router/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@example/shared": "workspace:*",
-    "next": "catalog:",
     "@opennextjs/aws": "workspace:*",
+    "next": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
   },
@@ -21,9 +21,9 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "autoprefixer": "10.4.15",
-    "postcss": "8.4.27",
-    "tailwindcss": "3.3.3",
-    "typescript": "^4.9.3"
+    "autoprefixer": "catalog:",
+    "postcss": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/examples/app-router/package.json
+++ b/examples/app-router/package.json
@@ -12,15 +12,15 @@
   },
   "dependencies": {
     "@example/shared": "workspace:*",
-    "next": "15.0.1",
+    "next": "catalog:",
     "@opennextjs/aws": "workspace:*",
-    "react": "19.0.0-rc-69d4b800-20241021",
-    "react-dom": "19.0.0-rc-69d4b800-20241021"
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
-    "@types/node": "20.5.0",
-    "@types/react": "npm:types-react@19.0.0-rc.1",
-    "@types/react-dom": "npm:types-react-dom@19.0.0-rc.1",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
     "autoprefixer": "10.4.15",
     "postcss": "8.4.27",
     "tailwindcss": "3.3.3",

--- a/examples/pages-router/package.json
+++ b/examples/pages-router/package.json
@@ -12,17 +12,17 @@
   },
   "dependencies": {
     "@example/shared": "workspace:*",
-    "@types/node": "20.5.0",
+    "@types/node": "catalog:",
     "autoprefixer": "10.4.15",
-    "next": "15.0.1",
+    "next": "catalog:",
     "postcss": "8.4.27",
-    "react": "19.0.0-rc-69d4b800-20241021",
-    "react-dom": "19.0.0-rc-69d4b800-20241021",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "tailwindcss": "3.3.3",
     "typescript": "^4.9.3"
   },
   "devDependencies": {
-    "@types/react": "npm:types-react@19.0.0-rc.1",
-    "@types/react-dom": "npm:types-react-dom@19.0.0-rc.1"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
   }
 }

--- a/examples/pages-router/package.json
+++ b/examples/pages-router/package.json
@@ -12,17 +12,17 @@
   },
   "dependencies": {
     "@example/shared": "workspace:*",
-    "@types/node": "catalog:",
-    "autoprefixer": "10.4.15",
     "next": "catalog:",
-    "postcss": "8.4.27",
     "react": "catalog:",
-    "react-dom": "catalog:",
-    "tailwindcss": "3.3.3",
-    "typescript": "^4.9.3"
+    "react-dom": "catalog:"
   },
   "devDependencies": {
+    "@types/node": "catalog:",
     "@types/react": "catalog:",
-    "@types/react-dom": "catalog:"
+    "@types/react-dom": "catalog:",
+    "tailwindcss": "catalog:",
+    "postcss": "catalog:",
+    "autoprefixer": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/examples/shared/package.json
+++ b/examples/shared/package.json
@@ -6,11 +6,11 @@
     "clean": "rm -rf .turbo && rm -rf node_modules"
   },
   "dependencies": {
-    "react": "19.0.0-rc-69d4b800-20241021",
-    "react-dom": "19.0.0-rc-69d4b800-20241021"
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "npm:types-react@19.0.0-rc.1",
-    "@types/react-dom": "npm:types-react-dom@19.0.0-rc.1"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
   }
 }

--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -45,9 +45,9 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.109",
-    "@types/node": "^18.16.1",
+    "@types/node": "catalog:",
     "tsc-alias": "^1.8.8",
-    "typescript": "^5.6.3"
+    "typescript": "catalog:"
   },
   "bugs": {
     "url": "https://github.com/opennextjs/opennextjs-aws/issues"

--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -163,7 +163,7 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
               ...this.headers,
             };
       const initialCookies = parseCookies(
-        this.initialHeaders[SET_COOKIE_HEADER],
+        this.initialHeaders[SET_COOKIE_HEADER]?.toString(),
       );
       this._cookies =
         mergeHeadersPriority === "middleware"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,7 +19,7 @@
   "dependencies": {},
   "devDependencies": {
     "tsup": "7.2.0",
-    "@types/node": "20.5.0"
+    "@types/node": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,15 +15,27 @@ catalogs:
     '@types/react-dom':
       specifier: npm:types-react-dom@19.0.0-rc.1
       version: 19.0.0-rc.1
+    autoprefixer:
+      specifier: 10.4.15
+      version: 10.4.15
     next:
       specifier: 15.0.1
       version: 15.0.1
+    postcss:
+      specifier: 8.4.27
+      version: 8.4.27
     react:
       specifier: 19.0.0-rc-69d4b800-20241021
       version: 19.0.0-rc-69d4b800-20241021
     react-dom:
       specifier: 19.0.0-rc-69d4b800-20241021
       version: 19.0.0-rc-69d4b800-20241021
+    tailwindcss:
+      specifier: 3.3.3
+      version: 3.3.3
+    typescript:
+      specifier: 5.6.3
+      version: 5.6.3
 
 importers:
 
@@ -73,17 +85,17 @@ importers:
         specifier: 'catalog:'
         version: types-react-dom@19.0.0-rc.1
       autoprefixer:
-        specifier: 10.4.15
+        specifier: 'catalog:'
         version: 10.4.15(postcss@8.4.27)
       postcss:
-        specifier: 8.4.27
+        specifier: 'catalog:'
         version: 8.4.27
       tailwindcss:
-        specifier: 3.3.3
-        version: 3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@4.9.5))
+        specifier: 'catalog:'
+        version: 3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3))
       typescript:
-        specifier: ^4.9.3
-        version: 4.9.5
+        specifier: 'catalog:'
+        version: 5.6.3
 
   examples/app-router:
     dependencies:
@@ -113,54 +125,54 @@ importers:
         specifier: 'catalog:'
         version: types-react-dom@19.0.0-rc.1
       autoprefixer:
-        specifier: 10.4.15
+        specifier: 'catalog:'
         version: 10.4.15(postcss@8.4.27)
       postcss:
-        specifier: 8.4.27
+        specifier: 'catalog:'
         version: 8.4.27
       tailwindcss:
-        specifier: 3.3.3
-        version: 3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@4.9.5))
+        specifier: 'catalog:'
+        version: 3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3))
       typescript:
-        specifier: ^4.9.3
-        version: 4.9.5
+        specifier: 'catalog:'
+        version: 5.6.3
 
   examples/pages-router:
     dependencies:
       '@example/shared':
         specifier: workspace:*
         version: link:../shared
-      '@types/node':
-        specifier: 'catalog:'
-        version: 20.5.0
-      autoprefixer:
-        specifier: 10.4.15
-        version: 10.4.15(postcss@8.4.27)
       next:
         specifier: 'catalog:'
         version: 15.0.1(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)
-      postcss:
-        specifier: 8.4.27
-        version: 8.4.27
       react:
         specifier: 'catalog:'
         version: 19.0.0-rc-69d4b800-20241021
       react-dom:
         specifier: 'catalog:'
         version: 19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021)
-      tailwindcss:
-        specifier: 3.3.3
-        version: 3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@4.9.5))
-      typescript:
-        specifier: ^4.9.3
-        version: 4.9.5
     devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.5.0
       '@types/react':
         specifier: 'catalog:'
         version: types-react@19.0.0-rc.1
       '@types/react-dom':
         specifier: 'catalog:'
         version: types-react-dom@19.0.0-rc.1
+      autoprefixer:
+        specifier: 'catalog:'
+        version: 10.4.15(postcss@8.4.27)
+      postcss:
+        specifier: 'catalog:'
+        version: 8.4.27
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.6.3
 
   examples/shared:
     dependencies:
@@ -4775,11 +4787,6 @@ packages:
 
   types-react@19.0.0-rc.1:
     resolution: {integrity: sha512-RshndUfqTW6K3STLPis8BtAYCGOkMbtvYsi90gmVNDZBXUyUc5juf2PE9LfS/JmOlUIRO8cWTS/1MTnmhjDqyQ==}
-
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
 
   typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
@@ -10001,25 +10008,17 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-import@15.1.0(postcss@8.4.27):
+  postcss-import@15.1.0(postcss@8.4.47):
     dependencies:
-      postcss: 8.4.27
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
 
-  postcss-js@4.0.1(postcss@8.4.27):
+  postcss-js@4.0.1(postcss@8.4.47):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.27
-
-  postcss-load-config@4.0.2(postcss@8.4.27)(ts-node@10.9.1(@types/node@20.5.0)(typescript@4.9.5)):
-    dependencies:
-      lilconfig: 3.1.2
-      yaml: 2.6.0
-    optionalDependencies:
-      postcss: 8.4.27
-      ts-node: 10.9.1(@types/node@20.5.0)(typescript@4.9.5)
+      postcss: 8.4.47
 
   postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3)):
     dependencies:
@@ -10029,9 +10028,9 @@ snapshots:
       postcss: 8.4.47
       ts-node: 10.9.1(@types/node@20.5.0)(typescript@5.6.3)
 
-  postcss-nested@6.2.0(postcss@8.4.27):
+  postcss-nested@6.2.0(postcss@8.4.47):
     dependencies:
-      postcss: 8.4.27
+      postcss: 8.4.47
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -10644,7 +10643,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  tailwindcss@3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@4.9.5)):
+  tailwindcss@3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -10660,11 +10659,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.4.27
-      postcss-import: 15.1.0(postcss@8.4.27)
-      postcss-js: 4.0.1(postcss@8.4.27)
-      postcss-load-config: 4.0.2(postcss@8.4.27)(ts-node@10.9.1(@types/node@20.5.0)(typescript@4.9.5))
-      postcss-nested: 6.2.0(postcss@8.4.27)
+      postcss: 8.4.47
+      postcss-import: 15.1.0(postcss@8.4.47)
+      postcss-js: 4.0.1(postcss@8.4.47)
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3))
+      postcss-nested: 6.2.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
       sucrase: 3.35.0
@@ -10749,25 +10748,6 @@ snapshots:
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
-
-  ts-node@10.9.1(@types/node@20.5.0)(typescript@4.9.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.5.0
-      acorn: 8.13.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3):
     dependencies:
@@ -10870,8 +10850,6 @@ snapshots:
   types-react@19.0.0-rc.1:
     dependencies:
       csstype: 3.1.3
-
-  typescript@4.9.5: {}
 
   typescript@5.6.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,13 +251,13 @@ importers:
         specifier: ^8.10.109
         version: 8.10.145
       '@types/node':
-        specifier: 20.5.0
+        specifier: 'catalog:'
         version: 20.5.0
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.10
       typescript:
-        specifier: ^5.6.3
+        specifier: 'catalog:'
         version: 5.6.3
 
   packages/tests-e2e:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,7 +300,7 @@ importers:
   packages/utils:
     devDependencies:
       '@types/node':
-        specifier: 20.5.0
+        specifier: 'catalog:'
         version: 20.5.0
       tsup:
         specifier: 7.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,27 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@types/node':
+      specifier: 20.5.0
+      version: 20.5.0
+    '@types/react':
+      specifier: npm:types-react@19.0.0-rc.1
+      version: 19.0.0-rc.1
+    '@types/react-dom':
+      specifier: npm:types-react-dom@19.0.0-rc.1
+      version: 19.0.0-rc.1
+    next:
+      specifier: 15.0.1
+      version: 15.0.1
+    react:
+      specifier: 19.0.0-rc-69d4b800-20241021
+      version: 19.0.0-rc-69d4b800-20241021
+    react-dom:
+      specifier: 19.0.0-rc-69d4b800-20241021
+      version: 19.0.0-rc-69d4b800-20241021
+
 importers:
 
   .:
@@ -33,23 +54,23 @@ importers:
         specifier: workspace:*
         version: link:../../packages/open-next
       next:
-        specifier: 15.0.1
+        specifier: 'catalog:'
         version: 15.0.1(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)
       react:
-        specifier: 19.0.0-rc-69d4b800-20241021
+        specifier: 'catalog:'
         version: 19.0.0-rc-69d4b800-20241021
       react-dom:
-        specifier: 19.0.0-rc-69d4b800-20241021
+        specifier: 'catalog:'
         version: 19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021)
     devDependencies:
       '@types/node':
-        specifier: 20.5.0
+        specifier: 'catalog:'
         version: 20.5.0
       '@types/react':
-        specifier: npm:types-react@19.0.0-rc.1
+        specifier: 'catalog:'
         version: types-react@19.0.0-rc.1
       '@types/react-dom':
-        specifier: npm:types-react-dom@19.0.0-rc.1
+        specifier: 'catalog:'
         version: types-react-dom@19.0.0-rc.1
       autoprefixer:
         specifier: 10.4.15
@@ -73,23 +94,23 @@ importers:
         specifier: workspace:*
         version: link:../../packages/open-next
       next:
-        specifier: 15.0.1
+        specifier: 'catalog:'
         version: 15.0.1(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)
       react:
-        specifier: 19.0.0-rc-69d4b800-20241021
+        specifier: 'catalog:'
         version: 19.0.0-rc-69d4b800-20241021
       react-dom:
-        specifier: 19.0.0-rc-69d4b800-20241021
+        specifier: 'catalog:'
         version: 19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021)
     devDependencies:
       '@types/node':
-        specifier: 20.5.0
+        specifier: 'catalog:'
         version: 20.5.0
       '@types/react':
-        specifier: npm:types-react@19.0.0-rc.1
+        specifier: 'catalog:'
         version: types-react@19.0.0-rc.1
       '@types/react-dom':
-        specifier: npm:types-react-dom@19.0.0-rc.1
+        specifier: 'catalog:'
         version: types-react-dom@19.0.0-rc.1
       autoprefixer:
         specifier: 10.4.15
@@ -110,22 +131,22 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@types/node':
-        specifier: 20.5.0
+        specifier: 'catalog:'
         version: 20.5.0
       autoprefixer:
         specifier: 10.4.15
         version: 10.4.15(postcss@8.4.27)
       next:
-        specifier: 15.0.1
+        specifier: 'catalog:'
         version: 15.0.1(react-dom@19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021))(react@19.0.0-rc-69d4b800-20241021)
       postcss:
         specifier: 8.4.27
         version: 8.4.27
       react:
-        specifier: 19.0.0-rc-69d4b800-20241021
+        specifier: 'catalog:'
         version: 19.0.0-rc-69d4b800-20241021
       react-dom:
-        specifier: 19.0.0-rc-69d4b800-20241021
+        specifier: 'catalog:'
         version: 19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021)
       tailwindcss:
         specifier: 3.3.3
@@ -135,26 +156,26 @@ importers:
         version: 4.9.5
     devDependencies:
       '@types/react':
-        specifier: npm:types-react@19.0.0-rc.1
+        specifier: 'catalog:'
         version: types-react@19.0.0-rc.1
       '@types/react-dom':
-        specifier: npm:types-react-dom@19.0.0-rc.1
+        specifier: 'catalog:'
         version: types-react-dom@19.0.0-rc.1
 
   examples/shared:
     dependencies:
       react:
-        specifier: 19.0.0-rc-69d4b800-20241021
+        specifier: 'catalog:'
         version: 19.0.0-rc-69d4b800-20241021
       react-dom:
-        specifier: 19.0.0-rc-69d4b800-20241021
+        specifier: 'catalog:'
         version: 19.0.0-rc-69d4b800-20241021(react@19.0.0-rc-69d4b800-20241021)
     devDependencies:
       '@types/react':
-        specifier: npm:types-react@19.0.0-rc.1
+        specifier: 'catalog:'
         version: types-react@19.0.0-rc.1
       '@types/react-dom':
-        specifier: npm:types-react-dom@19.0.0-rc.1
+        specifier: 'catalog:'
         version: types-react-dom@19.0.0-rc.1
 
   examples/sst:
@@ -259,7 +280,7 @@ importers:
         version: 5.4.9(@types/node@20.5.0)(terser@5.16.9)
       vite-tsconfig-paths:
         specifier: ^5.0.1
-        version: 5.0.1(vite@5.4.9(@types/node@20.5.0)(terser@5.16.9))
+        version: 5.0.1(typescript@5.6.3)(vite@5.4.9(@types/node@20.5.0)(terser@5.16.9))
       vitest:
         specifier: ^2.1.3
         version: 2.1.3(@types/node@20.5.0)(jsdom@22.1.0)(terser@5.16.9)
@@ -7153,7 +7174,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.5.0
+      '@types/node': 18.19.59
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -7357,7 +7378,7 @@ snapshots:
 
   '@playwright/test@1.37.0':
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.19.59
       playwright-core: 1.37.0
     optionalDependencies:
       fsevents: 2.3.2
@@ -7965,7 +7986,7 @@ snapshots:
 
   '@types/readable-stream@4.0.16':
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.19.59
       safe-buffer: 5.1.2
 
   '@types/resolve@1.20.6': {}
@@ -7980,7 +8001,7 @@ snapshots:
 
   '@types/ws@8.5.12':
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.19.59
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -9438,7 +9459,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.5.0
+      '@types/node': 18.19.59
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -10775,7 +10796,9 @@ snapshots:
       normalize-path: 3.0.0
       plimit-lit: 1.6.1
 
-  tsconfck@3.1.4: {}
+  tsconfck@3.1.4(typescript@5.6.3):
+    optionalDependencies:
+      typescript: 5.6.3
 
   tslib@2.8.0: {}
 
@@ -10937,11 +10960,11 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@5.0.1(vite@5.4.9(@types/node@20.5.0)(terser@5.16.9)):
+  vite-tsconfig-paths@5.0.1(typescript@5.6.3)(vite@5.4.9(@types/node@20.5.0)(terser@5.16.9)):
     dependencies:
       debug: 4.3.7
       globrex: 0.1.2
-      tsconfck: 3.1.4
+      tsconfck: 3.1.4(typescript@5.6.3)
     optionalDependencies:
       vite: 5.4.9(@types/node@20.5.0)(terser@5.16.9)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@types/node':
-      specifier: 20.5.0
-      version: 20.5.0
+      specifier: 20.17.6
+      version: 20.17.6
     '@types/react':
       specifier: npm:types-react@19.0.0-rc.1
       version: 19.0.0-rc.1
@@ -77,7 +77,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 20.5.0
+        version: 20.17.6
       '@types/react':
         specifier: 'catalog:'
         version: types-react@19.0.0-rc.1
@@ -92,7 +92,7 @@ importers:
         version: 8.4.27
       tailwindcss:
         specifier: 'catalog:'
-        version: 3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3))
+        version: 3.3.3(ts-node@10.9.1(@types/node@20.17.6)(typescript@5.6.3))
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
@@ -117,7 +117,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 20.5.0
+        version: 20.17.6
       '@types/react':
         specifier: 'catalog:'
         version: types-react@19.0.0-rc.1
@@ -132,7 +132,7 @@ importers:
         version: 8.4.27
       tailwindcss:
         specifier: 'catalog:'
-        version: 3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3))
+        version: 3.3.3(ts-node@10.9.1(@types/node@20.17.6)(typescript@5.6.3))
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
@@ -154,7 +154,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 20.5.0
+        version: 20.17.6
       '@types/react':
         specifier: 'catalog:'
         version: types-react@19.0.0-rc.1
@@ -169,7 +169,7 @@ importers:
         version: 8.4.27
       tailwindcss:
         specifier: 'catalog:'
-        version: 3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3))
+        version: 3.3.3(ts-node@10.9.1(@types/node@20.17.6)(typescript@5.6.3))
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
@@ -252,7 +252,7 @@ importers:
         version: 8.10.145
       '@types/node':
         specifier: 'catalog:'
-        version: 20.5.0
+        version: 20.17.6
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.10
@@ -270,7 +270,7 @@ importers:
         version: 2.0.0
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@20.5.0)(typescript@5.6.3)
+        version: 10.9.1(@types/node@20.17.6)(typescript@5.6.3)
 
   packages/tests-unit:
     dependencies:
@@ -283,28 +283,28 @@ importers:
         version: 5.14.9
       '@vitest/coverage-v8':
         specifier: ^2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.5.0)(jsdom@22.1.0)(terser@5.16.9))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.6)(jsdom@22.1.0)(terser@5.16.9))
       jsdom:
         specifier: ^22.1.0
         version: 22.1.0
       vite:
         specifier: 5.4.9
-        version: 5.4.9(@types/node@20.5.0)(terser@5.16.9)
+        version: 5.4.9(@types/node@20.17.6)(terser@5.16.9)
       vite-tsconfig-paths:
         specifier: ^5.0.1
-        version: 5.0.1(typescript@5.6.3)(vite@5.4.9(@types/node@20.5.0)(terser@5.16.9))
+        version: 5.0.1(typescript@5.6.3)(vite@5.4.9(@types/node@20.17.6)(terser@5.16.9))
       vitest:
         specifier: ^2.1.3
-        version: 2.1.3(@types/node@20.5.0)(jsdom@22.1.0)(terser@5.16.9)
+        version: 2.1.3(@types/node@20.17.6)(jsdom@22.1.0)(terser@5.16.9)
 
   packages/utils:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 20.5.0
+        version: 20.17.6
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3))(typescript@5.6.3)
+        version: 7.2.0(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.17.6)(typescript@5.6.3))(typescript@5.6.3)
 
 packages:
 
@@ -2207,6 +2207,9 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@20.17.6':
+    resolution: {integrity: sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==}
 
   '@types/node@20.5.0':
     resolution: {integrity: sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==}
@@ -4792,6 +4795,9 @@ packages:
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
@@ -7972,6 +7978,10 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@20.17.6':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/node@20.5.0': {}
 
   '@types/prop-types@15.7.13': {}
@@ -8006,7 +8016,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@vitest/coverage-v8@2.1.3(vitest@2.1.3(@types/node@20.5.0)(jsdom@22.1.0)(terser@5.16.9))':
+  '@vitest/coverage-v8@2.1.3(vitest@2.1.3(@types/node@20.17.6)(jsdom@22.1.0)(terser@5.16.9))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -8020,7 +8030,7 @@ snapshots:
       std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.3(@types/node@20.5.0)(jsdom@22.1.0)(terser@5.16.9)
+      vitest: 2.1.3(@types/node@20.17.6)(jsdom@22.1.0)(terser@5.16.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -8031,13 +8041,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@20.5.0)(terser@5.16.9))':
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@20.17.6)(terser@5.16.9))':
     dependencies:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
-      vite: 5.4.9(@types/node@20.5.0)(terser@5.16.9)
+      vite: 5.4.9(@types/node@20.17.6)(terser@5.16.9)
 
   '@vitest/pretty-format@2.1.3':
     dependencies:
@@ -10010,13 +10020,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.47
 
-  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3)):
+  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.17.6)(typescript@5.6.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.6.0
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.1(@types/node@20.5.0)(typescript@5.6.3)
+      ts-node: 10.9.1(@types/node@20.17.6)(typescript@5.6.3)
 
   postcss-nested@6.2.0(postcss@8.4.47):
     dependencies:
@@ -10633,7 +10643,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  tailwindcss@3.3.3(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3)):
+  tailwindcss@3.3.3(ts-node@10.9.1(@types/node@20.17.6)(typescript@5.6.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -10652,7 +10662,7 @@ snapshots:
       postcss: 8.4.47
       postcss-import: 15.1.0(postcss@8.4.47)
       postcss-js: 4.0.1(postcss@8.4.47)
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.17.6)(typescript@5.6.3))
       postcss-nested: 6.2.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -10739,14 +10749,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3):
+  ts-node@10.9.1(@types/node@20.17.6)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.5.0
+      '@types/node': 20.17.6
       acorn: 8.13.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -10772,7 +10782,7 @@ snapshots:
 
   tslib@2.8.0: {}
 
-  tsup@7.2.0(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3))(typescript@5.6.3):
+  tsup@7.2.0(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.17.6)(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.18.20)
       cac: 6.7.14
@@ -10782,7 +10792,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.5.0)(typescript@5.6.3))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.1(@types/node@20.17.6)(typescript@5.6.3))
       resolve-from: 5.0.0
       rollup: 3.29.5
       source-map: 0.8.0-beta.0
@@ -10844,6 +10854,8 @@ snapshots:
   typescript@5.6.3: {}
 
   ufo@1.5.4: {}
+
+  undici-types@6.19.8: {}
 
   undici@5.28.4:
     dependencies:
@@ -10909,12 +10921,12 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@2.1.3(@types/node@20.5.0)(terser@5.16.9):
+  vite-node@2.1.3(@types/node@20.17.6)(terser@5.16.9):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
       pathe: 1.1.2
-      vite: 5.4.9(@types/node@20.5.0)(terser@5.16.9)
+      vite: 5.4.9(@types/node@20.17.6)(terser@5.16.9)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10926,31 +10938,31 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@5.0.1(typescript@5.6.3)(vite@5.4.9(@types/node@20.5.0)(terser@5.16.9)):
+  vite-tsconfig-paths@5.0.1(typescript@5.6.3)(vite@5.4.9(@types/node@20.17.6)(terser@5.16.9)):
     dependencies:
       debug: 4.3.7
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.6.3)
     optionalDependencies:
-      vite: 5.4.9(@types/node@20.5.0)(terser@5.16.9)
+      vite: 5.4.9(@types/node@20.17.6)(terser@5.16.9)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.4.9(@types/node@20.5.0)(terser@5.16.9):
+  vite@5.4.9(@types/node@20.17.6)(terser@5.16.9):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.24.0
     optionalDependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.17.6
       fsevents: 2.3.3
       terser: 5.16.9
 
-  vitest@2.1.3(@types/node@20.5.0)(jsdom@22.1.0)(terser@5.16.9):
+  vitest@2.1.3(@types/node@20.17.6)(jsdom@22.1.0)(terser@5.16.9):
     dependencies:
       '@vitest/expect': 2.1.3
-      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@20.5.0)(terser@5.16.9))
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@20.17.6)(terser@5.16.9))
       '@vitest/pretty-format': 2.1.3
       '@vitest/runner': 2.1.3
       '@vitest/snapshot': 2.1.3
@@ -10965,11 +10977,11 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.9(@types/node@20.5.0)(terser@5.16.9)
-      vite-node: 2.1.3(@types/node@20.5.0)(terser@5.16.9)
+      vite: 5.4.9(@types/node@20.17.6)(terser@5.16.9)
+      vite-node: 2.1.3(@types/node@20.17.6)(terser@5.16.9)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.17.6
       jsdom: 22.1.0
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,8 +251,8 @@ importers:
         specifier: ^8.10.109
         version: 8.10.145
       '@types/node':
-        specifier: ^18.16.1
-        version: 18.19.59
+        specifier: 20.5.0
+        version: 20.5.0
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.10
@@ -2207,9 +2207,6 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
-  '@types/node@18.19.59':
-    resolution: {integrity: sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==}
 
   '@types/node@20.5.0':
     resolution: {integrity: sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==}
@@ -4796,9 +4793,6 @@ packages:
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
@@ -7181,7 +7175,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.59
+      '@types/node': 20.5.0
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -7385,7 +7379,7 @@ snapshots:
 
   '@playwright/test@1.37.0':
     dependencies:
-      '@types/node': 18.19.59
+      '@types/node': 20.5.0
       playwright-core: 1.37.0
     optionalDependencies:
       fsevents: 2.3.2
@@ -7978,10 +7972,6 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@18.19.59':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@20.5.0': {}
 
   '@types/prop-types@15.7.13': {}
@@ -7993,7 +7983,7 @@ snapshots:
 
   '@types/readable-stream@4.0.16':
     dependencies:
-      '@types/node': 18.19.59
+      '@types/node': 20.5.0
       safe-buffer: 5.1.2
 
   '@types/resolve@1.20.6': {}
@@ -8008,7 +7998,7 @@ snapshots:
 
   '@types/ws@8.5.12':
     dependencies:
-      '@types/node': 18.19.59
+      '@types/node': 20.5.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -9466,7 +9456,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.59
+      '@types/node': 20.5.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -10854,8 +10844,6 @@ snapshots:
   typescript@5.6.3: {}
 
   ufo@1.5.4: {}
-
-  undici-types@5.26.5: {}
 
   undici@5.28.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,7 @@ catalog:
   "@types/node": 20.5.0
   "@types/react": npm:types-react@19.0.0-rc.1
   "@types/react-dom": npm:types-react-dom@19.0.0-rc.1
+  autoprefixer: 10.4.15
+  postcss: 8.4.27
+  tailwindcss: 3.3.3
+  typescript: 5.6.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
 packages:
   - "examples/*"
   - "packages/*"
+
+catalog:
+  next: 15.0.1
+  react: 19.0.0-rc-69d4b800-20241021
+  react-dom: 19.0.0-rc-69d4b800-20241021
+  "@types/node": 20.5.0
+  "@types/react": npm:types-react@19.0.0-rc.1
+  "@types/react-dom": npm:types-react-dom@19.0.0-rc.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ catalog:
   next: 15.0.1
   react: 19.0.0-rc-69d4b800-20241021
   react-dom: 19.0.0-rc-69d4b800-20241021
-  "@types/node": 20.5.0
+  "@types/node": 20.17.6
   "@types/react": npm:types-react@19.0.0-rc.1
   "@types/react-dom": npm:types-react-dom@19.0.0-rc.1
   autoprefixer: 10.4.15


### PR DESCRIPTION
This PR will add [pnpm catalog](https://pnpm.io/catalogs) for deps that is reused through the repo. Making it easier to maintain. I will open this in draft mode so we can continue working on it. The alternative was using something like [syncpack](https://jamiemason.github.io/syncpack/guide/getting-started/), but that would add another dep so I decided to go with pnpm catalogs instead.

Any suggestions on what more we could add? I have considered using catalog for the other shared deps in `examples/*`, like f.ex `tailwindcss`/`typescript` or `postcss`. Not sure if we want that, and also should we consider using a caret or tilde in any of the catalog versions? 

Btw, I have tested building and deploying the examples apps with this PR, and it works as it should.