### PR TITLE
add: s3-lite override for imageLoader

### DIFF
--- a/.changeset/lucky-horses-worry.md
+++ b/.changeset/lucky-horses-worry.md
@@ -1,0 +1,19 @@
+---
+"@opennextjs/aws": patch
+---
+
+add: s3 lite override for loading images in the image optimization server
+
+`s3-lite` override for image loading. Uses `aws4fetch` to get the objects from your s3 bucket. This will make the image optimization server work without the aws s3 sdk. Important to note that a new environment variable is required on the image optimization server for this override to work: `BUCKET_REGION`.
+
+```ts
+import type { OpenNextConfig } from '@opennextjs/aws/types/open-next';
+const config = {
+  default: {},
+   imageOptimization: {
+     loader: 's3-lite', // make sure you have the required env variables defined
+   },
+} satisfies OpenNextConfig;
+
+export default config;
+```

--- a/.changeset/lucky-horses-worry.md
+++ b/.changeset/lucky-horses-worry.md
@@ -4,7 +4,7 @@
 
 add: s3 lite override for loading images in the image optimization server
 
-`s3-lite` override for image loading. Uses `aws4fetch` to get the objects from your s3 bucket. This will make the image optimization server work without the aws s3 sdk. This override introduces a new environment variable called `BUCKET_REGION`. It will fallback to `AWS_DEFAULT_REGION` if undefined. This will require no additional change in IAC for most users.
+`s3-lite` override for image loading. Uses `aws4fetch` to get the objects from your s3 bucket. This will make the image optimization server work without the aws s3 sdk. This override introduces a new environment variable called `BUCKET_REGION`. It will fallback to `AWS_REGION` ?? `AWS_DEFAULT_REGION` if undefined. This will require no additional change in IAC for most users.
 
 ```ts
 import type { OpenNextConfig } from '@opennextjs/aws/types/open-next';

--- a/.changeset/lucky-horses-worry.md
+++ b/.changeset/lucky-horses-worry.md
@@ -4,14 +4,14 @@
 
 add: s3 lite override for loading images in the image optimization server
 
-`s3-lite` override for image loading. Uses `aws4fetch` to get the objects from your s3 bucket. This will make the image optimization server work without the aws s3 sdk. Important to note that a new environment variable is required on the image optimization server for this override to work: `BUCKET_REGION`.
+`s3-lite` override for image loading. Uses `aws4fetch` to get the objects from your s3 bucket. This will make the image optimization server work without the aws s3 sdk. This override introduces a new environment variable called `BUCKET_REGION`. It will fallback to `AWS_DEFAULT_REGION` if undefined. This will require no additional change in IAC for most users.
 
 ```ts
 import type { OpenNextConfig } from '@opennextjs/aws/types/open-next';
 const config = {
   default: {},
    imageOptimization: {
-     loader: 's3-lite', // make sure you have the required env variables defined
+     loader: 's3-lite', 
    },
 } satisfies OpenNextConfig;
 

--- a/packages/open-next/src/build/createImageOptimizationBundle.ts
+++ b/packages/open-next/src/build/createImageOptimizationBundle.ts
@@ -89,6 +89,7 @@ export async function createImageOptimizationBundle(
           "const require = topLevelCreateRequire(import.meta.url);",
           "import bannerUrl from 'url';",
           "const __dirname = bannerUrl.fileURLToPath(new URL('.', import.meta.url));",
+          "globalThis.internalFetch = fetch;",
         ].join("\n"),
       },
     },

--- a/packages/open-next/src/build/createImageOptimizationBundle.ts
+++ b/packages/open-next/src/build/createImageOptimizationBundle.ts
@@ -89,7 +89,6 @@ export async function createImageOptimizationBundle(
           "const require = topLevelCreateRequire(import.meta.url);",
           "import bannerUrl from 'url';",
           "const __dirname = bannerUrl.fileURLToPath(new URL('.', import.meta.url));",
-          "globalThis.internalFetch = fetch;",
         ].join("\n"),
       },
     },

