### PR TITLE
update external rewrite destination in pages-router

### DIFF
--- a/examples/pages-router/next.config.ts
+++ b/examples/pages-router/next.config.ts
@@ -40,7 +40,8 @@ const nextConfig: NextConfig = {
     },
     {
       source: "/external-on-image",
-      destination: "https://opennext.js.org/share.png",
+      destination:
+        "https://raw.githubusercontent.com/opennextjs/docs/refs/heads/main/public/share.png",
     },
   ],
   redirects: async () => [


### PR DESCRIPTION
the current url used for the pages-router external rewrite (https://opennext.js.org/share.png) errors when being fetched from a Cloudflare worker, the error being:
![Screenshot 2025-02-03 at 16 21 51](https://github.com/user-attachments/assets/18b0368c-45ef-4c8e-9db1-4f625e5631e1)

To solve that the url has been updated to a github link (https://raw.githubusercontent.com/opennextjs/docs/refs/heads/main/public/share.png) which points to the same exact image

___

I had to make this change in the Cloudflare repo and I am replicating the same change here to keep our tests in sync, see: [original conversation](https://github.com/opennextjs/opennextjs-cloudflare/pull/332#discussion_r1939749127)