### PR TITLE
feat(build): add BuildOptions#minify to enable code minification

### DIFF
--- a/packages/open-next/src/build/bundleNextServer.ts
+++ b/packages/open-next/src/build/bundleNextServer.ts
@@ -45,7 +45,7 @@ const externals = [
 export async function bundleNextServer(
   outputDir: string,
   appPath: string,
-  { debug = false },
+  { minify = true },
 ) {
   const require = createRequire(`${appPath}/package.json`);
   const entrypoint = require.resolve("next/dist/esm/server/next-server.js");
@@ -58,7 +58,7 @@ export async function bundleNextServer(
     // packages: "external",
     format: "cjs",
     external: externals,
-    minify: !debug,
+    minify,
     outfile: path.join(outputDir, "next-server.runtime.prod.js"),
     sourcemap: false,
     plugins: [

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -134,7 +134,7 @@ async function generateBundle(
   const isBundled = fnOptions.experimentalBundledNextServer ?? false;
   if (isBundled) {
     await bundleNextServer(path.join(outputPath, packagePath), appPath, {
-      debug: options.debug,
+      minify: options.minify,
     });
   }
 

--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -160,7 +160,7 @@ globalThis.AsyncLocalStorage = AsyncLocalStorage;
       outfile,
       allowOverwrite: true,
       bundle: true,
-      minify: !options.debug,
+      minify: options.minify,
       platform: "node",
       format: "esm",
       conditions: ["workerd", "worker", "browser"],

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -43,6 +43,8 @@ export function normalizeOptions(
     appPackageJsonPath = findNextPackageJsonPath(appPath, monorepoRoot);
   }
 
+  const debug = Boolean(process.env.OPEN_NEXT_DEBUG) ?? false;
+
   return {
     appBuildOutputPath: buildOutputPath,
     appPackageJsonPath,
@@ -50,7 +52,9 @@ export function normalizeOptions(
     appPublicPath: path.join(appPath, "public"),
     buildDir: path.join(outputDir, ".build"),
     config,
-    debug: Boolean(process.env.OPEN_NEXT_DEBUG) ?? false,
+    debug,
+    // Whether ESBuild should minify the code
+    minify: !debug,
     monorepoRoot,
     nextVersion: getNextVersion(appPath),
     openNextVersion: getOpenNextVersion(),
@@ -98,13 +102,13 @@ export function esbuildSync(
   esbuildOptions: ESBuildOptions,
   options: BuildOptions,
 ) {
-  const { openNextVersion, debug } = options;
+  const { openNextVersion, debug, minify } = options;
   const result = buildSync({
     target: "esnext",
     format: "esm",
     platform: "node",
     bundle: true,
-    minify: !debug,
+    minify,
     mainFields: ["module", "main"],
     sourcemap: debug ? "inline" : false,
     sourcesContent: false,
@@ -134,13 +138,13 @@ export async function esbuildAsync(
   esbuildOptions: ESBuildOptions,
   options: BuildOptions,
 ) {
-  const { openNextVersion, debug } = options;
+  const { openNextVersion, debug, minify } = options;
   const result = await buildAsync({
     target: "esnext",
     format: "esm",
     platform: "node",
     bundle: true,
-    minify: !debug,
+    minify,
     mainFields: ["module", "main"],
     sourcemap: debug ? "inline" : false,
     sourcesContent: false,


### PR DESCRIPTION
Default to !BuildOptions#debug

This will be useful for cloudflare as we don't want to minify the code to be able to apply string replace patches (see [this issue](https://github.com/opennextjs/opennextjs-cloudflare/issues/143))

With this change, we can decide not to minify the code whether or not debug is enabled (by overriding the BuildOptions).

Notes:
- `wrangler` will ultimately minify the code anyway
- we plan to migrate the patches to AST transforms to not depend on whether or not the code is minified