### PR TITLE
fix: type of the edge converter

### DIFF
--- a/packages/open-next/src/overrides/converters/edge.ts
+++ b/packages/open-next/src/overrides/converters/edge.ts
@@ -13,7 +13,7 @@ declare global {
 
 const converter: Converter<
   InternalEvent,
-  InternalResult | ({ type: "middleware" } & MiddlewareOutputEvent)
+  InternalResult | MiddlewareOutputEvent
 > = {
   convertFrom: async (event: Request) => {
     const url = new URL(event.url);


### PR DESCRIPTION
I had missed the edge converter in https://github.com/opennextjs/opennextjs-aws/pull/644