### PR TITLE
make sure edge function entries are properly awaited

### DIFF
--- a/.changeset/smart-carrots-build.md
+++ b/.changeset/smart-carrots-build.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: make sure edge function entries are properly awaited

--- a/packages/open-next/src/core/edgeFunctionHandler.ts
+++ b/packages/open-next/src/core/edgeFunctionHandler.ts
@@ -17,9 +17,9 @@ export default async function edgeFunctionHandler(
     throw new Error(`No route found for ${request.url}`);
   }
 
-  const result = await self._ENTRIES[
-    `middleware_${correspondingRoute.name}`
-  ].default({
+  const entry = await self._ENTRIES[`middleware_${correspondingRoute.name}`];
+
+  const result = await entry.default({
     page: correspondingRoute.page,
     request: {
       ...request,

--- a/packages/open-next/src/types/global.ts
+++ b/packages/open-next/src/types/global.ts
@@ -37,13 +37,15 @@ export interface RequestData {
   signal: AbortSignal;
 }
 
+interface Entry {
+  default: (props: { page: string; request: RequestData }) => Promise<{
+    response: Response;
+    waitUntil: Promise<void>;
+  }>;
+}
+
 interface Entries {
-  [k: string]: {
-    default: (props: { page: string; request: RequestData }) => Promise<{
-      response: Response;
-      waitUntil: Promise<void>;
-    }>;
-  };
+  [k: string]: Entry | Promise<Entry>;
 }
 
 export interface EdgeRoute {


### PR DESCRIPTION
the values in `self._ENTRIES` can be promises so they need to be awaited before using them, AFAICT that's also what Next.js  does: [source code](
https://github.com/vercel/next.js/blob/6d17cc6b0f3c153d2405ac97e862da2e9008258f/packages/next/src/server/web/sandbox/sandbox.ts#L119)

this PR makes sure that such values are properly awaited