### PR TITLE
Feat: Add dev overrides

### DIFF
--- a/.changeset/forty-cars-smile.md
+++ b/.changeset/forty-cars-smile.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": minor
+---
+
+Added some override for debugging OpenNext locally

--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -45,12 +45,14 @@
     "aws4fetch": "^1.0.18",
     "chalk": "^5.3.0",
     "esbuild": "0.19.2",
+    "express": "5.0.1",
     "path-to-regexp": "^6.3.0",
     "promise.series": "^0.2.0",
     "urlpattern-polyfill": "^10.0.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.109",
+    "@types/express": "5.0.0",
     "@types/node": "catalog:",
     "tsc-alias": "^1.8.8",
     "typescript": "catalog:"

--- a/packages/open-next/src/build/validateConfig.ts
+++ b/packages/open-next/src/build/validateConfig.ts
@@ -20,7 +20,8 @@ const compatibilityMatrix: Record<IncludedWrapper, IncludedConverter[]> = {
   "cloudflare-edge": ["edge"],
   "cloudflare-node": ["edge"],
   node: ["node"],
-  dummy: [],
+  "express-dev": ["node"],
+  dummy: ["dummy"],
 };
 
 function validateFunctionOptions(fnOptions: FunctionOptions) {

--- a/packages/open-next/src/overrides/imageLoader/fs-dev.ts
+++ b/packages/open-next/src/overrides/imageLoader/fs-dev.ts
@@ -1,0 +1,17 @@
+import type { ImageLoader } from "types/overrides";
+import fs from "node:fs/promises";
+import { Readable } from "node:stream";
+
+export default {
+  name: "fs-dev",
+  load: async (url: string) => {
+    const basePath = "../../assets";
+    const fileData = await fs.readFile(`${basePath}/${url}`);
+    const contentType = url.endsWith(".png") ? "image/png" : "image/jpeg";
+    return {
+      body: Readable.from(fileData),
+      contentType,
+      cacheControl: "public, max-age=31536000, immutable",
+    };
+  },
+} satisfies ImageLoader;

--- a/packages/open-next/src/overrides/imageLoader/fs-dev.ts
+++ b/packages/open-next/src/overrides/imageLoader/fs-dev.ts
@@ -1,6 +1,6 @@
-import type { ImageLoader } from "types/overrides";
 import fs from "node:fs/promises";
 import { Readable } from "node:stream";
+import type { ImageLoader } from "types/overrides";
 
 export default {
   name: "fs-dev",

--- a/packages/open-next/src/overrides/imageLoader/fs-dev.ts
+++ b/packages/open-next/src/overrides/imageLoader/fs-dev.ts
@@ -1,15 +1,14 @@
-import fs from "node:fs/promises";
-import { Readable } from "node:stream";
+import fs from "node:fs";
 import type { ImageLoader } from "types/overrides";
 
 export default {
   name: "fs-dev",
   load: async (url: string) => {
     const basePath = "../../assets";
-    const fileData = await fs.readFile(`${basePath}/${url}`);
+    const body = fs.createReadStream(`${basePath}/${url}`);
     const contentType = url.endsWith(".png") ? "image/png" : "image/jpeg";
     return {
-      body: Readable.from(fileData),
+      body,
       contentType,
       cacheControl: "public, max-age=31536000, immutable",
     };

--- a/packages/open-next/src/overrides/incrementalCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/incrementalCache/fs-dev.ts
@@ -1,0 +1,33 @@
+import type { IncrementalCache } from "types/overrides.js";
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const buildId = process.env.NEXT_BUILD_ID;
+const basePath = path.resolve(process.cwd(), `../../cache/${buildId}`);
+
+const getCacheKey = (key: string) => {
+  return path.join(basePath, `${key}.cache`);
+};
+
+const cache: IncrementalCache = {
+  name: "fs-dev",
+  get: async (key: string) => {
+    const fileData = await fs.readFile(getCacheKey(key), "utf-8");
+    const data = JSON.parse(fileData);
+    const { mtime } = await fs.stat(getCacheKey(key));
+    return {
+      value: data,
+      lastModified: mtime.getTime(),
+    };
+  },
+  set: async (key, value, isFetch) => {
+    const data = JSON.stringify(value);
+    await fs.writeFile(getCacheKey(key), data);
+  },
+  delete: async (key) => {
+    await fs.rm(getCacheKey(key));
+  },
+};
+
+export default cache;

--- a/packages/open-next/src/overrides/incrementalCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/incrementalCache/fs-dev.ts
@@ -23,7 +23,10 @@ const cache: IncrementalCache = {
   },
   set: async (key, value, isFetch) => {
     const data = JSON.stringify(value);
-    await fs.writeFile(getCacheKey(key), data);
+    const cacheKey = getCacheKey(key);
+    // We need to create the directory before writing the file
+    await fs.mkdir(path.dirname(cacheKey), { recursive: true });
+    await fs.writeFile(cacheKey, data);
   },
   delete: async (key) => {
     await fs.rm(getCacheKey(key));

--- a/packages/open-next/src/overrides/queue/direct.ts
+++ b/packages/open-next/src/overrides/queue/direct.ts
@@ -1,0 +1,21 @@
+import type { Queue } from "types/overrides.js";
+
+const queue: Queue = {
+  name: "dev-queue",
+  send: async (message) => {
+    const prerenderManifest = (await import("../../adapters/config/index.js"))
+      .PrerenderManifest as any;
+    const { host, url } = message.MessageBody;
+    const protocol = host.includes("localhost") ? "http" : "https";
+    const revalidateId: string = prerenderManifest.preview.previewModeId;
+    await globalThis.internalFetch(`${protocol}://${host}${url}`, {
+      method: "HEAD",
+      headers: {
+        "x-prerender-revalidate": revalidateId,
+        "x-isr": "1",
+      },
+    });
+  },
+};
+
+export default queue;

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -33,12 +33,13 @@ const tagCache: TagCache = {
     return revalidatedTags.length > 0 ? -1 : (lastModified ?? Date.now());
   },
   writeTags: async (newTags) => {
-    const unchangedTags = tags.filter((tagPathMapping) =>
-      newTags.some(
-        (tag) =>
-          tag.tag === tagPathMapping.tag.S &&
-          tag.path === tagPathMapping.path.S,
-      ),
+    const unchangedTags = tags.filter(
+      (tagPathMapping) =>
+        !newTags.some(
+          (tag) =>
+            tag.tag === tagPathMapping.tag.S &&
+            tag.path === tagPathMapping.path.S,
+        ),
     );
     tags = unchangedTags.concat(
       newTags.map((tag) => ({

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -33,13 +33,11 @@ const tagCache: TagCache = {
     return revalidatedTags.length > 0 ? -1 : (lastModified ?? Date.now());
   },
   writeTags: async (newTags) => {
+    const newTagsSet = new Set(
+      newTags.map(({ tag, path }) => `${tag}-${path}`),
+    );
     const unchangedTags = tags.filter(
-      (tagPathMapping) =>
-        !newTags.some(
-          (tag) =>
-            tag.tag === tagPathMapping.tag.S &&
-            tag.path === tagPathMapping.path.S,
-        ),
+      ({ tag, path }) => !newTagsSet.has(`${tag.S}-${path.S}`),
     );
     tags = unchangedTags.concat(
       newTags.map((tag) => ({

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -1,0 +1,53 @@
+import type { TagCache } from "types/overrides";
+
+import fs from "node:fs";
+
+const tagFile = "../../dynamodb-provider/dynamodb-cache.json";
+
+const tagContent = fs.readFileSync(tagFile, "utf-8");
+
+let tags = JSON.parse(tagContent) as {
+  tag: { S: string };
+  path: { S: string };
+  revalidatedAt: { N: string };
+}[];
+
+const tagCache: TagCache = {
+  name: "fs-dev",
+  getByPath: async (path: string) => {
+    return tags
+      .filter((tagPathMapping) => tagPathMapping.path.S === path)
+      .map((tag) => tag.tag.S);
+  },
+  getByTag: async (tag: string) => {
+    return tags
+      .filter((tagPathMapping) => tagPathMapping.tag.S === tag)
+      .map((tag) => tag.path.S);
+  },
+  getLastModified: async (path: string, lastModified?: number) => {
+    const revalidatedTags = tags.filter(
+      (tagPathMapping) =>
+        tagPathMapping.path.S === path &&
+        Number.parseInt(tagPathMapping.revalidatedAt.N) > (lastModified ?? 0),
+    );
+    return revalidatedTags.length > 0 ? -1 : (lastModified ?? Date.now());
+  },
+  writeTags: async (newTags) => {
+    const unchangedTags = tags.filter((tagPathMapping) =>
+      newTags.some(
+        (tag) =>
+          tag.tag === tagPathMapping.tag.S &&
+          tag.path === tagPathMapping.path.S,
+      ),
+    );
+    tags = unchangedTags.concat(
+      newTags.map((tag) => ({
+        tag: { S: tag.tag },
+        path: { S: tag.path },
+        revalidatedAt: { N: String(tag.revalidatedAt) },
+      })),
+    );
+  },
+};
+
+export default tagCache;

--- a/packages/open-next/src/overrides/wrappers/dummy.ts
+++ b/packages/open-next/src/overrides/wrappers/dummy.ts
@@ -1,9 +1,14 @@
+import type { InternalEvent, StreamCreator } from "types/open-next";
 import type { Wrapper, WrapperHandler } from "types/overrides";
 
-const dummyWrapper: WrapperHandler = async () => async () => undefined;
+const dummyWrapper: WrapperHandler = async (handler, converter) => {
+  return async (event: InternalEvent, responseStream?: StreamCreator) => {
+    return await handler(event, responseStream);
+  };
+};
 
 export default {
   name: "dummy",
   wrapper: dummyWrapper,
-  supportStreaming: false,
+  supportStreaming: true,
 } satisfies Wrapper;

--- a/packages/open-next/src/overrides/wrappers/express-dev.ts
+++ b/packages/open-next/src/overrides/wrappers/express-dev.ts
@@ -1,0 +1,60 @@
+// dev/wrapper.ts
+// You'll need to install express
+import express from "express";
+
+import type { StreamCreator } from "types/open-next.js";
+import type { WrapperHandler } from "types/overrides.js";
+
+const wrapper: WrapperHandler = async (handler, converter) => {
+  const app = express();
+  // To serve static assets
+  app.use(express.static("../../assets"));
+
+  const imageHandlerPath = "../../image-optimization-function/index.mjs";
+  const imageHandler = await import(imageHandlerPath).then((m) => m.handler);
+
+  app.all("/_next/image", async (req, res) => {
+    const internalEvent = await converter.convertFrom(req);
+    const _res: StreamCreator = {
+      writeHeaders: (prelude) => {
+        res.writeHead(prelude.statusCode, prelude.headers);
+        return res;
+      },
+      onFinish: () => {},
+    };
+    await imageHandler(internalEvent, _res);
+  });
+
+  app.all("*paths", async (req, res) => {
+    const internalEvent = await converter.convertFrom(req);
+    const _res: StreamCreator = {
+      writeHeaders: (prelude) => {
+        res.writeHead(prelude.statusCode, prelude.headers);
+        return res;
+      },
+      onFinish: () => {},
+    };
+    await handler(internalEvent, _res);
+  });
+
+  const server = app.listen(
+    Number.parseInt(process.env.PORT ?? "3000", 10),
+    () => {
+      console.log(`Server running on port ${process.env.PORT ?? 3000}`);
+    },
+  );
+
+  app.on("error", (err) => {
+    console.error("error", err);
+  });
+
+  return () => {
+    server.close();
+  };
+};
+
+export default {
+  wrapper,
+  name: "expresss-dev",
+  supportStreaming: true,
+};

--- a/packages/open-next/src/overrides/wrappers/express-dev.ts
+++ b/packages/open-next/src/overrides/wrappers/express-dev.ts
@@ -1,5 +1,3 @@
-// dev/wrapper.ts
-// You'll need to install express
 import express from "express";
 
 import type { StreamCreator } from "types/open-next.js";
@@ -20,7 +18,6 @@ const wrapper: WrapperHandler = async (handler, converter) => {
         res.writeHead(prelude.statusCode, prelude.headers);
         return res;
       },
-      onFinish: () => {},
     };
     await imageHandler(internalEvent, _res);
   });

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -96,6 +96,7 @@ export type IncludedWrapper =
   | "cloudflare"
   | "cloudflare-edge"
   | "cloudflare-node"
+  | "express-dev"
   | "dummy";
 
 export type IncludedConverter =
@@ -133,13 +134,17 @@ export interface MiddlewareResult
   extends RoutingResult,
     BaseEventOrResult<"middleware"> {}
 
-export type IncludedQueue = "sqs" | "sqs-lite" | "dummy";
+export type IncludedQueue = "sqs" | "sqs-lite" | "direct" | "dummy";
 
-export type IncludedIncrementalCache = "s3" | "s3-lite" | "dummy";
+export type IncludedIncrementalCache = "s3" | "s3-lite" | "fs-dev" | "dummy";
 
-export type IncludedTagCache = "dynamodb" | "dynamodb-lite" | "dummy";
+export type IncludedTagCache =
+  | "dynamodb"
+  | "dynamodb-lite"
+  | "fs-dev"
+  | "dummy";
 
-export type IncludedImageLoader = "s3" | "host" | "dummy";
+export type IncludedImageLoader = "s3" | "host" | "fs-dev" | "dummy";
 
 export type IncludedOriginResolver = "pattern-env" | "dummy";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
       esbuild:
         specifier: 0.19.2
         version: 0.19.2
+      express:
+        specifier: 5.0.1
+        version: 5.0.1
       path-to-regexp:
         specifier: ^6.3.0
         version: 6.3.0
@@ -250,6 +253,9 @@ importers:
       '@types/aws-lambda':
         specifier: ^8.10.109
         version: 8.10.145
+      '@types/express':
+        specifier: 5.0.0
+        version: 5.0.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.17.6
@@ -2189,8 +2195,23 @@ packages:
   '@types/aws-lambda@8.10.145':
     resolution: {integrity: sha512-dtByW6WiFk5W5Jfgz1VM+YPA21xMXTuSFoLYIDY0L44jDLLflVPtZkYuu3/YxpGcvjzKFBZLU+GyKjR0HOYtyw==}
 
+  '@types/body-parser@1.19.5':
+    resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/express-serve-static-core@5.0.3':
+    resolution: {integrity: sha512-JEhMNwUJt7bw728CydvYzntD0XJeTmDnvwLlbfbAhE7Tbslm/ax6bdIiUwTgeVlZTsJQPwZwKpAkyDtIjsvx3g==}
+
+  '@types/express@5.0.0':
+    resolution: {integrity: sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==}
+
+  '@types/http-errors@2.0.4':
+    resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -2204,6 +2225,9 @@ packages:
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -2212,6 +2236,12 @@ packages:
 
   '@types/node@20.5.0':
     resolution: {integrity: sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==}
+
+  '@types/qs@6.9.17':
+    resolution: {integrity: sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
   '@types/react-dom@19.0.0':
     resolution: {integrity: sha512-1KfiQKsH1o00p9m5ag12axHQSb3FOU9H20UTrujVSkNhuCrRHiQWFqgEnTNK5ZNfnzZv8UWrnXVqCmCF9fgY3w==}
@@ -2224,6 +2254,12 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/send@0.17.4':
+    resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
+
+  '@types/serve-static@1.15.7':
+    resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -2307,6 +2343,10 @@ packages:
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
   acorn-walk@8.3.4:
@@ -2399,6 +2439,9 @@ packages:
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  array-flatten@3.0.0:
+    resolution: {integrity: sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -2521,6 +2564,10 @@ packages:
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.0.2:
+    resolution: {integrity: sha512-SNMk0OONlQ01uk8EPeiBvTW7W4ovpL5b1O3t1sjpPgfxOQ6BqQJ6XjxinDPR79Z6HdcD5zBBwr5ssiTlgdNztQ==}
+    engines: {node: '>=18'}
 
   bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
@@ -2734,6 +2781,10 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.0.0:
+    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
+    engines: {node: '>= 0.6'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -2747,6 +2798,10 @@ packages:
 
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
@@ -2808,8 +2863,25 @@ packages:
       supports-color:
         optional: true
 
+  debug@3.1.0:
+    resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.6:
+    resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -3048,9 +3120,13 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  express@4.21.1:
-    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
+  express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.0.1:
+    resolution: {integrity: sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==}
+    engines: {node: '>= 18'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -3113,6 +3189,10 @@ packages:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.0.0:
+    resolution: {integrity: sha512-MX6Zo2adDViYh+GcxxB1dpO43eypOGUOL12rLCOTMQv/DfIbpSJUy4oQIIZhVZkH9e+bZWKMon0XHFEju16tkQ==}
+    engines: {node: '>= 0.8'}
+
   find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
     engines: {node: '>=6'}
@@ -3151,6 +3231,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   from@0.1.7:
     resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
@@ -3322,6 +3406,10 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.5.2:
+    resolution: {integrity: sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -3434,6 +3522,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -3707,8 +3798,16 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3729,8 +3828,16 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.53.0:
+    resolution: {integrity: sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.0:
+    resolution: {integrity: sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==}
     engines: {node: '>= 0.6'}
 
   mime@1.6.0:
@@ -3847,6 +3954,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   next@15.1.0:
@@ -4018,11 +4129,15 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -4239,6 +4354,10 @@ packages:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
 
+  raw-body@3.0.0:
+    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
+    engines: {node: '>= 0.8'}
+
   react-dom@19.0.0:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
@@ -4339,6 +4458,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.0.0:
+    resolution: {integrity: sha512-dIM5zVoG8xhC6rnSN8uoAgFARwTE7BQs8YwHEvK0VCmfxQXMaOuA1uiR1IPwsW7JyK5iTt7Od/TC9StasS2NPQ==}
+    engines: {node: '>= 0.10'}
+
   rrweb-cssom@0.6.0:
     resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
 
@@ -4383,9 +4506,17 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.1.0:
+    resolution: {integrity: sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==}
+    engines: {node: '>= 18'}
+
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.1.0:
+    resolution: {integrity: sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==}
+    engines: {node: '>= 18'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -4781,6 +4912,10 @@ packages:
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  type-is@2.0.0:
+    resolution: {integrity: sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==}
     engines: {node: '>= 0.6'}
 
   typedarray@0.0.6:
@@ -7179,7 +7314,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.5.0
+      '@types/node': 20.17.6
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -7954,7 +8089,32 @@ snapshots:
 
   '@types/aws-lambda@8.10.145': {}
 
+  '@types/body-parser@1.19.5':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.17.6
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.17.6
+
   '@types/estree@1.0.6': {}
+
+  '@types/express-serve-static-core@5.0.3':
+    dependencies:
+      '@types/node': 20.17.6
+      '@types/qs': 6.9.17
+      '@types/range-parser': 1.2.7
+      '@types/send': 0.17.4
+
+  '@types/express@5.0.0':
+    dependencies:
+      '@types/body-parser': 1.19.5
+      '@types/express-serve-static-core': 5.0.3
+      '@types/qs': 6.9.17
+      '@types/serve-static': 1.15.7
+
+  '@types/http-errors@2.0.4': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -7971,6 +8131,8 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
+  '@types/mime@1.3.5': {}
+
   '@types/node@12.20.55': {}
 
   '@types/node@20.17.6':
@@ -7978,6 +8140,10 @@ snapshots:
       undici-types: 6.19.8
 
   '@types/node@20.5.0': {}
+
+  '@types/qs@6.9.17': {}
+
+  '@types/range-parser@1.2.7': {}
 
   '@types/react-dom@19.0.0':
     dependencies:
@@ -7989,10 +8155,21 @@ snapshots:
 
   '@types/readable-stream@4.0.16':
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.17.6
       safe-buffer: 5.1.2
 
   '@types/resolve@1.20.6': {}
+
+  '@types/send@0.17.4':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 20.17.6
+
+  '@types/serve-static@1.15.7':
+    dependencies:
+      '@types/http-errors': 2.0.4
+      '@types/node': 20.17.6
+      '@types/send': 0.17.4
 
   '@types/stack-utils@2.0.3': {}
 
@@ -8004,7 +8181,7 @@ snapshots:
 
   '@types/ws@8.5.12':
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.17.6
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -8106,6 +8283,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.0
+      negotiator: 1.0.0
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.13.0
@@ -8203,6 +8385,8 @@ snapshots:
       sprintf-js: 1.0.3
 
   array-flatten@1.1.1: {}
+
+  array-flatten@3.0.0: {}
 
   array-union@2.1.0: {}
 
@@ -8360,6 +8544,21 @@ snapshots:
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.0.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 3.1.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.5.2
+      on-finished: 2.4.1
+      qs: 6.13.0
+      raw-body: 3.0.0
+      type-is: 1.6.18
     transitivePeerDependencies:
       - supports-color
 
@@ -8598,6 +8797,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.0.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
@@ -8605,6 +8808,8 @@ snapshots:
   convert-to-spaces@2.0.1: {}
 
   cookie-signature@1.0.6: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.7.1: {}
 
@@ -8657,7 +8862,15 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
+  debug@3.1.0:
+    dependencies:
+      ms: 2.0.0
+
   debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
+
+  debug@4.3.6:
     dependencies:
       ms: 2.1.2
 
@@ -8934,7 +9147,7 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  express@4.21.1:
+  express@4.21.2:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -8955,7 +9168,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.13.0
       range-parser: 1.2.1
@@ -8965,6 +9178,43 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.0.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.0.2
+      content-disposition: 1.0.0
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.2.2
+      debug: 4.3.6
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.0.0
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      methods: 1.1.2
+      mime-types: 3.0.0
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.13.0
+      range-parser: 1.2.1
+      router: 2.0.0
+      safe-buffer: 5.2.1
+      send: 1.1.0
+      serve-static: 2.1.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 2.0.0
       utils-merge: 1.0.1
       vary: 1.1.2
     transitivePeerDependencies:
@@ -9042,6 +9292,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.0.0:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@3.0.0:
     dependencies:
       locate-path: 3.0.0
@@ -9075,6 +9337,8 @@ snapshots:
   fraction.js@4.3.7: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   from@0.1.7: {}
 
@@ -9265,6 +9529,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.5.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -9376,6 +9644,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-stream@2.0.1: {}
 
   is-subdir@1.2.0:
@@ -9462,7 +9732,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.5.0
+      '@types/node': 20.17.6
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -9647,7 +9917,11 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -9662,9 +9936,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.53.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.0:
+    dependencies:
+      mime-db: 1.53.0
 
   mime@1.6.0: {}
 
@@ -9950,9 +10230,11 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  path-to-regexp@0.1.10: {}
+  path-to-regexp@0.1.12: {}
 
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.2.0: {}
 
   path-type@4.0.0: {}
 
@@ -10149,6 +10431,13 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      unpipe: 1.0.0
+
   react-dom@19.0.0(react@19.0.0):
     dependencies:
       react: 19.0.0
@@ -10270,6 +10559,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.24.0
       fsevents: 2.3.3
 
+  router@2.0.0:
+    dependencies:
+      array-flatten: 3.0.0
+      is-promise: 4.0.0
+      methods: 1.1.2
+      parseurl: 1.3.3
+      path-to-regexp: 8.2.0
+      setprototypeof: 1.2.0
+      utils-merge: 1.0.1
+
   rrweb-cssom@0.6.0: {}
 
   run-parallel@1.2.0:
@@ -10320,12 +10619,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.1.0:
+    dependencies:
+      debug: 4.3.7
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime-types: 2.1.35
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   serve-static@1.16.2:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.1.0:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10503,7 +10828,7 @@ snapshots:
       dendriform-immer-patch-optimiser: 2.1.3(immer@9.0.21)
       dotenv: 16.4.5
       esbuild: 0.18.13
-      express: 4.21.1
+      express: 4.21.2
       fast-jwt: 3.3.3
       get-port: 6.1.2
       glob: 10.4.5
@@ -10843,6 +11168,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.0.0:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.0
 
   typedarray@0.0.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2234,9 +2234,6 @@ packages:
   '@types/node@20.17.6':
     resolution: {integrity: sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==}
 
-  '@types/node@20.5.0':
-    resolution: {integrity: sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==}
-
   '@types/qs@6.9.17':
     resolution: {integrity: sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==}
 
@@ -8139,8 +8136,6 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@20.5.0': {}
-
   '@types/qs@6.9.17': {}
 
   '@types/range-parser@1.2.7': {}
@@ -10082,6 +10077,8 @@ snapshots:
   nanoid@3.3.7: {}
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   next@15.1.0(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:


### PR DESCRIPTION
This PR adds a bunch of overrides that is useful to run OpenNext locally.
They can be used in the config file: 
```ts
import type {OpenNextConfig} from "@opennextjs/aws/types/open-next.js"

export default {
  default: {
    override: {
      wrapper: "express-dev",
      converter: "node",
      incrementalCache: "fs-dev",
      queue: "direct",
      tagCache: "fs-dev"
    }
  },

  imageOptimization: {
    override: {
      wrapper: "dummy",
      converter: "dummy"
    },
    loader: "fs-dev",
    // This part is not needed on arm linux, and image optimization will only work in linux
    install: {
      arch: "x64",
      packages: ["sharp"]
    }
  },
} satisfies OpenNextConfig
```

`"direct"` queue could also be used to remove the need to have a queue. It should not be used where `waitUntil` is not properly supported as it means that ISR will wait for the revalidation to be done before returning the response. Revalidation request will also not be deduped