### PR TITLE
add additional metadata to RoutingResult

### DIFF
--- a/.changeset/spotty-chairs-pretend.md
+++ b/.changeset/spotty-chairs-pretend.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Add additional metadata to RoutingResult

--- a/.changeset/spotty-chairs-pretend.md
+++ b/.changeset/spotty-chairs-pretend.md
@@ -3,3 +3,6 @@
 ---
 
 Add additional metadata to RoutingResult
+
+For some future features [#658](https://github.com/opennextjs/opennextjs-aws/issues/658) (and bug fix [#677](https://github.com/opennextjs/opennextjs-aws/issues/677)) we need to add some additional metadata to the RoutingResult. 
+This PR adds 2 new fields to the RoutingResult: `initialPath` and `resolvedRoutes`

--- a/packages/open-next/src/adapters/config/index.ts
+++ b/packages/open-next/src/adapters/config/index.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 
 import { debug } from "../logger";
 import {
+  loadAppPathsManifest,
   loadAppPathsManifestKeys,
   loadBuildId,
   loadConfig,
@@ -9,7 +10,6 @@ import {
   loadHtmlPages,
   loadMiddlewareManifest,
   loadPrerenderManifest,
-  // loadPublicAssets,
   loadRoutesManifest,
 } from "./util.js";
 
@@ -31,3 +31,4 @@ export const AppPathsManifestKeys =
   /* @__PURE__ */ loadAppPathsManifestKeys(NEXT_DIR);
 export const MiddlewareManifest =
   /* @__PURE__ */ loadMiddlewareManifest(NEXT_DIR);
+export const AppPathsManifest = loadAppPathsManifest(NEXT_DIR);

--- a/packages/open-next/src/adapters/config/index.ts
+++ b/packages/open-next/src/adapters/config/index.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 
 import { debug } from "../logger";
 import {
+  loadAppPathRoutesManifest,
   loadAppPathsManifest,
   loadAppPathsManifestKeys,
   loadBuildId,
@@ -31,4 +32,6 @@ export const AppPathsManifestKeys =
   /* @__PURE__ */ loadAppPathsManifestKeys(NEXT_DIR);
 export const MiddlewareManifest =
   /* @__PURE__ */ loadMiddlewareManifest(NEXT_DIR);
-export const AppPathsManifest = loadAppPathsManifest(NEXT_DIR);
+export const AppPathsManifest = /* @__PURE__ */ loadAppPathsManifest(NEXT_DIR);
+export const AppPathRoutesManifest =
+  /* @__PURE__ */ loadAppPathRoutesManifest(NEXT_DIR);

--- a/packages/open-next/src/adapters/config/util.ts
+++ b/packages/open-next/src/adapters/config/util.ts
@@ -89,15 +89,17 @@ export function loadAppPathsManifest(nextDir: string) {
   return JSON.parse(appPathsManifestJson) as Record<string, string>;
 }
 
-export function loadAppPathRoutesManifest(nextDir: string) {
+export function loadAppPathRoutesManifest(
+  nextDir: string,
+): Record<string, string> {
   const appPathRoutesManifestPath = path.join(
     nextDir,
     "app-path-routes-manifest.json",
   );
-  const appPathRoutesManifestJson = fs.existsSync(appPathRoutesManifestPath)
-    ? fs.readFileSync(appPathRoutesManifestPath, "utf-8")
-    : "{}";
-  return JSON.parse(appPathRoutesManifestJson) as Record<string, string>;
+  if (fs.existsSync(appPathRoutesManifestPath)) {
+    return JSON.parse(fs.readFileSync(appPathRoutesManifestPath, "utf-8"));
+  }
+  return {};
 }
 
 export function loadAppPathsManifestKeys(nextDir: string) {

--- a/packages/open-next/src/adapters/config/util.ts
+++ b/packages/open-next/src/adapters/config/util.ts
@@ -89,6 +89,17 @@ export function loadAppPathsManifest(nextDir: string) {
   return JSON.parse(appPathsManifestJson) as Record<string, string>;
 }
 
+export function loadAppPathRoutesManifest(nextDir: string) {
+  const appPathRoutesManifestPath = path.join(
+    nextDir,
+    "app-path-routes-manifest.json",
+  );
+  const appPathRoutesManifestJson = fs.existsSync(appPathRoutesManifestPath)
+    ? fs.readFileSync(appPathRoutesManifestPath, "utf-8")
+    : "{}";
+  return JSON.parse(appPathRoutesManifestJson) as Record<string, string>;
+}
+
 export function loadAppPathsManifestKeys(nextDir: string) {
   const appPathsManifest = loadAppPathsManifest(nextDir);
   return Object.keys(appPathsManifest).map((key) => {

--- a/packages/open-next/src/adapters/config/util.ts
+++ b/packages/open-next/src/adapters/config/util.ts
@@ -77,7 +77,7 @@ export function loadPrerenderManifest(nextDir: string) {
   return JSON.parse(json) as PrerenderManifest;
 }
 
-export function loadAppPathsManifestKeys(nextDir: string) {
+export function loadAppPathsManifest(nextDir: string) {
   const appPathsManifestPath = path.join(
     nextDir,
     "server",
@@ -86,10 +86,11 @@ export function loadAppPathsManifestKeys(nextDir: string) {
   const appPathsManifestJson = fs.existsSync(appPathsManifestPath)
     ? fs.readFileSync(appPathsManifestPath, "utf-8")
     : "{}";
-  const appPathsManifest = JSON.parse(appPathsManifestJson) as Record<
-    string,
-    string
-  >;
+  return JSON.parse(appPathsManifestJson) as Record<string, string>;
+}
+
+export function loadAppPathsManifestKeys(nextDir: string) {
+  const appPathsManifest = loadAppPathsManifest(nextDir);
   return Object.keys(appPathsManifest).map((key) => {
     // Remove parallel route
     let cleanedKey = key.replace(/\/@[^\/]+/g, "");

--- a/packages/open-next/src/adapters/middleware.ts
+++ b/packages/open-next/src/adapters/middleware.ts
@@ -16,8 +16,7 @@ import {
 } from "../core/resolve";
 import routingHandler, {
   INTERNAL_HEADER_INITIAL_PATH,
-  INTERNAL_HEADER_RESOLVED_ROUTE,
-  INTERNAL_HEADER_ROUTE_TYPE,
+  INTERNAL_HEADER_RESOLVED_ROUTES,
 } from "../core/routingHandler";
 
 globalThis.internalFetch = fetch;
@@ -66,14 +65,15 @@ const defaultHandler = async (
               headers: {
                 ...result.internalEvent.headers,
                 [INTERNAL_HEADER_INITIAL_PATH]: internalEvent.rawPath,
-                [INTERNAL_HEADER_RESOLVED_ROUTE]: result.resolvedRoute ?? "",
-                [INTERNAL_HEADER_ROUTE_TYPE]: result.routeType ?? "",
+                [INTERNAL_HEADER_RESOLVED_ROUTES]:
+                  JSON.stringify(result.resolvedRoutes) ?? "[]",
               },
             },
             isExternalRewrite: result.isExternalRewrite,
             origin,
             isISR: result.isISR,
             initialPath: result.initialPath,
+            resolvedRoutes: result.resolvedRoutes,
           };
         }
         try {
@@ -93,6 +93,7 @@ const defaultHandler = async (
             origin: false,
             isISR: result.isISR,
             initialPath: result.internalEvent.rawPath,
+            resolvedRoutes: [{ route: "/500", type: "page" }],
           };
         }
       }

--- a/packages/open-next/src/adapters/middleware.ts
+++ b/packages/open-next/src/adapters/middleware.ts
@@ -14,7 +14,11 @@ import {
   resolveQueue,
   resolveTagCache,
 } from "../core/resolve";
-import routingHandler from "../core/routingHandler";
+import routingHandler, {
+  INTERNAL_HEADER_INITIAL_PATH,
+  INTERNAL_HEADER_RESOLVED_ROUTE,
+  INTERNAL_HEADER_ROUTE_TYPE,
+} from "../core/routingHandler";
 
 globalThis.internalFetch = fetch;
 globalThis.__openNextAls = new AsyncLocalStorage();
@@ -61,9 +65,9 @@ const defaultHandler = async (
               ...result.internalEvent,
               headers: {
                 ...result.internalEvent.headers,
-                "x-opennext-initial-path": internalEvent.rawPath,
-                "x-opennext-resolved-route": result.resolvedRoute ?? "",
-                "x-opennext-route-type": result.routeType ?? "",
+                [INTERNAL_HEADER_INITIAL_PATH]: internalEvent.rawPath,
+                [INTERNAL_HEADER_RESOLVED_ROUTE]: result.resolvedRoute ?? "",
+                [INTERNAL_HEADER_ROUTE_TYPE]: result.routeType ?? "",
               },
             },
             isExternalRewrite: result.isExternalRewrite,

--- a/packages/open-next/src/adapters/middleware.ts
+++ b/packages/open-next/src/adapters/middleware.ts
@@ -57,10 +57,19 @@ const defaultHandler = async (
           );
           return {
             type: "middleware",
-            internalEvent: result.internalEvent,
+            internalEvent: {
+              ...result.internalEvent,
+              headers: {
+                ...result.internalEvent.headers,
+                "x-opennext-initial-path": internalEvent.rawPath,
+                "x-opennext-resolved-route": result.resolvedRoute ?? "",
+                "x-opennext-route-type": result.routeType ?? "",
+              },
+            },
             isExternalRewrite: result.isExternalRewrite,
             origin,
             isISR: result.isISR,
+            initialPath: result.initialPath,
           };
         }
         try {
@@ -79,6 +88,7 @@ const defaultHandler = async (
             isExternalRewrite: false,
             origin: false,
             isISR: result.isISR,
+            initialPath: result.internalEvent.rawPath,
           };
         }
       }

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -31,22 +31,22 @@ export async function openNextHandler(
   internalEvent: InternalEvent,
   responseStreaming?: StreamCreator,
 ): Promise<InternalResult> {
+  const initialHeaders = internalEvent.headers;
   // We run everything in the async local storage context so that it is available in the middleware as well as in NextServer
   return runWithOpenNextRequestContext(
-    { isISRRevalidation: internalEvent.headers["x-isr"] === "1" },
+    { isISRRevalidation: initialHeaders["x-isr"] === "1" },
     async () => {
-      if (internalEvent.headers["x-forwarded-host"]) {
-        internalEvent.headers.host = internalEvent.headers["x-forwarded-host"];
+      if (initialHeaders["x-forwarded-host"]) {
+        initialHeaders.host = initialHeaders["x-forwarded-host"];
       }
       debug("internalEvent", internalEvent);
 
       // These 2 will get overwritten by the routing handler if not using an external middleware
       const internalHeaders = {
         initialPath:
-          internalEvent.headers[INTERNAL_HEADER_INITIAL_PATH] ??
-          internalEvent.rawPath,
-        resolvedRoutes: internalEvent.headers[INTERNAL_HEADER_RESOLVED_ROUTES]
-          ? JSON.parse(internalEvent.headers[INTERNAL_HEADER_RESOLVED_ROUTES])
+          initialHeaders[INTERNAL_HEADER_INITIAL_PATH] ?? internalEvent.rawPath,
+        resolvedRoutes: initialHeaders[INTERNAL_HEADER_RESOLVED_ROUTES]
+          ? JSON.parse(initialHeaders[INTERNAL_HEADER_RESOLVED_ROUTES])
           : ([] as ResolvedRoute[]),
       };
 

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -5,6 +5,7 @@ import { IncomingMessage } from "http/index.js";
 import type {
   InternalEvent,
   InternalResult,
+  RouteType,
   RoutingResult,
   StreamCreator,
 } from "types/open-next";
@@ -14,6 +15,7 @@ import { debug, error, warn } from "../adapters/logger";
 import { patchAsyncStorage } from "./patchAsyncStorage";
 import { convertRes, createServerResponse } from "./routing/util";
 import routingHandler, {
+  INTERNAL_HEADER_PREFIX,
   MIDDLEWARE_HEADER_PREFIX,
   MIDDLEWARE_HEADER_PREFIX_LEN,
 } from "./routingHandler";
@@ -42,6 +44,15 @@ export async function openNextHandler(
         isExternalRewrite: false,
         origin: false,
         isISR: false,
+        // These 3 will get overwritten by the routing handler if not using an external middleware
+        initialPath:
+          internalEvent.headers[`${INTERNAL_HEADER_PREFIX}-initial-path`] ??
+          internalEvent.rawPath,
+        resolvedRoute:
+          internalEvent.headers[`${INTERNAL_HEADER_PREFIX}-resolved-route`],
+        routeType: internalEvent.headers[
+          `${INTERNAL_HEADER_PREFIX}-route-type`
+        ] as RouteType | undefined,
       };
 
       //#override withRouting
@@ -94,6 +105,8 @@ export async function openNextHandler(
             isExternalRewrite: false,
             isISR: false,
             origin: false,
+            initialPath: internalEvent.rawPath,
+            resolvedRoute: "/500",
           };
         }
       }

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -5,7 +5,7 @@ import { IncomingMessage } from "http/index.js";
 import type {
   InternalEvent,
   InternalResult,
-  RouteType,
+  ResolvedRoute,
   RoutingResult,
   StreamCreator,
 } from "types/open-next";
@@ -16,8 +16,7 @@ import { patchAsyncStorage } from "./patchAsyncStorage";
 import { convertRes, createServerResponse } from "./routing/util";
 import routingHandler, {
   INTERNAL_HEADER_INITIAL_PATH,
-  INTERNAL_HEADER_RESOLVED_ROUTE,
-  INTERNAL_HEADER_ROUTE_TYPE,
+  INTERNAL_HEADER_RESOLVED_ROUTES,
   MIDDLEWARE_HEADER_PREFIX,
   MIDDLEWARE_HEADER_PREFIX_LEN,
 } from "./routingHandler";
@@ -41,15 +40,14 @@ export async function openNextHandler(
       }
       debug("internalEvent", internalEvent);
 
-      // These 3 will get overwritten by the routing handler if not using an external middleware
+      // These 2 will get overwritten by the routing handler if not using an external middleware
       const internalHeaders = {
         initialPath:
           internalEvent.headers[INTERNAL_HEADER_INITIAL_PATH] ??
           internalEvent.rawPath,
-        resolvedRoute: internalEvent.headers[INTERNAL_HEADER_RESOLVED_ROUTE],
-        routeType: internalEvent.headers[INTERNAL_HEADER_ROUTE_TYPE] as
-          | RouteType
-          | undefined,
+        resolvedRoutes: internalEvent.headers[INTERNAL_HEADER_RESOLVED_ROUTES]
+          ? JSON.parse(internalEvent.headers[INTERNAL_HEADER_RESOLVED_ROUTES])
+          : ([] as ResolvedRoute[]),
       };
 
       let routingResult: InternalResult | RoutingResult = {
@@ -111,7 +109,7 @@ export async function openNextHandler(
             isISR: false,
             origin: false,
             initialPath: internalEvent.rawPath,
-            resolvedRoute: "/500",
+            resolvedRoutes: [{ route: "/500", type: "page" }],
           };
         }
       }

--- a/packages/open-next/src/core/routing/routeMatcher.ts
+++ b/packages/open-next/src/core/routing/routeMatcher.ts
@@ -1,0 +1,66 @@
+import { AppPathRoutesManifest, RoutesManifest } from "config/index";
+import type { RouteDefinition } from "types/next-types";
+import type { RouteType } from "types/open-next";
+
+// Add the locale prefix to the regex so we correctly match the rawPath
+const optionalLocalePrefixRegex = RoutesManifest.locales.length
+  ? `^/(?:${RoutesManifest.locales.map((locale) => `${locale}/?`).join("|")})?`
+  : "^/";
+
+// Add the basepath prefix to the regex so we correctly match the rawPath
+const optionalBasepathPrefixRegex = RoutesManifest.basePath
+  ? `^${RoutesManifest.basePath}/?`
+  : "^/";
+
+// Add the basePath prefix to the api routes
+export const apiPrefix = RoutesManifest.basePath
+  ? `${RoutesManifest.basePath}/api`
+  : "/api";
+
+function routeMatcher(routeDefinitions: RouteDefinition[]) {
+  const regexp = routeDefinitions.map((route) => {
+    return {
+      page: route.page,
+      regexp: new RegExp(
+        route.regex
+          .replace("^/", optionalLocalePrefixRegex)
+          .replace("^/", optionalBasepathPrefixRegex),
+      ),
+    };
+  });
+
+  // We need to use AppPathRoutesManifest here
+  const appPathsSet = new Set(
+    Object.entries(AppPathRoutesManifest)
+      .filter(([key, _]) => key.endsWith("page"))
+      .map(([_, value]) => value),
+  );
+  const routePathsSet = new Set(
+    Object.entries(AppPathRoutesManifest)
+      .filter(([key, _]) => key.endsWith("route"))
+      .map(([_, value]) => value),
+  );
+  return function matchRoute(path: string) {
+    const foundRoutes = regexp.filter((route) => route.regexp.test(path));
+
+    if (foundRoutes.length > 0) {
+      return foundRoutes.map((foundRoute) => {
+        const routeType: RouteType | undefined = appPathsSet.has(
+          foundRoute.page,
+        )
+          ? "app"
+          : routePathsSet.has(foundRoute.page)
+            ? "route"
+            : "page";
+        return {
+          route: foundRoute.page,
+          type: routeType,
+        };
+      });
+    }
+    return false;
+  };
+}
+
+export const staticRouteMatcher = routeMatcher(RoutesManifest.routes.static);
+export const dynamicRouteMatcher = routeMatcher(RoutesManifest.routes.dynamic);

--- a/packages/open-next/src/core/routing/routeMatcher.ts
+++ b/packages/open-next/src/core/routing/routeMatcher.ts
@@ -3,9 +3,7 @@ import type { RouteDefinition } from "types/next-types";
 import type { RouteType } from "types/open-next";
 
 // Add the locale prefix to the regex so we correctly match the rawPath
-const optionalLocalePrefixRegex = RoutesManifest.locales.length
-  ? `^/(?:${RoutesManifest.locales.map((locale) => `${locale}/?`).join("|")})?`
-  : "^/";
+const optionalLocalePrefixRegex = `^/(?:${RoutesManifest.locales.map((locale) => `${locale}/?`).join("|")})?`;
 
 // Add the basepath prefix to the regex so we correctly match the rawPath
 const optionalBasepathPrefixRegex = RoutesManifest.basePath
@@ -13,50 +11,45 @@ const optionalBasepathPrefixRegex = RoutesManifest.basePath
   : "^/";
 
 // Add the basePath prefix to the api routes
-export const apiPrefix = RoutesManifest.basePath
-  ? `${RoutesManifest.basePath}/api`
-  : "/api";
+export const apiPrefix = `${RoutesManifest.basePath ?? ""}/api`;
+
+const optionalPrefix = optionalLocalePrefixRegex.replace(
+  "^/",
+  optionalBasepathPrefixRegex,
+);
 
 function routeMatcher(routeDefinitions: RouteDefinition[]) {
   const regexp = routeDefinitions.map((route) => ({
     page: route.page,
-    regexp: new RegExp(
-      route.regex
-        .replace("^/", optionalLocalePrefixRegex)
-        .replace("^/", optionalBasepathPrefixRegex),
-    ),
+    regexp: new RegExp(route.regex.replace("^/", optionalPrefix)),
   }));
 
+  const appPathsSet = new Set();
+  const routePathsSet = new Set();
   // We need to use AppPathRoutesManifest here
-  const appPathsSet = new Set(
-    Object.entries(AppPathRoutesManifest)
-      .filter(([key, _]) => key.endsWith("page"))
-      .map(([_, value]) => value),
-  );
-  const routePathsSet = new Set(
-    Object.entries(AppPathRoutesManifest)
-      .filter(([key, _]) => key.endsWith("route"))
-      .map(([_, value]) => value),
-  );
+  for (const [k, v] of Object.entries(AppPathRoutesManifest)) {
+    if (k.endsWith("page")) {
+      appPathsSet.add(v);
+    } else if (k.endsWith("route")) {
+      routePathsSet.add(v);
+    }
+  }
+
   return function matchRoute(path: string) {
     const foundRoutes = regexp.filter((route) => route.regexp.test(path));
 
-    if (foundRoutes.length > 0) {
-      return foundRoutes.map((foundRoute) => {
-        const routeType: RouteType | undefined = appPathsSet.has(
-          foundRoute.page,
-        )
-          ? "app"
-          : routePathsSet.has(foundRoute.page)
-            ? "route"
-            : "page";
-        return {
-          route: foundRoute.page,
-          type: routeType,
-        };
-      });
-    }
-    return false;
+    return foundRoutes.map((foundRoute) => {
+      let routeType: RouteType = "page";
+      if (appPathsSet.has(foundRoute.page)) {
+        routeType = "app";
+      } else if (routePathsSet.has(foundRoute.page)) {
+        routeType = "route";
+      }
+      return {
+        route: foundRoute.page,
+        type: routeType,
+      };
+    });
   };
 }
 

--- a/packages/open-next/src/core/routing/routeMatcher.ts
+++ b/packages/open-next/src/core/routing/routeMatcher.ts
@@ -18,16 +18,14 @@ export const apiPrefix = RoutesManifest.basePath
   : "/api";
 
 function routeMatcher(routeDefinitions: RouteDefinition[]) {
-  const regexp = routeDefinitions.map((route) => {
-    return {
-      page: route.page,
-      regexp: new RegExp(
-        route.regex
-          .replace("^/", optionalLocalePrefixRegex)
-          .replace("^/", optionalBasepathPrefixRegex),
-      ),
-    };
-  });
+  const regexp = routeDefinitions.map((route) => ({
+    page: route.page,
+    regexp: new RegExp(
+      route.regex
+        .replace("^/", optionalLocalePrefixRegex)
+        .replace("^/", optionalBasepathPrefixRegex),
+    ),
+  }));
 
   // We need to use AppPathRoutesManifest here
   const appPathsSet = new Set(

--- a/packages/open-next/src/core/routingHandler.ts
+++ b/packages/open-next/src/core/routingHandler.ts
@@ -115,9 +115,9 @@ export default async function routingHandler(
     isExternalRewrite = beforeRewrites.isExternalRewrite;
   }
   const foundStaticRoute = staticRouteMatcher(internalEvent.rawPath);
-  const isStaticRoute = !isExternalRewrite && Boolean(foundStaticRoute);
+  const isStaticRoute = !isExternalRewrite && foundStaticRoute.length > 0;
 
-  if (!isStaticRoute && !isExternalRewrite) {
+  if (!(isStaticRoute || isExternalRewrite)) {
     // Second rewrite to be applied
     const afterRewrites = handleRewrites(
       internalEvent,
@@ -135,7 +135,7 @@ export default async function routingHandler(
   internalEvent = fallbackEvent;
 
   const foundDynamicRoute = dynamicRouteMatcher(internalEvent.rawPath);
-  const isDynamicRoute = !isExternalRewrite && Boolean(foundDynamicRoute);
+  const isDynamicRoute = !isExternalRewrite && foundDynamicRoute.length > 0;
 
   if (!(isDynamicRoute || isStaticRoute || isExternalRewrite)) {
     // Fallback rewrite to be applied
@@ -167,8 +167,8 @@ export default async function routingHandler(
       isApiRoute ||
       isNextImageRoute ||
       // We need to check again once all rewrites have been applied
-      staticRouteMatcher(internalEvent.rawPath) ||
-      dynamicRouteMatcher(internalEvent.rawPath)
+      staticRouteMatcher(internalEvent.rawPath).length > 0 ||
+      dynamicRouteMatcher(internalEvent.rawPath).length > 0
     )
   ) {
     internalEvent = {
@@ -209,11 +209,11 @@ export default async function routingHandler(
   });
 
   const resolvedRoutes: ResolvedRoute[] = [
-    ...(Array.isArray(foundStaticRoute) ? foundStaticRoute : []),
-    ...(Array.isArray(foundDynamicRoute) ? foundDynamicRoute : []),
+    ...foundStaticRoute,
+    ...foundDynamicRoute,
   ];
 
-  console.log("resolvedRoutes", resolvedRoutes);
+  debug("resolvedRoutes", resolvedRoutes);
 
   return {
     internalEvent,

--- a/packages/open-next/src/core/routingHandler.ts
+++ b/packages/open-next/src/core/routingHandler.ts
@@ -28,10 +28,10 @@ import {
 } from "./routing/routeMatcher";
 
 export const MIDDLEWARE_HEADER_PREFIX = "x-middleware-response-";
+export const MIDDLEWARE_HEADER_PREFIX_LEN = MIDDLEWARE_HEADER_PREFIX.length;
 export const INTERNAL_HEADER_PREFIX = "x-opennext-";
 export const INTERNAL_HEADER_INITIAL_PATH = `${INTERNAL_HEADER_PREFIX}initial-path`;
 export const INTERNAL_HEADER_RESOLVED_ROUTES = `${INTERNAL_HEADER_PREFIX}resolved-routes`;
-export const MIDDLEWARE_HEADER_PREFIX_LEN = MIDDLEWARE_HEADER_PREFIX.length;
 
 // Geolocation headers starting from Nextjs 15
 // See https://github.com/vercel/vercel/blob/7714b1c/packages/functions/src/headers.ts

--- a/packages/open-next/src/plugins/edge.ts
+++ b/packages/open-next/src/plugins/edge.ts
@@ -6,6 +6,7 @@ import type { Plugin } from "esbuild";
 import type { MiddlewareInfo } from "types/next-types.js";
 
 import {
+  loadAppPathRoutesManifest,
   loadAppPathsManifest,
   loadAppPathsManifestKeys,
   loadBuildId,
@@ -169,6 +170,7 @@ ${contents}
         const AppPathsManifestKeys = loadAppPathsManifestKeys(nextDir);
         const MiddlewareManifest = loadMiddlewareManifest(nextDir);
         const AppPathsManifest = loadAppPathsManifest(nextDir);
+        const AppPathRoutesManifest = loadAppPathRoutesManifest(nextDir);
 
         const contents = `
   import path from "node:path";
@@ -191,6 +193,8 @@ ${contents}
   export const AppPathsManifestKeys = ${JSON.stringify(AppPathsManifestKeys)};
   export const MiddlewareManifest = ${JSON.stringify(MiddlewareManifest)};
   export const AppPathsManifest = ${JSON.stringify(AppPathsManifest)};
+  export const AppPathRoutesManifest = ${JSON.stringify(AppPathRoutesManifest)};
+
 
   process.env.NEXT_BUILD_ID = BuildId;
 `;

--- a/packages/open-next/src/plugins/edge.ts
+++ b/packages/open-next/src/plugins/edge.ts
@@ -6,6 +6,7 @@ import type { Plugin } from "esbuild";
 import type { MiddlewareInfo } from "types/next-types.js";
 
 import {
+  loadAppPathsManifest,
   loadAppPathsManifestKeys,
   loadBuildId,
   loadConfig,
@@ -167,6 +168,7 @@ ${contents}
         const PrerenderManifest = loadPrerenderManifest(nextDir);
         const AppPathsManifestKeys = loadAppPathsManifestKeys(nextDir);
         const MiddlewareManifest = loadMiddlewareManifest(nextDir);
+        const AppPathsManifest = loadAppPathsManifest(nextDir);
 
         const contents = `
   import path from "node:path";
@@ -188,6 +190,7 @@ ${contents}
   export const PrerenderManifest = ${JSON.stringify(PrerenderManifest)};
   export const AppPathsManifestKeys = ${JSON.stringify(AppPathsManifestKeys)};
   export const MiddlewareManifest = ${JSON.stringify(MiddlewareManifest)};
+  export const AppPathsManifest = ${JSON.stringify(AppPathsManifest)};
 
   process.env.NEXT_BUILD_ID = BuildId;
 `;

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -107,11 +107,22 @@ export type IncludedConverter =
   | "sqs-revalidate"
   | "dummy";
 
+export type RouteType = "route" | "page" | "app";
+
 export interface RoutingResult {
   internalEvent: InternalEvent;
+  // If the request is an external rewrite, if used with an external middleware will be false on every server function
   isExternalRewrite: boolean;
+  // Origin is only used in external middleware, will be false on every server function
   origin: Origin | false;
+  // If the request is for an ISR route, will be false on every server function. Only used in external middleware
   isISR: boolean;
+  // The initial rawPath of the request before applying rewrites, if used with an external middleware will be defined in x-opennext-initial-path header
+  initialPath: string;
+  // The resolved route after applying rewrites, if used with an external middleware will be defined in x-opennext-resolved-route header
+  resolvedRoute?: string;
+  // The type of the resolved route, if used with an external middleware will be defined in x-opennext-route-type header
+  routeType?: RouteType;
 }
 
 export interface MiddlewareResult

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -109,6 +109,11 @@ export type IncludedConverter =
 
 export type RouteType = "route" | "page" | "app";
 
+export interface ResolvedRoute {
+  route: string;
+  type: RouteType;
+}
+
 export interface RoutingResult {
   internalEvent: InternalEvent;
   // If the request is an external rewrite, if used with an external middleware will be false on every server function
@@ -119,10 +124,9 @@ export interface RoutingResult {
   isISR: boolean;
   // The initial rawPath of the request before applying rewrites, if used with an external middleware will be defined in x-opennext-initial-path header
   initialPath: string;
-  // The resolved route after applying rewrites, if used with an external middleware will be defined in x-opennext-resolved-route header
-  resolvedRoute?: string;
-  // The type of the resolved route, if used with an external middleware will be defined in x-opennext-route-type header
-  routeType?: RouteType;
+
+  // The resolved route after applying rewrites, if used with an external middleware will be defined in x-opennext-resolved-routes header as a json encoded array
+  resolvedRoutes: ResolvedRoute[];
 }
 
 export interface MiddlewareResult

--- a/packages/tests-unit/tests/core/routing/routeMatcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/routeMatcher.test.ts
@@ -75,8 +75,8 @@ describe("routeMatcher", () => {
 
   describe("staticRouteMatcher", () => {
     it("should match static app route", () => {
-      const route = staticRouteMatcher("/app");
-      expect(route).toEqual([
+      const routes = staticRouteMatcher("/app");
+      expect(routes).toEqual([
         {
           route: "/app",
           type: "app",
@@ -85,8 +85,8 @@ describe("routeMatcher", () => {
     });
 
     it("should match static api route", () => {
-      const route = staticRouteMatcher("/api/app");
-      expect(route).toEqual([
+      const routes = staticRouteMatcher("/api/app");
+      expect(routes).toEqual([
         {
           route: "/api/app",
           type: "route",
@@ -95,25 +95,25 @@ describe("routeMatcher", () => {
     });
 
     it("should not match app dynamic route", () => {
-      const route = staticRouteMatcher("/catchAll/slug");
-      expect(route).toEqual(false);
+      const routes = staticRouteMatcher("/catchAll/slug");
+      expect(routes).toEqual([]);
     });
 
     it("should not match page dynamic route", () => {
-      const route = staticRouteMatcher("/page/catchAll/slug");
-      expect(route).toEqual(false);
+      const routes = staticRouteMatcher("/page/catchAll/slug");
+      expect(routes).toEqual([]);
     });
 
     it("should not match random route", () => {
-      const route = staticRouteMatcher("/random");
-      expect(route).toEqual(false);
+      const routes = staticRouteMatcher("/random");
+      expect(routes).toEqual([]);
     });
   });
 
   describe("dynamicRouteMatcher", () => {
     it("should match dynamic app page", () => {
-      const route = dynamicRouteMatcher("/catchAll/slug/b");
-      expect(route).toEqual([
+      const routes = dynamicRouteMatcher("/catchAll/slug/b");
+      expect(routes).toEqual([
         {
           route: "/catchAll/[...slug]",
           type: "app",
@@ -122,8 +122,8 @@ describe("routeMatcher", () => {
     });
 
     it("should match dynamic page router page", () => {
-      const route = dynamicRouteMatcher("/page/catchAll/slug/b");
-      expect(route).toEqual([
+      const routes = dynamicRouteMatcher("/page/catchAll/slug/b");
+      expect(routes).toEqual([
         {
           route: "/page/catchAll/[...slug]",
           type: "page",
@@ -134,13 +134,14 @@ describe("routeMatcher", () => {
     it("should match both the static and dynamic page", () => {
       const pathToMatch = "/page/catchAll/static";
       const dynamicRoutes = dynamicRouteMatcher(pathToMatch);
-      const staticRoutes = staticRouteMatcher(pathToMatch);
       expect(dynamicRoutes).toEqual([
         {
           route: "/page/catchAll/[...slug]",
           type: "page",
         },
       ]);
+
+      const staticRoutes = staticRouteMatcher(pathToMatch);
       expect(staticRoutes).toEqual([
         {
           route: "/page/catchAll/static",

--- a/packages/tests-unit/tests/core/routing/routeMatcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/routeMatcher.test.ts
@@ -1,6 +1,6 @@
 import {
-  staticRouteMatcher,
   dynamicRouteMatcher,
+  staticRouteMatcher,
 } from "@opennextjs/aws/core/routing/routeMatcher.js";
 import { vi } from "vitest";
 

--- a/packages/tests-unit/tests/core/routing/routeMatcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/routeMatcher.test.ts
@@ -1,0 +1,152 @@
+import {
+  staticRouteMatcher,
+  dynamicRouteMatcher,
+} from "@opennextjs/aws/core/routing/routeMatcher.js";
+import { vi } from "vitest";
+
+vi.mock("@opennextjs/aws/adapters/config/index.js", () => ({
+  NextConfig: {},
+  AppPathRoutesManifest: {
+    "/api/app/route": "/api/app",
+    "/app/page": "/app",
+    "/catchAll/[...slug]/page": "/catchAll/[...slug]",
+  },
+  RoutesManifest: {
+    version: 3,
+    pages404: true,
+    caseSensitive: false,
+    basePath: "",
+    locales: [],
+    redirects: [],
+    headers: [],
+    routes: {
+      dynamic: [
+        {
+          page: "/catchAll/[...slug]",
+          regex: "^/catchAll/(.+?)(?:/)?$",
+          routeKeys: {
+            nxtPslug: "nxtPslug",
+          },
+          namedRegex: "^/catchAll/(?<nxtPslug>.+?)(?:/)?$",
+        },
+        {
+          page: "/page/catchAll/[...slug]",
+          regex: "^/page/catchAll/(.+?)(?:/)?$",
+          routeKeys: {
+            nxtPslug: "nxtPslug",
+          },
+          namedRegex: "^/page/catchAll/(?<nxtPslug>.+?)(?:/)?$",
+        },
+      ],
+      static: [
+        {
+          page: "/app",
+          regex: "^/app(?:/)?$",
+          routeKeys: {},
+          namedRegex: "^/app(?:/)?$",
+        },
+        {
+          page: "/api/app",
+          regex: "^/api/app(?:/)?$",
+          routeKeys: {},
+          namedRegex: "^/api/app(?:/)?$",
+        },
+        {
+          page: "/page",
+          regex: "^/page(?:/)?$",
+          routeKeys: {},
+          namedRegex: "^/page(?:/)?$",
+        },
+        {
+          page: "/page/catchAll/static",
+          regex: "^/page/catchAll/static(?:/)?$",
+          routeKeys: {},
+          namedRegex: "^/page/catchAll/static(?:/)?$",
+        },
+      ],
+    },
+  },
+}));
+
+describe("routeMatcher", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("staticRouteMatcher", () => {
+    it("should match static app route", () => {
+      const route = staticRouteMatcher("/app");
+      expect(route).toEqual([
+        {
+          route: "/app",
+          type: "app",
+        },
+      ]);
+    });
+
+    it("should match static api route", () => {
+      const route = staticRouteMatcher("/api/app");
+      expect(route).toEqual([
+        {
+          route: "/api/app",
+          type: "route",
+        },
+      ]);
+    });
+
+    it("should not match app dynamic route", () => {
+      const route = staticRouteMatcher("/catchAll/slug");
+      expect(route).toEqual(false);
+    });
+
+    it("should not match page dynamic route", () => {
+      const route = staticRouteMatcher("/page/catchAll/slug");
+      expect(route).toEqual(false);
+    });
+
+    it("should not match random route", () => {
+      const route = staticRouteMatcher("/random");
+      expect(route).toEqual(false);
+    });
+  });
+
+  describe("dynamicRouteMatcher", () => {
+    it("should match dynamic app page", () => {
+      const route = dynamicRouteMatcher("/catchAll/slug/b");
+      expect(route).toEqual([
+        {
+          route: "/catchAll/[...slug]",
+          type: "app",
+        },
+      ]);
+    });
+
+    it("should match dynamic page router page", () => {
+      const route = dynamicRouteMatcher("/page/catchAll/slug/b");
+      expect(route).toEqual([
+        {
+          route: "/page/catchAll/[...slug]",
+          type: "page",
+        },
+      ]);
+    });
+
+    it("should match both the static and dynamic page", () => {
+      const pathToMatch = "/page/catchAll/static";
+      const dynamicRoutes = dynamicRouteMatcher(pathToMatch);
+      const staticRoutes = staticRouteMatcher(pathToMatch);
+      expect(dynamicRoutes).toEqual([
+        {
+          route: "/page/catchAll/[...slug]",
+          type: "page",
+        },
+      ]);
+      expect(staticRoutes).toEqual([
+        {
+          route: "/page/catchAll/static",
+          type: "page",
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
This PR will help #665.
This may also allow us in the future to use https://github.com/vercel/next.js/blob/4d1613d049037b2b39295a9479c9f8c9a12df907/packages/next/src/server/base-server.ts#L1581 instead of `getRequestHandler`