### PR TITLE
Update package.json exports for types imports

### DIFF
--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -22,13 +22,6 @@
       "types": "./dist/*.d.ts"
     }
   },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "dist/*"
-      ]
-    }
-  },
   "keywords": [],
   "author": "",
   "files": [

--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -17,7 +17,8 @@
     "dev": "tsc -w"
   },
   "exports": {
-    "./*": "./dist/*"
+    "default": "./dist/*",
+    "types": "./dist/*.d.ts"
   },
   "typesVersions": {
     "*": {

--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -17,8 +17,10 @@
     "dev": "tsc -w"
   },
   "exports": {
-    "default": "./dist/*",
-    "types": "./dist/*.d.ts"
+    "./*": {
+      "default": "./dist/*",
+      "types": "./dist/*.d.ts"
+    }
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
Updates the `package.json` `exports` field to split into `default` and `types` to fix issue with TypeScript being unable to reference types such as:
```ts
import type { OpenNextConfig } from "open-next/types/open-next";
```
Error message: `Cannot find module 'open-next/types/open-next' or its corresponding type declarations. ts(2307)`