### PR TITLE
fix(cloudflare): fix the node wrapper

### DIFF
--- a/.changeset/big-terms-boil.md
+++ b/.changeset/big-terms-boil.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": minor
+---
+
+refactor: move StreamCreator to types/open-next

--- a/.changeset/giant-parrots-hear.md
+++ b/.changeset/giant-parrots-hear.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(cloudflare): fix the node wrapper

--- a/packages/open-next/src/adapters/image-optimization-adapter.ts
+++ b/packages/open-next/src/adapters/image-optimization-adapter.ts
@@ -9,7 +9,6 @@ import path from "node:path";
 import type { Writable } from "node:stream";
 
 import { loadBuildId, loadConfig } from "config/util.js";
-import type { StreamCreator } from "http/openNextResponse.js";
 import { OpenNextNodeResponse } from "http/openNextResponse.js";
 // @ts-ignore
 import { defaultConfig } from "next/dist/server/config-shared";
@@ -19,7 +18,11 @@ import {
 } from "next/dist/server/image-optimizer";
 // @ts-ignore
 import type { NextUrlWithParsedQuery } from "next/dist/server/request-meta";
-import type { InternalEvent, InternalResult } from "types/open-next.js";
+import type {
+  InternalEvent,
+  InternalResult,
+  StreamCreator,
+} from "types/open-next.js";
 import { emptyReadableStream, toReadableStream } from "utils/stream.js";
 
 import { createGenericHandler } from "../core/createGenericHandler.js";

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -1,11 +1,12 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
-import type { OpenNextNodeResponse, StreamCreator } from "http/index.js";
+import type { OpenNextNodeResponse } from "http/index.js";
 import { IncomingMessage } from "http/index.js";
 import type {
   InternalEvent,
   InternalResult,
   RoutingResult,
+  StreamCreator,
 } from "types/open-next";
 import { runWithOpenNextRequestContext } from "utils/promise";
 

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -3,11 +3,15 @@ import type { OutgoingHttpHeaders } from "node:http";
 import { Readable } from "node:stream";
 
 import { BuildId, HtmlPages, NextConfig } from "config/index.js";
-import type { IncomingMessage, StreamCreator } from "http/index.js";
+import type { IncomingMessage } from "http/index.js";
 import { OpenNextNodeResponse } from "http/openNextResponse.js";
 import { parseHeaders } from "http/util.js";
 import type { MiddlewareManifest } from "types/next-types";
-import type { InternalEvent, InternalResult } from "types/open-next.js";
+import type {
+  InternalEvent,
+  InternalResult,
+  StreamCreator,
+} from "types/open-next.js";
 
 import { debug, error } from "../../adapters/logger.js";
 import { isBinaryContentType } from "../../utils/binary.js";

--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -82,7 +82,9 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
   }
 
   get finished() {
-    return this.writableFinished && (this.responseStream?.writableFinished ?? true);
+    return this.responseStream
+      ? this.responseStream?.writableFinished
+      : this.writableFinished;
   }
 
   setHeader(name: string, value: string | string[]): this {

--- a/packages/open-next/src/overrides/wrappers/aws-lambda-streaming.ts
+++ b/packages/open-next/src/overrides/wrappers/aws-lambda-streaming.ts
@@ -2,9 +2,9 @@ import { Readable, type Writable } from "node:stream";
 import zlib from "node:zlib";
 
 import type { APIGatewayProxyEventV2 } from "aws-lambda";
-import type { StreamCreator } from "http/index";
 import type { Wrapper, WrapperHandler } from "types/overrides";
 
+import type { StreamCreator } from "types/open-next";
 import { debug, error } from "../../adapters/logger";
 import type {
   WarmerEvent,
@@ -92,10 +92,6 @@ const handler: WrapperHandler = async (handler, converter) =>
 
           return compressedStream ?? responseStream;
         },
-        onWrite: () => {
-          // _hasWriten = true;
-        },
-        onFinish: () => {},
       };
 
       const response = await handler(internalEvent, streamCreator);

