### PR TITLE
add e2e test for top-level await in middleware

### DIFF
--- a/examples/app-pages-router/middleware.ts
+++ b/examples/app-pages-router/middleware.ts
@@ -1,6 +1,14 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
+// Needed to test top-level await
+// @ts-expect-error - It will cause a warning at build time, but it should just work
+const topLevelAwait = await new Promise<string>((resolve) => {
+  setTimeout(() => {
+    resolve("top-level-await");
+  }, 150);
+});
+
 export function middleware(request: NextRequest) {
   const path = request.nextUrl.pathname; //new URL(request.url).pathname;
 
@@ -19,6 +27,14 @@ export function middleware(request: NextRequest) {
   }
   if (path === "/api/middleware") {
     return new NextResponse(JSON.stringify({ hello: "middleware" }), {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  }
+  if (path === "/api/middlewareTopLevelAwait") {
+    return new NextResponse(JSON.stringify({ hello: topLevelAwait }), {
       status: 200,
       headers: {
         "content-type": "application/json",

--- a/examples/app-pages-router/middleware.ts
+++ b/examples/app-pages-router/middleware.ts
@@ -2,11 +2,13 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 // Needed to test top-level await
+// We are using `setTimeout` to simulate a "long" running operation
+// we could have used `Promise.resolve` instead, but it would be running in a different way in the event loop
 // @ts-expect-error - It will cause a warning at build time, but it should just work
 const topLevelAwait = await new Promise<string>((resolve) => {
   setTimeout(() => {
     resolve("top-level-await");
-  }, 150);
+  }, 10);
 });
 
 export function middleware(request: NextRequest) {

--- a/packages/tests-e2e/tests/appPagesRouter/api.test.ts
+++ b/packages/tests-e2e/tests/appPagesRouter/api.test.ts
@@ -27,3 +27,9 @@ test("API call from middleware", async ({ page }) => {
   el = page.getByText('API: { "hello": "middleware" }');
   await expect(el).toBeVisible();
 });
+
+test("API call from middleware with top-level await", async ({ request }) => {
+  const response = await request.get("/api/middlewareTopLevelAwait");
+  const data = await response.json();
+  expect(data).toEqual({ hello: "top-level-await" });
+});


### PR DESCRIPTION
This PR add test for #704
I've added a `@ts-expect-error` for the top level await, i didn't want to go down the rabbit hole of finding the issue here (middleware is somehow considered a cjs file and if set as a module, `next/server` import does not work anymore)
There is also a build time warning, but it still works both with `next start` or in the e2e test