### PR TITLE
refactor(cache): deprecate global disableDynamoDBCache and disableIncrementalCache

### DIFF
--- a/.changeset/sweet-kiwis-agree.md
+++ b/.changeset/sweet-kiwis-agree.md
@@ -1,0 +1,12 @@
+---
+"@opennextjs/aws": patch
+---
+
+refactor(cache): deprecate global disableDynamoDBCache and disableIncrementalCache
+
+In the cache adapter:
+
+- `globalThis.disableDynamoDBCache` is deprecated and will be removed.
+  use `globalThis.openNextConfig.dangerous?.disableTagCache` instead.
+- `globalThis.disableIncrementalCache` is deprecated and will be removed.
+  use `globalThis.openNextConfig.dangerous?.disableIncrementalCache` instead.

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -116,7 +116,7 @@ export default class Cache {
           kind?: "FETCH";
         },
   ) {
-    if (globalThis.disableIncrementalCache) {
+    if (globalThis.openNextConfig.dangerous?.disableIncrementalCache) {
       return null;
     }
 
@@ -260,7 +260,7 @@ export default class Cache {
     data?: IncrementalCacheValue,
     ctx?: IncrementalCacheContext,
   ): Promise<void> {
-    if (globalThis.disableIncrementalCache) {
+    if (globalThis.openNextConfig.dangerous?.disableIncrementalCache) {
       return;
     }
     // This one might not even be necessary anymore
@@ -396,7 +396,8 @@ export default class Cache {
   }
 
   public async revalidateTag(tags: string | string[]) {
-    if (globalThis.disableDynamoDBCache || globalThis.disableIncrementalCache) {
+    const config = globalThis.openNextConfig.dangerous;
+    if (config?.disableTagCache || config?.disableIncrementalCache) {
       return;
     }
     try {

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -68,7 +68,9 @@ function buildDynamoObject(path: string, tags: string, revalidatedAt?: number) {
 const tagCache: TagCache = {
   async getByPath(path) {
     try {
-      if (globalThis.disableDynamoDBCache) return [];
+      if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+        return [];
+      }
       const { CACHE_DYNAMO_TABLE, NEXT_BUILD_ID } = process.env;
       const result = await awsFetch(
         JSON.stringify({
@@ -101,7 +103,9 @@ const tagCache: TagCache = {
   },
   async getByTag(tag) {
     try {
-      if (globalThis.disableDynamoDBCache) return [];
+      if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+        return [];
+      }
       const { CACHE_DYNAMO_TABLE, NEXT_BUILD_ID } = process.env;
       const result = await awsFetch(
         JSON.stringify({
@@ -133,7 +137,9 @@ const tagCache: TagCache = {
   },
   async getLastModified(key, lastModified) {
     try {
-      if (globalThis.disableDynamoDBCache) return lastModified ?? Date.now();
+      if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+        return lastModified ?? Date.now();
+      }
       const { CACHE_DYNAMO_TABLE } = process.env;
       const result = await awsFetch(
         JSON.stringify({
@@ -168,7 +174,9 @@ const tagCache: TagCache = {
   async writeTags(tags) {
     try {
       const { CACHE_DYNAMO_TABLE } = process.env;
-      if (globalThis.disableDynamoDBCache) return;
+      if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+        return;
+      }
       const dataChunks = chunk(tags, MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT).map(
         (Items) => ({
           RequestItems: {

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -44,7 +44,9 @@ function buildDynamoObject(path: string, tags: string, revalidatedAt?: number) {
 const tagCache: TagCache = {
   async getByPath(path) {
     try {
-      if (globalThis.disableDynamoDBCache) return [];
+      if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+        return [];
+      }
       const result = await dynamoClient.send(
         new QueryCommand({
           TableName: CACHE_DYNAMO_TABLE,
@@ -69,7 +71,9 @@ const tagCache: TagCache = {
   },
   async getByTag(tag) {
     try {
-      if (globalThis.disableDynamoDBCache) return [];
+      if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+        return [];
+      }
       const { Items } = await dynamoClient.send(
         new QueryCommand({
           TableName: CACHE_DYNAMO_TABLE,
@@ -95,7 +99,9 @@ const tagCache: TagCache = {
   },
   async getLastModified(key, lastModified) {
     try {
-      if (globalThis.disableDynamoDBCache) return lastModified ?? Date.now();
+      if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+        return lastModified ?? Date.now();
+      }
       const result = await dynamoClient.send(
         new QueryCommand({
           TableName: CACHE_DYNAMO_TABLE,
@@ -123,7 +129,9 @@ const tagCache: TagCache = {
   },
   async writeTags(tags) {
     try {
-      if (globalThis.disableDynamoDBCache) return;
+      if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+        return;
+      }
       const dataChunks = chunk(tags, MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT).map(
         (Items) => ({
           RequestItems: {

--- a/packages/open-next/src/types/global.ts
+++ b/packages/open-next/src/types/global.ts
@@ -75,13 +75,13 @@ declare global {
   var tagCache: TagCache;
   /**
    * A boolean that indicates if the DynamoDB cache is disabled.
-   * TODO: Remove this, we already have access to the config file
+   * @deprecated This will be removed, use `globalThis.openNextConfig.dangerous?.disableTagCache` instead.
    * Defined in esbuild banner for the cache adapter.
    */
   var disableDynamoDBCache: boolean;
   /**
    * A boolean that indicates if the incremental cache is disabled.
-   * TODO: Remove this, we already have access to the config file
+   * @deprecated This will be removed, use `globalThis.openNextConfig.dangerous?.disableIncrementalCache` instead.
    * Defined in esbuild banner for the cache adapter.
    */
   var disableIncrementalCache: boolean;

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -3,8 +3,9 @@ import Cache from "@opennextjs/aws/adapters/cache.js";
 import { vi } from "vitest";
 
 declare global {
-  var disableIncrementalCache: boolean;
-  var disableDynamoDBCache: boolean;
+  var openNextConfig: {
+    dangerous: { disableIncrementalCache?: boolean; disableTagCache?: boolean };
+  };
   var isNextAfter15: boolean;
 }
 
@@ -62,7 +63,11 @@ describe("CacheHandler", () => {
 
     cache = new Cache();
 
-    globalThis.disableIncrementalCache = false;
+    globalThis.openNextConfig = {
+      dangerous: {
+        disableIncrementalCache: false,
+      },
+    };
     globalThis.isNextAfter15 = false;
 
     globalThis.lastModified = {};
@@ -79,7 +84,7 @@ describe("CacheHandler", () => {
 
     describe("disableIncrementalCache", () => {
       beforeEach(() => {
-        globalThis.disableIncrementalCache = true;
+        globalThis.openNextConfig.dangerous.disableIncrementalCache = true;
       });
 
       it("Should return null when incremental cache is disabled", async () => {
@@ -89,7 +94,7 @@ describe("CacheHandler", () => {
       });
 
       it("Should not set cache when incremental cache is disabled", async () => {
-        globalThis.disableIncrementalCache = true;
+        globalThis.openNextConfig.dangerous.disableIncrementalCache = true;
 
         await cache.set("key", { kind: "REDIRECT", props: {} });
 
@@ -97,7 +102,7 @@ describe("CacheHandler", () => {
       });
 
       it("Should not delete cache when incremental cache is disabled", async () => {
-        globalThis.disableIncrementalCache = true;
+        globalThis.openNextConfig.dangerous.disableIncrementalCache = true;
 
         await cache.set("key", undefined);
 
@@ -480,11 +485,11 @@ describe("CacheHandler", () => {
 
   describe("revalidateTag", () => {
     beforeEach(() => {
-      globalThis.disableDynamoDBCache = false;
-      globalThis.disableIncrementalCache = false;
+      globalThis.openNextConfig.dangerous.disableTagCache = false;
+      globalThis.openNextConfig.dangerous.disableIncrementalCache = false;
     });
     it("Should do nothing if disableIncrementalCache is true", async () => {
-      globalThis.disableIncrementalCache = true;
+      globalThis.openNextConfig.dangerous.disableIncrementalCache = true;
 
       await cache.revalidateTag("tag");
 
@@ -492,7 +497,7 @@ describe("CacheHandler", () => {
     });
 
     it("Should do nothing if disableTagCache is true", async () => {
-      globalThis.disableDynamoDBCache = true;
+      globalThis.openNextConfig.dangerous.disableTagCache = true;
 
       await cache.revalidateTag("tag");
 


### PR DESCRIPTION
@conico974 Actually, this might be a breaking change...
So maybe I should deprecate instead and add a changeset then we can remove later.
WDYT?