### PR TITLE
refactor: introduce a getPackagePath helper

### DIFF
--- a/packages/open-next/src/build/createAssets.ts
+++ b/packages/open-next/src/build/createAssets.ts
@@ -61,7 +61,7 @@ export function createCacheAssets(options: buildHelper.BuildOptions) {
   logger.info("Bundling cache assets...");
 
   const { appBuildOutputPath, outputDir } = options;
-  const packagePath = path.relative(options.monorepoRoot, appBuildOutputPath);
+  const packagePath = buildHelper.getPackagePath(options);
   const buildId = buildHelper.getBuildId(appBuildOutputPath);
   let useTagCache = false;
 

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -47,18 +47,14 @@ export async function createServerBundle(options: buildHelper.BuildOptions) {
 
   const remainingRoutes = new Set<string>();
 
-  const { appBuildOutputPath, monorepoRoot } = options;
-
-  const packagePath = path.relative(monorepoRoot, appBuildOutputPath);
+  const { appBuildOutputPath } = options;
 
   // Find remaining routes
   const serverPath = path.join(
     appBuildOutputPath,
-    ".next",
-    "standalone",
-    packagePath,
-    ".next",
-    "server",
+    ".next/standalone",
+    buildHelper.getPackagePath(options),
+    ".next/server",
   );
 
   // Find app dir routes
@@ -118,7 +114,7 @@ async function generateBundle(
   //       `node_modules` inside `.next/standalone`, and others inside
   //       `.next/standalone/package/path` (ie. `.next`, `server.js`).
   //       We need to output the handler file inside the package path.
-  const packagePath = path.relative(monorepoRoot, appBuildOutputPath);
+  const packagePath = buildHelper.getPackagePath(options);
   fs.mkdirSync(path.join(outputPath, packagePath), { recursive: true });
 
   const ext = fnOptions.runtime === "deno" ? "mjs" : "cjs";

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -389,3 +389,7 @@ export async function isEdgeRuntime(
   }
   return (await overrides?.wrapper?.())?.edgeRuntime;
 }
+
+export function getPackagePath(options: BuildOptions) {
+  return path.relative(options.monorepoRoot, options.appBuildOutputPath);
+}


### PR DESCRIPTION
Will also be needed for `@opennextjs/cloudflare`