### PR TITLE
Dump ESBuild build metadata to `<bundle>.meta.json` in debug mode

### DIFF
--- a/.changeset/smooth-crabs-end.md
+++ b/.changeset/smooth-crabs-end.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Dump ESBuild build metadata to `<bundle>.meta.json` in debug mode

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -141,12 +141,15 @@ export async function esbuildAsync(
   options: BuildOptions,
 ) {
   const { openNextVersion, debug, minify } = options;
+  // Dump ESBuild build metadata to file in debug mode
+  const metafile = debug && esbuildOptions.outfile !== undefined;
   const result = await buildAsync({
     target: "esnext",
     format: "esm",
     platform: "node",
     bundle: true,
     minify,
+    metafile,
     mainFields: ["module", "main"],
     sourcemap: debug ? "inline" : false,
     sourcesContent: false,
@@ -173,6 +176,11 @@ export async function esbuildAsync(
         (esbuildOptions.entryPoints as string[])[0]
       }.`,
     );
+  }
+
+  if (result.metafile) {
+    const metaFile = `${esbuildOptions.outfile}.meta.json`;
+    fs.writeFileSync(metaFile, JSON.stringify(result.metafile, null, 2));
   }
 }
 


### PR DESCRIPTION
fixes #714

Tested in opennext-cloudflare, works nicely
