### PR TITLE
fix: host not in route handler url when using external middleware

### DIFF
--- a/.changeset/little-geese-study.md
+++ b/.changeset/little-geese-study.md
@@ -1,0 +1,5 @@
+---
+'@opennextjs/aws': patch
+---
+
+Mark the host header as trusted when the OpenNext project has external middleware to align with normal behavior for the Next.js server.

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -196,8 +196,7 @@ async function generateBundle(
       target: /core(\/|\\)util\.js/g,
       deletes: [
         ...(disableNextPrebundledReact ? ["requireHooks"] : []),
-        ...(disableRouting ? ["trustHostHeader"] : []),
-        ...(!isBefore13413 ? ["requestHandlerHost"] : []),
+        ...(isBefore13413 ? ["trustHostHeader"] : ["requestHandlerHost"]),
         ...(isAfter141
           ? ["experimentalIncrementalCacheHandler"]
           : ["stableIncrementalCache"]),


### PR DESCRIPTION
ref: https://github.com/opennextjs/opennextjs-cloudflare/pull/234#discussion_r1907320812