### PR TITLE
fix: import correct logger

### DIFF
--- a/.changeset/three-cobras-mix.md
+++ b/.changeset/three-cobras-mix.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Import correct loggers in proxyExternalRequest override

--- a/packages/open-next/src/overrides/proxyExternalRequest/node.ts
+++ b/packages/open-next/src/overrides/proxyExternalRequest/node.ts
@@ -1,8 +1,8 @@
-import { debug, error } from "node:console";
 import { request } from "node:https";
 import { Readable } from "node:stream";
 import type { InternalEvent, InternalResult } from "types/open-next";
 import type { ProxyExternalRequest } from "types/overrides";
+import { debug, error } from "../../adapters/logger";
 import { isBinaryContentType } from "../../utils/binary";
 
 function filterHeadersForProxy(


### PR DESCRIPTION
There was an user in our Discord that complained about his lambda were outputting tons of logging, but he didn't have `OPEN_NEXT_DEBUG` set to any truthy value. Turns out that the `node.ts` module from the `proxyExternalRequest` override imported debug, and error from `node:console` instead of our own in `adapters/logger`.