### PR TITLE
return meta files from createAssets()

### DIFF
--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -22,6 +22,13 @@
       "types": "./dist/*.d.ts"
     }
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
   "keywords": [],
   "author": "",
   "files": [

--- a/packages/open-next/src/build/createAssets.ts
+++ b/packages/open-next/src/build/createAssets.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import logger from "../logger.js";
-import type { TagCacheMetaFile } from "../types/open-next.js";
+import type { TagCacheMetaFile } from "../types/cache.js";
 import { isBinaryContentType } from "../utils/binary.js";
 import * as buildHelper from "./helper.js";
 
@@ -56,7 +56,7 @@ export function createStaticAssets(options: buildHelper.BuildOptions) {
  * Create the cache assets.
  *
  * @param options Build options.
- * @returns Whether tag cache is used.
+ * @returns Whether the tag cache is used, and the meta files collected.
  */
 export function createCacheAssets(options: buildHelper.BuildOptions) {
   logger.info("Bundling cache assets...");

--- a/packages/open-next/src/build/createAssets.ts
+++ b/packages/open-next/src/build/createAssets.ts
@@ -244,5 +244,5 @@ export function createCacheAssets(options: buildHelper.BuildOptions) {
     ({ relativePath }) => !relativePath.endsWith(".cache"),
   );
 
-  return { useTagCache };
+  return { useTagCache, metaFiles };
 }

--- a/packages/open-next/src/build/createAssets.ts
+++ b/packages/open-next/src/build/createAssets.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import logger from "../logger.js";
+import type { TagCacheMetaFile } from "../types/open-next.js";
 import { isBinaryContentType } from "../utils/binary.js";
 import * as buildHelper from "./helper.js";
 
@@ -157,11 +158,7 @@ export function createCacheAssets(options: buildHelper.BuildOptions) {
   });
 
   // We need to traverse the cache to find every .meta file
-  const metaFiles: {
-    tag: { S: string };
-    path: { S: string };
-    revalidatedAt: { N: string };
-  }[] = [];
+  const metaFiles: TagCacheMetaFile[] = [];
 
   // Copy fetch-cache to cache folder
   const fetchCachePath = path.join(

--- a/packages/open-next/src/types/cache.ts
+++ b/packages/open-next/src/types/cache.ts
@@ -75,3 +75,9 @@ export interface Meta {
   headers?: Record<string, undefined | string | string[]>;
   postponed?: string;
 }
+
+export type TagCacheMetaFile = {
+  tag: { S: string };
+  path: { S: string };
+  revalidatedAt: { N: string };
+};

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -447,9 +447,3 @@ export interface OpenNextConfig {
    */
   edgeExternals?: string[];
 }
-
-export type TagCacheMetaFile = {
-  tag: { S: string };
-  path: { S: string };
-  revalidatedAt: { N: string };
-};

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -447,3 +447,9 @@ export interface OpenNextConfig {
    */
   edgeExternals?: string[];
 }
+
+export type TagCacheMetaFile = {
+  tag: { S: string };
+  path: { S: string };
+  revalidatedAt: { N: string };
+};


### PR DESCRIPTION
I want to re-use the value instead of importing the generated file.

I also had to add back the `typesVersions` that was removed in https://github.com/opennextjs/opennextjs-aws/pull/747 as it broke builds and imports for the cloudflare adapter.

<img width="740" alt="image" src="https://github.com/user-attachments/assets/d410ed08-25dc-4e73-bb71-efc03cbd58fa" />
<img width="833" alt="image" src="https://github.com/user-attachments/assets/51ac79ee-0706-4885-9d56-3414cd6962dc" />
