### PR TITLE
allow `null` to be returned as an incremental cache get result

### DIFF
--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -132,6 +132,8 @@ export default class Cache {
     try {
       const cachedEntry = await globalThis.incrementalCache.get(key, true);
 
+      if (cachedEntry?.value === undefined) return null;
+
       const _lastModified = await globalThis.tagCache.getLastModified(
         key,
         cachedEntry?.lastModified,
@@ -140,8 +142,6 @@ export default class Cache {
         // If some tags are stale we need to force revalidation
         return null;
       }
-
-      if (cachedEntry?.value === undefined) return null;
 
       // For cases where we don't have tags, we need to ensure that the soft tags are not being revalidated
       // We only need to check for the path as it should already contain all the tags
@@ -180,7 +180,11 @@ export default class Cache {
     try {
       const cachedEntry = await globalThis.incrementalCache.get(key, false);
 
-      const meta = cachedEntry?.value?.meta;
+      if (!cachedEntry?.value) {
+        return null;
+      }
+
+      const meta = cachedEntry.value.meta;
       const _lastModified = await globalThis.tagCache.getLastModified(
         key,
         cachedEntry?.lastModified,

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -130,21 +130,18 @@ export default class Cache {
   async getFetchCache(key: string, softTags?: string[], tags?: string[]) {
     debug("get fetch cache", { key, softTags, tags });
     try {
-      const { value, lastModified } = await globalThis.incrementalCache.get(
-        key,
-        true,
-      );
+      const cachedEntry = await globalThis.incrementalCache.get(key, true);
 
       const _lastModified = await globalThis.tagCache.getLastModified(
         key,
-        lastModified,
+        cachedEntry?.lastModified,
       );
       if (_lastModified === -1) {
         // If some tags are stale we need to force revalidation
         return null;
       }
 
-      if (value === undefined) return null;
+      if (cachedEntry?.value === undefined) return null;
 
       // For cases where we don't have tags, we need to ensure that the soft tags are not being revalidated
       // We only need to check for the path as it should already contain all the tags
@@ -159,7 +156,7 @@ export default class Cache {
         if (path) {
           const pathLastModified = await globalThis.tagCache.getLastModified(
             path.replace("_N_T_/", ""),
-            lastModified,
+            cachedEntry.lastModified,
           );
           if (pathLastModified === -1) {
             // In case the path has been revalidated, we don't want to use the fetch cache
@@ -170,7 +167,7 @@ export default class Cache {
 
       return {
         lastModified: _lastModified,
-        value: value,
+        value: cachedEntry.value,
       } as CacheHandlerValue;
     } catch (e) {
       // We can usually ignore errors here as they are usually due to cache not being found
@@ -181,18 +178,18 @@ export default class Cache {
 
   async getIncrementalCache(key: string): Promise<CacheHandlerValue | null> {
     try {
-      const { value: cacheData, lastModified } =
-        await globalThis.incrementalCache.get(key, false);
+      const cachedEntry = await globalThis.incrementalCache.get(key, false);
 
-      const meta = cacheData?.meta;
+      const meta = cachedEntry?.value?.meta;
       const _lastModified = await globalThis.tagCache.getLastModified(
         key,
-        lastModified,
+        cachedEntry?.lastModified,
       );
       if (_lastModified === -1) {
         // If some tags are stale we need to force revalidation
         return null;
       }
+      const cacheData = cachedEntry?.value;
       const requestId = globalThis.__openNextAls.getStore()?.requestId ?? "";
       globalThis.lastModified[requestId] = _lastModified;
       if (cacheData?.type === "route") {

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -157,7 +157,7 @@ export async function cacheInterceptor(
     try {
       const cachedData = await globalThis.incrementalCache.get(localizedPath);
       debug("cached data in interceptor", cachedData);
-      if (cachedData.value?.type === "app") {
+      if (cachedData?.value?.type === "app") {
         // We need to check the tag cache now
         const _lastModified = await globalThis.tagCache.getLastModified(
           localizedPath,
@@ -169,7 +169,7 @@ export async function cacheInterceptor(
         }
       }
       const host = event.headers.host;
-      switch (cachedData.value?.type) {
+      switch (cachedData?.value?.type) {
         case "app":
         case "page":
           return generateResult(

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -157,6 +157,11 @@ export async function cacheInterceptor(
     try {
       const cachedData = await globalThis.incrementalCache.get(localizedPath);
       debug("cached data in interceptor", cachedData);
+
+      if (!cachedData?.value) {
+        return event;
+      }
+
       if (cachedData?.value?.type === "app") {
         // We need to check the tag cache now
         const _lastModified = await globalThis.tagCache.getLastModified(

--- a/packages/open-next/src/overrides/incrementalCache/multi-tier-ddb-s3.ts
+++ b/packages/open-next/src/overrides/incrementalCache/multi-tier-ddb-s3.ts
@@ -92,7 +92,7 @@ const multiTierCache: IncrementalCache = {
       }
     }
     const result = await S3Cache.get(key, isFetch);
-    if (result.value) {
+    if (result?.value) {
       localCache.set(key, {
         value: result.value,
         lastModified: result.lastModified ?? Date.now(),

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -69,7 +69,7 @@ export type IncrementalCache = {
   get<IsFetch extends boolean = false>(
     key: string,
     isFetch?: IsFetch,
-  ): Promise<WithLastModified<CacheValue<IsFetch>>>;
+  ): Promise<WithLastModified<CacheValue<IsFetch>> | null>;
   set<IsFetch extends boolean = false>(
     key: string,
     value: CacheValue<IsFetch>,


### PR DESCRIPTION
Very minor but I think it would be nice if we could return `null` as the incremental cache `get` result instead of being forced to return an empty object:
https://github.com/opennextjs/opennextjs-cloudflare/blob/642c3d2e654ef830b7957faecb1cbe26bae469ed/packages/cloudflare/src/api/kvCache.ts#L46