### PR TITLE
fix: remove `cf-connecting-ip` headers from external override requests

### DIFF
--- a/.changeset/new-beers-worry.md
+++ b/.changeset/new-beers-worry.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: remove `cf-connecting-header` headers from external override requests
+
+this change removes `cf-connecting-header` headers from requests being sent to
+external urls during rewrites, this allows such overrides, when run inside a
+Cloudflare worker to rewrite to urls also hosted on Cloudflare

--- a/.changeset/new-beers-worry.md
+++ b/.changeset/new-beers-worry.md
@@ -2,8 +2,8 @@
 "@opennextjs/aws": patch
 ---
 
-fix: remove `cf-connecting-header` headers from external override requests
+fix: remove `cf-connecting-ip` headers from external override requests
 
-this change removes `cf-connecting-header` headers from requests being sent to
+this change removes `cf-connecting-ip` headers from requests being sent to
 external urls during rewrites, this allows such overrides, when run inside a
 Cloudflare worker to rewrite to urls also hosted on Cloudflare

--- a/packages/open-next/src/overrides/proxyExternalRequest/fetch.ts
+++ b/packages/open-next/src/overrides/proxyExternalRequest/fetch.ts
@@ -5,7 +5,14 @@ const fetchProxy: ProxyExternalRequest = {
   name: "fetch-proxy",
   // @ts-ignore
   proxy: async (internalEvent) => {
-    const { url, headers, method, body } = internalEvent;
+    const { url, headers: eventHeaders, method, body } = internalEvent;
+
+    const headers = Object.fromEntries(
+      Object.entries(eventHeaders).filter(
+        ([key]) => key.toLowerCase() !== "cf-connecting-ip",
+      ),
+    );
+
     const response = await fetch(url, {
       method,
       headers,

--- a/packages/tests-unit/tests/overrides/proxyExternalRequest/fetch.test.ts
+++ b/packages/tests-unit/tests/overrides/proxyExternalRequest/fetch.test.ts
@@ -1,0 +1,39 @@
+import fetchProxy from "@opennextjs/aws/overrides/proxyExternalRequest/fetch.js";
+import { vi } from "vitest";
+
+describe("proxyExternalRequest/fetch", () => {
+  // Note: if the url is hosted on the Cloudflare network we want to make sure that a `cf-connecting-ip` header is not being sent as that causes a DNS error
+  //       (see: https://developers.cloudflare.com/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-1xxx-errors/#error-1000-dns-points-to-prohibited-ip)
+  it("the proxy should remove any cf-connecting-ip headers (with any casing) before passing it to fetch", async () => {
+    const fetchMock = vi.fn<typeof global.fetch>(async () => new Response());
+    globalThis.fetch = fetchMock;
+
+    const { proxy } = fetchProxy;
+
+    await proxy({
+      headers: {
+        "header-1": "valid header 1",
+        "header-2": "valid header 2",
+        "cf-connecting-ip": "forbidden header 1",
+        "header-3": "valid header 3",
+        "CF-Connecting-IP": "forbidden header 2",
+        "CF-CONNECTING-IP": "forbidden header 3",
+        "header-4": "valid header 4",
+      },
+    });
+
+    expect(fetchMock.mock.calls.length).toEqual(1);
+
+    const headersPassedToFetch = Object.keys(
+      fetchMock.mock.calls[0][1]?.headers ?? {},
+    );
+
+    expect(headersPassedToFetch).toContain("header-1");
+    expect(headersPassedToFetch).toContain("header-2");
+    expect(headersPassedToFetch).not.toContain("cf-connecting-ip");
+    expect(headersPassedToFetch).toContain("header-3");
+    expect(headersPassedToFetch).not.toContain("CF-Connecting-IP");
+    expect(headersPassedToFetch).not.toContain("CF-CONNECTING-IP");
+    expect(headersPassedToFetch).toContain("header-4");
+  });
+});


### PR DESCRIPTION
this change removes `cf-connecting-header` headers from requests being sent to external urls during rewrites, this allows such overrides, when run inside a Cloudflare worker to rewrite to urls also hosted on Cloudflare

_____

With this change the [`Rewrite to external image` test](
 https://github.com/opennextjs/opennextjs-aws/blob/main/packages/tests-e2e/tests/pagesRouter/rewrite.test.ts#L20-L25) passes when run in the Cloudflare repo

_____

Original conversation: https://github.com/opennextjs/opennextjs-aws/pull/723#pullrequestreview-2590722699