### PR TITLE
fix: return when an error is downplayed

### DIFF
--- a/.changeset/orange-impalas-repeat.md
+++ b/.changeset/orange-impalas-repeat.md
@@ -2,4 +2,8 @@
 "@opennextjs/aws": patch
 ---
 
-Early return when an error gets downplayed
+fix: add early return for downplayed aws-sdk errors
+
+In the logger adapter:
+
+An issue was identified where downplayed errors from the aws-sdk client (f.ex NoSuchKey from S3) would not return from the function early. This caused unnecessary invocation of `console.error` outside the conditional.

--- a/.changeset/orange-impalas-repeat.md
+++ b/.changeset/orange-impalas-repeat.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Early return when an error gets downplayed

--- a/packages/open-next/src/adapters/logger.ts
+++ b/packages/open-next/src/adapters/logger.ts
@@ -44,7 +44,8 @@ export function error(...args: any[]) {
   // we try to catch errors from the aws-sdk client and downplay some of them
   if (args.some((arg) => isDownplayedErrorLog(arg))) {
     return debug(...args);
-  } else if (args.some((arg) => isOpenNextError(arg))) {
+  }
+  if (args.some((arg) => isOpenNextError(arg))) {
     // In case of an internal error, we log it with the appropriate log level
     const error = args.find((arg) => isOpenNextError(arg))!;
     if (error.logLevel < getOpenNextErrorLogLevel()) {

--- a/packages/open-next/src/adapters/logger.ts
+++ b/packages/open-next/src/adapters/logger.ts
@@ -43,7 +43,7 @@ const isDownplayedErrorLog = (errorLog: AwsSdkClientCommandErrorLog) =>
 export function error(...args: any[]) {
   // we try to catch errors from the aws-sdk client and downplay some of them
   if (args.some((arg) => isDownplayedErrorLog(arg))) {
-    debug(...args);
+    return debug(...args);
   } else if (args.some((arg) => isOpenNextError(arg))) {
     // In case of an internal error, we log it with the appropriate log level
     const error = args.find((arg) => isOpenNextError(arg))!;


### PR DESCRIPTION
People were reporting getting this error in SST Console: 
```Name: 'S3Client', commandName: 'GetObjectCommand', input: { Bucket: 'myapp-dev-myappassets-bvaaaaa', Key: '_cache/kbhQ5yYbaaaaaaaAa/dk.cache' }, error: NoSuchKey: The specified key does not exist.```

The error gets downplayed correctly but turns out we are not returning when an error is downplayed so this [line](https://github.com/opennextjs/opennextjs-aws/blob/9e770b53701e96f2007926b86450699696763bae/packages/open-next/src/adapters/logger.ts#L72) gets run aswell. This PR fixes this.