--- a/packages/open-next/src/overrides/imageLoader/s3-lite.ts
+++ b/packages/open-next/src/overrides/imageLoader/s3-lite.ts
@@ -1,0 +1,69 @@
+import { AwsClient } from "aws4fetch";
+import { Readable } from "node:stream";
+import type { ReadableStream } from "node:stream/web";
+
+import type { ImageLoader } from "types/overrides";
+import { FatalError } from "utils/error";
+import { customFetchClient } from "utils/fetch";
+
+
+let awsClient: AwsClient | null = null;
+
+const getAwsClient = () => {
+  if (awsClient) {
+    return awsClient;
+  }
+  awsClient = new AwsClient({
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+    sessionToken: process.env.AWS_SESSION_TOKEN,
+    region: process.env.BUCKET_REGION,
+  });
+  return awsClient;
+};
+
+const { BUCKET_NAME, BUCKET_KEY_PREFIX, BUCKET_REGION } = process.env;
+
+function ensureEnvExists() {
+  if (!BUCKET_NAME || !BUCKET_REGION || BUCKET_KEY_PREFIX) {
+    throw new Error("Bucket name, region and key prefix must be defined!");
+  }
+}
+
+const awsFetch = async (key: string, options: RequestInit) => {
+  const client = getAwsClient();
+  const url = `https://${BUCKET_NAME}.s3.${BUCKET_REGION}.amazonaws.com/${key}`;
+  return customFetchClient(client)(url, options);
+};
+
+
+const s3Loader: ImageLoader = {
+  name: "s3",
+  load: async (key: string) => {
+    ensureEnvExists();
+    const keyPrefix = BUCKET_KEY_PREFIX?.replace(/^\/|\/$/g, "");
+    const response = await awsFetch(
+     keyPrefix
+          ? `${keyPrefix}/${key.replace(/^\//, "")}`
+          : key.replace(/^\//, ""),
+      {
+        method: "GET",
+      },
+    );
+
+    if (!response.body) {
+      throw new FatalError("No body in aws4fetch s3 response");
+    }
+
+    // We need to cast it else there will be a TypeError: o.pipe is not a function
+    const body = Readable.fromWeb(response.body as ReadableStream<Uint8Array>);
+
+    return {
+      body: body,
+      contentType: response.headers.get("content-type") ?? undefined,
+      cacheControl: response.headers.get("cache-control") ?? undefined,
+    };
+  },
+};
+
+export default s3Loader;

--- a/packages/open-next/src/overrides/imageLoader/s3-lite.ts
+++ b/packages/open-next/src/overrides/imageLoader/s3-lite.ts
@@ -8,8 +8,12 @@ import { FatalError, IgnorableError, RecoverableError } from "utils/error";
 let awsClient: AwsClient | null = null;
 
 const { BUCKET_NAME, BUCKET_KEY_PREFIX } = process.env;
+// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
+// If AWS_REGION is defined it will override AWS_DEFAULT_REGION
 const BUCKET_REGION =
-  process.env.BUCKET_REGION ?? process.env.AWS_DEFAULT_REGION;
+  process.env.BUCKET_REGION ??
+  process.env.AWS_REGION ??
+  process.env.AWS_DEFAULT_REGION;
 
 const getAwsClient = () => {
   if (awsClient) {

--- a/packages/open-next/src/overrides/imageLoader/s3-lite.ts
+++ b/packages/open-next/src/overrides/imageLoader/s3-lite.ts
@@ -24,7 +24,7 @@ const getAwsClient = () => {
 const { BUCKET_NAME, BUCKET_KEY_PREFIX, BUCKET_REGION } = process.env;
 
 function ensureEnvExists() {
-  if (!BUCKET_NAME || !BUCKET_REGION || BUCKET_KEY_PREFIX) {
+  if (!(BUCKET_NAME || BUCKET_REGION || BUCKET_KEY_PREFIX)) {
     throw new Error("Bucket name, region and key prefix must be defined!");
   }
 }

--- a/packages/open-next/src/overrides/imageLoader/s3-lite.ts
+++ b/packages/open-next/src/overrides/imageLoader/s3-lite.ts
@@ -1,11 +1,10 @@
-import { AwsClient } from "aws4fetch";
 import { Readable } from "node:stream";
 import type { ReadableStream } from "node:stream/web";
+import { AwsClient } from "aws4fetch";
 
 import type { ImageLoader } from "types/overrides";
 import { FatalError } from "utils/error";
 import { customFetchClient } from "utils/fetch";
-
 
 let awsClient: AwsClient | null = null;
 
@@ -36,16 +35,15 @@ const awsFetch = async (key: string, options: RequestInit) => {
   return customFetchClient(client)(url, options);
 };
 
-
 const s3Loader: ImageLoader = {
   name: "s3",
   load: async (key: string) => {
     ensureEnvExists();
     const keyPrefix = BUCKET_KEY_PREFIX?.replace(/^\/|\/$/g, "");
     const response = await awsFetch(
-     keyPrefix
-          ? `${keyPrefix}/${key.replace(/^\//, "")}`
-          : key.replace(/^\//, ""),
+      keyPrefix
+        ? `${keyPrefix}/${key.replace(/^\//, "")}`
+        : key.replace(/^\//, ""),
       {
         method: "GET",
       },

--- a/packages/open-next/src/overrides/imageLoader/s3-lite.ts
+++ b/packages/open-next/src/overrides/imageLoader/s3-lite.ts
@@ -3,7 +3,7 @@ import type { ReadableStream } from "node:stream/web";
 import { AwsClient } from "aws4fetch";
 
 import type { ImageLoader } from "types/overrides";
-import { FatalError, IgnorableError, RecoverableError } from "utils/error";
+import { FatalError } from "utils/error";
 
 let awsClient: AwsClient | null = null;
 
@@ -55,10 +55,10 @@ const s3Loader: ImageLoader = {
     );
 
     if (response.status === 404) {
-      throw new IgnorableError("The specified key does not exist.");
+      throw new FatalError("The specified key does not exist.");
     }
     if (response.status !== 200) {
-      throw new RecoverableError(
+      throw new FatalError(
         `Failed to get image. Status code: ${response.status}`,
       );
     }

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -151,7 +151,12 @@ export type IncludedTagCache =
   | "fs-dev"
   | "dummy";
 
-export type IncludedImageLoader = "s3" | "host" | "fs-dev" | "dummy";
+export type IncludedImageLoader =
+  | "s3"
+  | "s3-lite"
+  | "host"
+  | "fs-dev"
+  | "dummy";
 
 export type IncludedOriginResolver = "pattern-env" | "dummy";
 


### PR DESCRIPTION
- Uses `aws4fetch`
- New env variable `BUCKET_REGION`. Falls back to `AWS_REGION` ?? `AWS_DEFAULT_REGION` if undefined. This way no change in IAC is needed for most users. 

Add an `open-next.config.ts` with these options: 
```ts
import type { OpenNextConfig } from '@opennextjs/aws/types/open-next';
const config = {
  default: {},
   imageOptimization: {
     loader: 's3-lite',
   },
} satisfies OpenNextConfig;

export default config;
```