### PR TITLE
fix: esbuild plugins not matching windows paths

### DIFF
--- a/.changeset/thirty-donuts-buy.md
+++ b/.changeset/thirty-donuts-buy.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix esbuild edge plugins not matching Windows paths.

--- a/packages/open-next/src/plugins/edge.ts
+++ b/packages/open-next/src/plugins/edge.ts
@@ -93,9 +93,11 @@ export function openNextEdgePlugins({
       );
 
       // We inject the entry files into the edgeFunctionHandler
-      build.onLoad({ filter: /(\/|\\)edgeFunctionHandler.js/g }, async (args) => {
-        let contents = readFileSync(args.path, "utf-8");
-        contents = `
+      build.onLoad(
+        { filter: /(\/|\\)edgeFunctionHandler.js/g },
+        async (args) => {
+          let contents = readFileSync(args.path, "utf-8");
+          contents = `
 globalThis._ENTRIES = {};
 globalThis.self = globalThis;
 globalThis._ROUTES = ${JSON.stringify(routes)};
@@ -155,24 +157,27 @@ ${wasmFiles
 ${entryFiles.map((file) => `require("${file}");`).join("\n")}
 ${contents}
         `;
-        return {
-          contents,
-        };
-      });
+          return {
+            contents,
+          };
+        },
+      );
 
-      build.onLoad({ filter: /adapters(\/|\\)config(\/|\\)index/g }, async () => {
-        const NextConfig = loadConfig(nextDir);
-        const BuildId = loadBuildId(nextDir);
-        const HtmlPages = loadHtmlPages(nextDir);
-        const RoutesManifest = loadRoutesManifest(nextDir);
-        const ConfigHeaders = loadConfigHeaders(nextDir);
-        const PrerenderManifest = loadPrerenderManifest(nextDir);
-        const AppPathsManifestKeys = loadAppPathsManifestKeys(nextDir);
-        const MiddlewareManifest = loadMiddlewareManifest(nextDir);
-        const AppPathsManifest = loadAppPathsManifest(nextDir);
-        const AppPathRoutesManifest = loadAppPathRoutesManifest(nextDir);
+      build.onLoad(
+        { filter: /adapters(\/|\\)config(\/|\\)index/g },
+        async () => {
+          const NextConfig = loadConfig(nextDir);
+          const BuildId = loadBuildId(nextDir);
+          const HtmlPages = loadHtmlPages(nextDir);
+          const RoutesManifest = loadRoutesManifest(nextDir);
+          const ConfigHeaders = loadConfigHeaders(nextDir);
+          const PrerenderManifest = loadPrerenderManifest(nextDir);
+          const AppPathsManifestKeys = loadAppPathsManifestKeys(nextDir);
+          const MiddlewareManifest = loadMiddlewareManifest(nextDir);
+          const AppPathsManifest = loadAppPathsManifest(nextDir);
+          const AppPathRoutesManifest = loadAppPathRoutesManifest(nextDir);
 
-        const contents = `
+          const contents = `
   import path from "node:path";
 
   import { debug } from "../logger";
@@ -198,8 +203,9 @@ ${contents}
 
   process.env.NEXT_BUILD_ID = BuildId;
 `;
-        return { contents };
-      });
+          return { contents };
+        },
+      );
     },
   };
 }

--- a/packages/open-next/src/plugins/edge.ts
+++ b/packages/open-next/src/plugins/edge.ts
@@ -58,7 +58,7 @@ export function openNextEdgePlugins({
       logger.debug(chalk.blue("OpenNext Edge plugin"));
       if (edgeFunctionHandlerPath) {
         // If we bundle the routing, we need to resolve the middleware
-        build.onResolve({ filter: /\.\/middleware.mjs/g }, () => {
+        build.onResolve({ filter: /\.(\/|\\)middleware.mjs/g }, () => {
           return {
             path: edgeFunctionHandlerPath,
           };
@@ -93,7 +93,7 @@ export function openNextEdgePlugins({
       );
 
       // We inject the entry files into the edgeFunctionHandler
-      build.onLoad({ filter: /\/edgeFunctionHandler.js/g }, async (args) => {
+      build.onLoad({ filter: /(\/|\\)edgeFunctionHandler.js/g }, async (args) => {
         let contents = readFileSync(args.path, "utf-8");
         contents = `
 globalThis._ENTRIES = {};
@@ -160,7 +160,7 @@ ${contents}
         };
       });
 
-      build.onLoad({ filter: /adapters\/config\/index/g }, async () => {
+      build.onLoad({ filter: /adapters(\/|\\)config(\/|\\)index/g }, async () => {
         const NextConfig = loadConfig(nextDir);
         const BuildId = loadBuildId(nextDir);
         const HtmlPages = loadHtmlPages(nextDir);

--- a/packages/open-next/src/plugins/replacement.ts
+++ b/packages/open-next/src/plugins/replacement.ts
@@ -18,7 +18,7 @@ const importPattern = /\/\/#import([\s\S]*?)\n\/\/#endImport/gm;
 /**
  *
  * openNextPlugin({
- *   target: /plugins\/default\.js/g,
+ *   target: /plugins(\/|\\)default\.js/g,
  *   replacements: [require.resolve("./plugins/default.js")],
  *   deletes: ["id1"],
  * })


### PR DESCRIPTION
Some of the filters were missing Windows separators.