### PR TITLE
fix: add audio/flac to commonBinaryMimeTypes

### DIFF
--- a/.changeset/light-shirts-press.md
+++ b/.changeset/light-shirts-press.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: add audio/flac to commonBinaryMimeTypes

--- a/packages/open-next/src/utils/binary.ts
+++ b/packages/open-next/src/utils/binary.ts
@@ -27,6 +27,7 @@ const commonBinaryMimeTypes = new Set([
   "audio/3gpp",
   "audio/aac",
   "audio/basic",
+  "audio/flac",
   "audio/mpeg",
   "audio/ogg",
   "audio/wavaudio/webm",

--- a/packages/tests-unit/tests/binary.test.ts
+++ b/packages/tests-unit/tests/binary.test.ts
@@ -39,6 +39,7 @@ describe("isBinaryContentType", () => {
     { type: "audio/3gpp", binary: true },
     { type: "audio/aac", binary: true },
     { type: "audio/basic", binary: true },
+    { type: "audio/flac", binary: true },
     { type: "audio/mpeg", binary: true },
     { type: "audio/ogg", binary: true },
     { type: "audio/wavaudio/webm", binary: true },


### PR DESCRIPTION
This commit adds `audio/flac` to the `commonBinaryMimeTypes` Set.

Mozilla lists `audio/flac` as a valid media container format in their documentation: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#flac

For my part, I was creating a route handler in my Next.js app (built with SST and opennextjs-aws) that was returning an FLAC file passed through from an S3 bucket. The file is supposed to be played in the client using an Web Audio AudioContext. 

I was mystified why the file size was different than expected when it was returned to the client to be played, and after digging around found that the `isBase64Encoded` response parameter was likely being set to true in `open-next/src/core/routing/utils.ts`.  I've temporarily set my `Content-Type` to `application/octet-stream` to fix the issue, but it's not a perfect solution (since the client can't then tell the "file" from my API route endpoint is actually a FLAC file.)

Anyway, I expect audio/flac shouldn't be a terribly controversial addition, and would also love to get rid of my workaround for my users.  Thanks!