### PR TITLE
change `setNodeEnv` code to avoid warnings when using the Cloudflare adapter

### DIFF
--- a/packages/open-next/src/adapters/util.ts
+++ b/packages/open-next/src/adapters/util.ts
@@ -1,7 +1,11 @@
 //TODO: We should probably move all the utils to a separate location
 
 export function setNodeEnv() {
-  process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
+  // Note: we create a `processEnv` variable instead of just using `process.env` directly
+  //       because build tools can substitute `process.env.NODE_ENV` on build making
+  //       assignments such as `process.env.NODE_ENV = ...` problematic
+  const processEnv = process.env;
+  processEnv.NODE_ENV = process.env.NODE_ENV ?? "production";
 }
 
 export function generateUniqueId() {


### PR DESCRIPTION
This is a quick change to avoid warnings such as:
![Screenshot 2024-12-27 at 18 20 06](https://github.com/user-attachments/assets/2707d2f7-360c-4f13-bfc9-00226f2cf8e2)
when using the Cloudflare adapter

I am not a huge fan of this change but, for a quick fix which doesn't require too much refactoring in the aws package, I think it's either this or patching the aws code on the Cloudflare adapter (as I've done in https://github.com/opennextjs/opennextjs-cloudflare/pull/211).

(A more proper fix would be to make the aws code configurable so that when used by the Cloudflare adapter the `setNodeEnv` is either never called, thus three shaken away, or becomes a no-op function, but that as I referred to before would be a much bigger change, which might not be worth it right now)