### PR TITLE
refactor: getBuildId takes the BuildOptions

### DIFF
--- a/packages/open-next/src/build/createAssets.ts
+++ b/packages/open-next/src/build/createAssets.ts
@@ -62,7 +62,7 @@ export function createCacheAssets(options: buildHelper.BuildOptions) {
 
   const { appBuildOutputPath, outputDir } = options;
   const packagePath = buildHelper.getPackagePath(options);
-  const buildId = buildHelper.getBuildId(appBuildOutputPath);
+  const buildId = buildHelper.getBuildId(options);
   let useTagCache = false;
 
   // Copy pages to cache folder

--- a/packages/open-next/src/build/generateOutput.ts
+++ b/packages/open-next/src/build/generateOutput.ts
@@ -292,9 +292,7 @@ export async function generateOutput(options: BuildOptions) {
     const patterns = "patterns" in value ? value.patterns : ["*"];
     patterns.forEach((pattern) => {
       behaviors.push({
-        pattern: prefixer(
-          pattern.replace(/BUILD_ID/, getBuildId(appBuildOutputPath)),
-        ),
+        pattern: prefixer(pattern.replace(/BUILD_ID/, getBuildId(options))),
         origin: value.placement === "global" ? undefined : key,
         edgeFunction:
           value.placement === "global"

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -252,9 +252,12 @@ export function getHtmlPages(dotNextPath: string) {
     .reduce((acc, page) => acc.add(page), new Set<string>());
 }
 
-export function getBuildId(dotNextPath: string) {
+export function getBuildId(options: BuildOptions) {
   return fs
-    .readFileSync(path.join(dotNextPath, ".next/BUILD_ID"), "utf-8")
+    .readFileSync(
+      path.join(options.appBuildOutputPath, ".next/BUILD_ID"),
+      "utf-8",
+    )
     .trim();
 }
 


### PR DESCRIPTION
a bit simpler interface (as I'm introducing it in cf)