### PR TITLE
fix: add correct typing to tagCache in initializationFunction

### DIFF
--- a/.changeset/stale-walls-sin.md
+++ b/.changeset/stale-walls-sin.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: tagCache in initializationFunction
+
+Add correct typing to tagCache in initializationFunction and also adds it to the `overrides` in `compileTagCacheProvider` function.

--- a/packages/open-next/src/build/compileTagCacheProvider.ts
+++ b/packages/open-next/src/build/compileTagCacheProvider.ts
@@ -25,6 +25,7 @@ export async function compileTagCacheProvider(
           overrides: {
             converter: overrides?.converter ?? "dummy",
             wrapper: overrides?.wrapper,
+            tagCache: options.config.initializationFunction?.tagCache,
           },
         }),
       ],

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -404,7 +404,7 @@ export interface OpenNextConfig {
    * Supports only node runtime
    */
   initializationFunction?: DefaultFunctionOptions & {
-    tagCache?: "dynamodb" | LazyLoadedOverride<TagCache>;
+    tagCache?: IncludedTagCache | LazyLoadedOverride<TagCache>;
   };
 
   /**


### PR DESCRIPTION
Turns out we didn't have the correct typing for `tagCache` in `initializationFunction`. We also didn't provide the override to `compileTagCacheProvider`. 