### PR TITLE
Relax the type of OpenNextConfig.middleware.external

### DIFF
--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -343,8 +343,8 @@ export interface OpenNextConfig {
    * @default undefined
    */
   middleware?: DefaultFunctionOptions & {
-    //We force the middleware to be a function
-    external: true;
+    // Force the middleware to be a function when `true` (default to `false`)
+    external?: boolean;
 
     /**
      * The override options for the middleware.


### PR DESCRIPTION
minor change but there should be not real reason to force this to be true?