--- a/packages/open-next/src/overrides/wrappers/aws-lambda.ts
+++ b/packages/open-next/src/overrides/wrappers/aws-lambda.ts
@@ -8,9 +8,9 @@ import type {
   CloudFrontRequestEvent,
   CloudFrontRequestResult,
 } from "aws-lambda";
-import type { StreamCreator } from "http/openNextResponse";
 import type { WrapperHandler } from "types/overrides";
 
+import type { StreamCreator } from "types/open-next";
 import type {
   WarmerEvent,
   WarmerResponse,
@@ -58,9 +58,6 @@ const handler: WrapperHandler =
             callback();
           },
         });
-      },
-      onFinish: () => {
-        // Do nothing
       },
     };
 

--- a/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
@@ -1,8 +1,11 @@
-import type { InternalEvent, InternalResult } from "types/open-next";
+import type {
+  InternalEvent,
+  InternalResult,
+  StreamCreator,
+} from "types/open-next";
 import type { Wrapper, WrapperHandler } from "types/overrides";
 
 import { Writable } from "node:stream";
-import type { StreamCreator } from "http/index";
 
 const handler: WrapperHandler<InternalEvent, InternalResult> =
   async (handler, converter) =>
@@ -56,8 +59,6 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
 
         return Writable.fromWeb(writable);
       },
-      onWrite: () => {},
-      onFinish: (_length: number) => {},
     };
 
     ctx.waitUntil(handler(internalEvent, streamCreator));

--- a/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
@@ -50,7 +50,11 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
           responseHeaders.append("Set-Cookie", cookie);
         }
 
-        const { readable, writable } = new TransformStream();
+        const { readable, writable } = new TransformStream({
+          transform(chunk, controller) {
+            controller.enqueue(Uint8Array.from(chunk.chunk ?? chunk));
+          },
+        });
         const response = new Response(readable, {
           status: statusCode,
           headers: responseHeaders,

--- a/packages/open-next/src/overrides/wrappers/node.ts
+++ b/packages/open-next/src/overrides/wrappers/node.ts
@@ -1,8 +1,8 @@
 import { createServer } from "node:http";
 
-import type { StreamCreator } from "http/index";
 import type { Wrapper, WrapperHandler } from "types/overrides";
 
+import type { StreamCreator } from "types/open-next";
 import { debug, error } from "../../adapters/logger";
 
 const wrapper: WrapperHandler = async (handler, converter) => {
@@ -15,9 +15,6 @@ const wrapper: WrapperHandler = async (handler, converter) => {
         res.flushHeaders();
         res.uncork();
         return res;
-      },
-      onFinish: () => {
-        // Is it necessary to do something here?
       },
     };
     if (internalEvent.rawPath === "/__health") {

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -1,5 +1,6 @@
 import type { ReadableStream } from "node:stream/web";
 
+import type { Writable } from "node:stream";
 import type { WarmerEvent, WarmerResponse } from "../adapters/warmer-function";
 import type {
   Converter,
@@ -34,6 +35,17 @@ export type InternalResult = {
   body: ReadableStream;
   isBase64Encoded: boolean;
 } & BaseEventOrResult<"core">;
+
+export interface StreamCreator {
+  writeHeaders(prelude: {
+    statusCode: number;
+    cookies: string[];
+    headers: Record<string, string>;
+  }): Writable;
+  // Just to fix an issue with aws lambda streaming with empty body
+  onWrite?: () => void;
+  onFinish?: (length: number) => void;
+}
 
 export interface DangerousOptions {
   /**

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -1,6 +1,5 @@
 import type { Readable } from "node:stream";
 
-import type { StreamCreator } from "http/index";
 import type { Meta } from "types/cache";
 
 import type {
@@ -9,6 +8,7 @@ import type {
   InternalEvent,
   InternalResult,
   Origin,
+  StreamCreator,
 } from "./open-next";
 
 // Queue


### PR DESCRIPTION
Returns the response converted from the internal event. 
It fixes a "This ReadableStream did not return bytes" workerd error.

Co-authored-by: conico974 <nicodorseuil@yahoo.fr>

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #664 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #663 
<!-- GitButler Footer Boundary Bottom -->

