### PR TITLE
refactor(cloudflare): rename the "cloudflare" wrapper to "cloudflare-edge"

### DIFF
--- a/.changeset/green-news-give.md
+++ b/.changeset/green-news-give.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+refactor(cloudflare): rename the "cloudflare" wrapper to "cloudflare-edge"

--- a/packages/open-next/src/build/createMiddleware.ts
+++ b/packages/open-next/src/build/createMiddleware.ts
@@ -44,7 +44,7 @@ export async function createMiddleware(
     buildHelper.copyOpenNextConfig(
       options.buildDir,
       outputPath,
-      config.middleware.override?.wrapper === "cloudflare",
+      await buildHelper.isEdgeRuntime(config.middleware.override),
     );
 
     // Bundle middleware

--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -18,7 +18,7 @@ import logger from "../../logger.js";
 import { openNextEdgePlugins } from "../../plugins/edge.js";
 import { openNextReplacementPlugin } from "../../plugins/replacement.js";
 import { openNextResolvePlugin } from "../../plugins/resolve.js";
-import type { BuildOptions } from "../helper.js";
+import { type BuildOptions, isEdgeRuntime } from "../helper.js";
 import { copyOpenNextConfig, esbuildAsync } from "../helper.js";
 
 interface BuildEdgeBundleOptions {
@@ -52,10 +52,7 @@ export async function buildEdgeBundle({
   onlyBuildOnce,
   name,
 }: BuildEdgeBundleOptions) {
-  const isInCloudfare =
-    typeof overrides?.wrapper === "string"
-      ? overrides.wrapper === "cloudflare"
-      : (await overrides?.wrapper?.())?.edgeRuntime;
+  const isInCloudfare = await isEdgeRuntime(overrides);
   await esbuildAsync(
     {
       entryPoints: [entrypoint],

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -5,7 +5,10 @@ import url from "node:url";
 
 import type { BuildOptions as ESBuildOptions } from "esbuild";
 import { build as buildAsync, buildSync } from "esbuild";
-import type { OpenNextConfig } from "types/open-next.js";
+import type {
+  DefaultOverrideOptions,
+  OpenNextConfig,
+} from "types/open-next.js";
 
 import logger from "../logger.js";
 
@@ -355,4 +358,19 @@ export function initOutputDir(options: BuildOptions) {
   const { buildDir } = options;
   fs.mkdirSync(buildDir, { recursive: true });
   fs.cpSync(options.tempBuildDir, buildDir, { recursive: true });
+}
+
+/**
+ * @returns Whether the edge runtime is used
+ */
+export async function isEdgeRuntime(
+  overrides: DefaultOverrideOptions | undefined,
+) {
+  if (!overrides?.wrapper) {
+    return false;
+  }
+  if (typeof overrides.wrapper === "string") {
+    return overrides.wrapper.startsWith("cloudflare");
+  }
+  return (await overrides?.wrapper?.())?.edgeRuntime;
 }

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -370,7 +370,7 @@ export async function isEdgeRuntime(
     return false;
   }
   if (typeof overrides.wrapper === "string") {
-    return overrides.wrapper.startsWith("cloudflare");
+    return ["cloudflare-edge", "cloudflare"].includes(overrides.wrapper);
   }
   return (await overrides?.wrapper?.())?.edgeRuntime;
 }

--- a/packages/open-next/src/build/validateConfig.ts
+++ b/packages/open-next/src/build/validateConfig.ts
@@ -17,7 +17,8 @@ const compatibilityMatrix: Record<IncludedWrapper, IncludedConverter[]> = {
   ],
   "aws-lambda-streaming": ["aws-apigw-v2"],
   cloudflare: ["edge"],
-  "cloudflare-streaming": ["edge"],
+  "cloudflare-edge": ["edge"],
+  "cloudflare-node": ["edge"],
   node: ["node"],
   dummy: [],
 };

--- a/packages/open-next/src/helpers/withCloudflare.ts
+++ b/packages/open-next/src/helpers/withCloudflare.ts
@@ -94,7 +94,7 @@ export function withCloudflare<
               routes: [fn.routes],
               patterns: [fn.patterns],
               override: {
-                wrapper: "cloudflare",
+                wrapper: "cloudflare-edge",
                 converter: "edge",
               },
             }
@@ -110,7 +110,7 @@ export function withCloudflare<
       external: true,
       originResolver: "pattern-env",
       override: {
-        wrapper: "cloudflare",
+        wrapper: "cloudflare-edge",
         converter: "edge",
       },
     },

--- a/packages/open-next/src/overrides/wrappers/cloudflare-edge.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare-edge.ts
@@ -62,7 +62,7 @@ const handler: WrapperHandler<
 
 export default {
   wrapper: handler,
-  name: "cloudflare",
+  name: "cloudflare-edge",
   supportStreaming: true,
   edgeRuntime: true,
 } satisfies Wrapper<InternalEvent, InternalResult | MiddlewareOutputEvent>;

--- a/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
@@ -67,6 +67,6 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
 
 export default {
   wrapper: handler,
-  name: "cloudflare-streaming",
+  name: "cloudflare-node",
   supportStreaming: true,
 } satisfies Wrapper;

--- a/packages/open-next/src/plugins/resolve.ts
+++ b/packages/open-next/src/plugins/resolve.ts
@@ -84,14 +84,19 @@ export function openNextResolvePlugin({
       build.onLoad({ filter: /core(\/|\\)resolve\.js/g }, async (args) => {
         let contents = readFileSync(args.path, "utf-8");
         const overridesEntries = Object.entries(overrides ?? {});
-        for (const [overrideName, overrideValue] of overridesEntries) {
+        for (let [overrideName, overrideValue] of overridesEntries) {
           if (!overrideValue) {
             continue;
+          }
+          if (overrideName === "wrapper" && overrideValue === "cloudflare") {
+            // "cloudflare" is deprecated and replaced by "cloudflare-edge".
+            overrideValue = "cloudflare-edge";
           }
           const folder =
             nameToFolder[overrideName as keyof typeof nameToFolder];
           const defaultOverride =
             defaultOverrides[overrideName as keyof typeof defaultOverrides];
+
           contents = contents.replace(
             `../overrides/${folder}/${defaultOverride}.js`,
             `../overrides/${folder}/${getOverrideOrDummy(overrideValue)}.js`,

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -80,8 +80,10 @@ export type IncludedWrapper =
   | "aws-lambda"
   | "aws-lambda-streaming"
   | "node"
+  // @deprecated - use "cloudflare-edge" instead.
   | "cloudflare"
-  | "cloudflare-streaming"
+  | "cloudflare-edge"
+  | "cloudflare-node"
   | "dummy";
 
 export type IncludedConverter =


### PR DESCRIPTION
The commit message do not mention "cloudflare-streaming" -> "cloudflare-node" as this was never released officially.