### PR TITLE
Remove package.json from biome format

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -5,7 +5,11 @@
     "ignoreUnknown": true
   },
   "organizeImports": { "enabled": true },
-  "formatter": { "enabled": true, "indentStyle": "space" },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "ignore": ["**/package.json"]
+  },
   "css": { "formatter": { "quoteStyle": "single" } },
   "linter": {
     "enabled": true,


### PR DESCRIPTION
Fix #639
I don't think there is a way to force the changeset bot to follow a specific format. Easiest fix is just to disable biome format for `package.json`