### PR TITLE
fix: make `patchAsyncStorage` work with non-mutable `node:module` modules

### DIFF
--- a/.changeset/seven-mirrors-sleep.md
+++ b/.changeset/seven-mirrors-sleep.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: make `patchAsyncStorage` work with non-mutable `node:module` modules

--- a/packages/open-next/src/core/patchAsyncStorage.ts
+++ b/packages/open-next/src/core/patchAsyncStorage.ts
@@ -1,9 +1,9 @@
-const mod = require("node:module");
+let mod = require("node:module");
 
 const resolveFilename = mod._resolveFilename;
 
 export function patchAsyncStorage() {
-  mod._resolveFilename = ((
+  const _resolveFilename = ((
     originalResolveFilename: typeof resolveFilename,
     request: string,
     parent: any,
@@ -29,4 +29,8 @@ export function patchAsyncStorage() {
 
     // We use `bind` here to avoid referencing outside variables to create potential memory leaks.
   }).bind(null, resolveFilename);
+  mod = {
+    ...mod,
+    _resolveFilename,
+  };
 }


### PR DESCRIPTION
This change allows `patchAsyncStorage` to work with the cloudflare adapter allowing us to get rid of the [code that comments the function out](
https://github.com/opennextjs/opennextjs-cloudflare/blob/6a3e35e3f79ad10607ae0acc7f88dbe9a89e8d6f/packages/cloudflare/src/cli/build/bundle-server.ts#L202-L208)

The problem with the current patch is that it updates `mod._resolveFilename` which doesn't work in the cloudflare adapter since the worker gets build by esbuild making the exports of the module (which we polyfill using unenv) non-settable:
![Screenshot 2025-02-07 at 17 46 41](https://github.com/user-attachments/assets/67bb193f-3caf-4cf2-8bbd-8b1b0df72cfc)

> [!WARNING]
> __Disclamer__: I did test the Cloudflare adapter with this change and this does allow us to use `patchAsyncStorage` without getting the runtime error anymore, I could however not see any other difference in the app I tested this with (the `app-router` app), if anyone would have suggestions on how/if I can check some effects that the patch has that would be very much appreciated 🙏 
