### PR TITLE
fix(aws): add missing base path to data routes

### DIFF
--- a/.changeset/thirty-grapes-punch.md
+++ b/.changeset/thirty-grapes-punch.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(aws): add missing base path to data routes

--- a/packages/open-next/src/core/routing/matcher.ts
+++ b/packages/open-next/src/core/routing/matcher.ts
@@ -336,7 +336,8 @@ export function fixDataPage(
   buildId: string,
 ): InternalEvent | InternalResult {
   const { rawPath, query } = internalEvent;
-  const dataPattern = `/_next/data/${buildId}`;
+  const dataPattern = `${NextConfig.basePath ?? ""}/_next/data/${buildId}`;
+
   // Return 404 for data requests that don't match the buildId
   if (rawPath.startsWith("/_next/data") && !rawPath.startsWith(dataPattern)) {
     return {

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -501,8 +501,6 @@ describe("fixDataPage", () => {
 
     expect(response.statusCode).not.toEqual(404);
     expect(response).toEqual(event);
-
-    NextConfig.basePath = undefined;
   });
 
   it("should remove json extension from data requests and add __nextDataReq to query", () => {
@@ -533,7 +531,5 @@ describe("fixDataPage", () => {
       rawPath: "/test/file",
       url: "/test/file?hello=world&__nextDataReq=1",
     });
-
-    NextConfig.basePath = undefined;
   });
 });

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -491,7 +491,7 @@ describe("fixDataPage", () => {
   });
 
   it("should not return 404 for data requests (with base path) that don't match the buildId", () => {
-    NextConfig.basePath = '/base';
+    NextConfig.basePath = "/base";
 
     const event = createEvent({
       url: "/base/_next/data/abc/test",
@@ -520,7 +520,7 @@ describe("fixDataPage", () => {
   });
 
   it("should remove json extension from data requests (with base path) and add __nextDataReq to query", () => {
-    NextConfig.basePath = '/base';
+    NextConfig.basePath = "/base";
 
     const event = createEvent({
       url: "/base/_next/data/abc/test/file.json?hello=world",

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -490,6 +490,21 @@ describe("fixDataPage", () => {
     expect(response).toEqual(event);
   });
 
+  it("should not return 404 for data requests (with base path) that don't match the buildId", () => {
+    NextConfig.basePath = '/base';
+
+    const event = createEvent({
+      url: "/base/_next/data/abc/test",
+    });
+
+    const response = fixDataPage(event, "abc");
+
+    expect(response.statusCode).not.toEqual(404);
+    expect(response).toEqual(event);
+
+    NextConfig.basePath = undefined;
+  });
+
   it("should remove json extension from data requests and add __nextDataReq to query", () => {
     const event = createEvent({
       url: "/_next/data/abc/test/file.json?hello=world",
@@ -502,5 +517,23 @@ describe("fixDataPage", () => {
       rawPath: "/test/file",
       url: "/test/file?hello=world&__nextDataReq=1",
     });
+  });
+
+  it("should remove json extension from data requests (with base path) and add __nextDataReq to query", () => {
+    NextConfig.basePath = '/base';
+
+    const event = createEvent({
+      url: "/base/_next/data/abc/test/file.json?hello=world",
+    });
+
+    const response = fixDataPage(event, "abc");
+
+    expect(response).toEqual({
+      ...event,
+      rawPath: "/test/file",
+      url: "/test/file?hello=world&__nextDataReq=1",
+    });
+
+    NextConfig.basePath = undefined;
   });
 });

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -491,7 +491,7 @@ describe("fixDataPage", () => {
   });
 
   it("should not return 404 for data requests (with base path) that don't match the buildId", () => {
-    NextConfig.basePath = '/base';
+    NextConfig.basePath = "/base";
 
     const event = createEvent({
       url: "/base/_next/data/abc/test",
@@ -518,7 +518,7 @@ describe("fixDataPage", () => {
   });
 
   it("should remove json extension from data requests (with base path) and add __nextDataReq to query", () => {
-    NextConfig.basePath = '/base';
+    NextConfig.basePath = "/base";
 
     const event = createEvent({
       url: "/base/_next/data/abc/test/file.json?hello=world",

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -491,7 +491,7 @@ describe("fixDataPage", () => {
   });
 
   it("should not return 404 for data requests (with base path) that don't match the buildId", () => {
-    NextConfig.basePath = "/base";
+    NextConfig.basePath = '/base';
 
     const event = createEvent({
       url: "/base/_next/data/abc/test",
@@ -501,6 +501,8 @@ describe("fixDataPage", () => {
 
     expect(response.statusCode).not.toEqual(404);
     expect(response).toEqual(event);
+
+    NextConfig.basePath = undefined;
   });
 
   it("should remove json extension from data requests and add __nextDataReq to query", () => {
@@ -518,7 +520,7 @@ describe("fixDataPage", () => {
   });
 
   it("should remove json extension from data requests (with base path) and add __nextDataReq to query", () => {
-    NextConfig.basePath = "/base";
+    NextConfig.basePath = '/base';
 
     const event = createEvent({
       url: "/base/_next/data/abc/test/file.json?hello=world",
@@ -531,5 +533,7 @@ describe("fixDataPage", () => {
       rawPath: "/test/file",
       url: "/test/file?hello=world&__nextDataReq=1",
     });
+
+    NextConfig.basePath = undefined;
   });
 });


### PR DESCRIPTION
Related https://github.com/opennextjs/opennextjs-aws/issues/670

I was trying to figure out how to add (and run) a unit test in `matcher.test.ts` but then I saw [this issue](https://github.com/opennextjs/opennextjs-aws/issues/539) that mentions all unit tests are broken (?).

If e2e test(s) are required I'd appreciate any help as I'm not very familiar. And let me know if you need something else.

Thanks!