### PR TITLE
refactor: internalEvent.url is a full URL

### DIFF
--- a/.changeset/smooth-laws-pull.md
+++ b/.changeset/smooth-laws-pull.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/aws": patch
+---
+
+`InternalEvent#url` is now a full URL
+
+BREAKING CHANGE: `InternalEvent#url` was only composed of the path and search query before.
+
+Custom converters should be updated to populate the full URL instead.

--- a/packages/open-next/src/adapters/edge-adapter.ts
+++ b/packages/open-next/src/adapters/edge-adapter.ts
@@ -8,10 +8,7 @@ import type { OpenNextHandlerOptions } from "types/overrides";
 // We import it like that so that the edge plugin can replace it
 import { NextConfig } from "../adapters/config";
 import { createGenericHandler } from "../core/createGenericHandler";
-import {
-  convertBodyToReadableStream,
-  convertToQueryString,
-} from "../core/routing/util";
+import { convertBodyToReadableStream } from "../core/routing/util";
 
 globalThis.__openNextAls = new AsyncLocalStorage();
 
@@ -25,13 +22,6 @@ const defaultHandler = async (
   return runWithOpenNextRequestContext(
     { isISRRevalidation: false, waitUntil: options?.waitUntil },
     async () => {
-      const host = internalEvent.headers.host
-        ? `https://${internalEvent.headers.host}`
-        : "http://localhost:3000";
-      const initialUrl = new URL(internalEvent.rawPath, host);
-      initialUrl.search = convertToQueryString(internalEvent.query);
-      const url = initialUrl.toString();
-
       // @ts-expect-error - This is bundled
       const handler = await import("./middleware.mjs");
 
@@ -43,7 +33,7 @@ const defaultHandler = async (
           i18n: NextConfig.i18n,
           trailingSlash: NextConfig.trailingSlash,
         },
-        url,
+        url: internalEvent.url,
         body: convertBodyToReadableStream(
           internalEvent.method,
           internalEvent.body,

--- a/packages/open-next/src/adapters/middleware.ts
+++ b/packages/open-next/src/adapters/middleware.ts
@@ -15,6 +15,7 @@ import {
   resolveQueue,
   resolveTagCache,
 } from "../core/resolve";
+import { constructNextUrl } from "../core/routing/util";
 import routingHandler, {
   INTERNAL_HEADER_INITIAL_PATH,
   INTERNAL_HEADER_RESOLVED_ROUTES,
@@ -90,7 +91,7 @@ const defaultHandler = async (
             internalEvent: {
               ...result.internalEvent,
               rawPath: "/500",
-              url: new URL("/500", new URL(result.internalEvent.url)).href,
+              url: constructNextUrl(result.internalEvent.url, "/500"),
               method: "GET",
             },
             // On error we need to rewrite to the 500 page which is an internal rewrite

--- a/packages/open-next/src/adapters/middleware.ts
+++ b/packages/open-next/src/adapters/middleware.ts
@@ -90,7 +90,7 @@ const defaultHandler = async (
             internalEvent: {
               ...result.internalEvent,
               rawPath: "/500",
-              url: "/500",
+              url: new URL("/500", new URL(result.internalEvent.url)).href,
               method: "GET",
             },
             // On error we need to rewrite to the 500 page which is an internal rewrite

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -102,7 +102,7 @@ export async function openNextHandler(
               rawPath: "/500",
               method: "GET",
               headers: {},
-              url: "/500",
+              url: new URL("/500", new URL(internalEvent.url)).href,
               query: {},
               cookies: {},
               remoteAddress: "",
@@ -146,12 +146,13 @@ export async function openNextHandler(
 
       const preprocessedEvent = routingResult.internalEvent;
       debug("preprocessedEvent", preprocessedEvent);
+      const { search, pathname, hash } = new URL(preprocessedEvent.url);
       const reqProps = {
         method: preprocessedEvent.method,
-        url: preprocessedEvent.url,
+        url: `${pathname}${search}${hash}`,
         //WORKAROUND: We pass this header to the serverless function to mimic a prefetch request which will not trigger revalidation since we handle revalidation differently
         // There is 3 way we can handle revalidation:
-        // 1. We could just let the revalidation go as normal, but due to race condtions the revalidation will be unreliable
+        // 1. We could just let the revalidation go as normal, but due to race conditions the revalidation will be unreliable
         // 2. We could alter the lastModified time of our cache to make next believe that the cache is fresh, but this could cause issues with stale data since the cdn will cache the stale data as if it was fresh
         // 3. OUR CHOICE: We could pass a purpose prefetch header to the serverless function to make next believe that the request is a prefetch request and not trigger revalidation (This could potentially break in the future if next changes the behavior of prefetch requests)
         headers: { ...headers, purpose: "prefetch" },

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -13,7 +13,11 @@ import { runWithOpenNextRequestContext } from "utils/promise";
 import type { OpenNextHandlerOptions } from "types/overrides";
 import { debug, error, warn } from "../adapters/logger";
 import { patchAsyncStorage } from "./patchAsyncStorage";
-import { convertRes, createServerResponse } from "./routing/util";
+import {
+  constructNextUrl,
+  convertRes,
+  createServerResponse,
+} from "./routing/util";
 import routingHandler, {
   INTERNAL_HEADER_INITIAL_PATH,
   INTERNAL_HEADER_RESOLVED_ROUTES,
@@ -102,7 +106,7 @@ export async function openNextHandler(
               rawPath: "/500",
               method: "GET",
               headers: {},
-              url: new URL("/500", new URL(internalEvent.url)).href,
+              url: constructNextUrl(internalEvent.url, "/500"),
               query: {},
               cookies: {},
               remoteAddress: "",

--- a/packages/open-next/src/core/routing/matcher.ts
+++ b/packages/open-next/src/core/routing/matcher.ts
@@ -245,7 +245,10 @@ export function handleRewrites<T extends RewriteDefinition>(
     internalEvent: {
       ...event,
       rawPath: rewrittenUrl,
-      url: `${rewrittenUrl}${convertToQueryString(finalQuery)}`,
+      url: new URL(
+        `${rewrittenUrl}${convertToQueryString(finalQuery)}`,
+        new URL(event.url),
+      ).href,
     },
     __rewrite: rewrite,
     isExternalRewrite,
@@ -365,7 +368,10 @@ export function fixDataPage(
       ...internalEvent,
       rawPath: newPath,
       query,
-      url: `${newPath}${convertToQueryString(query)}`,
+      url: new URL(
+        `${newPath}${convertToQueryString(query)}`,
+        new URL(internalEvent.url),
+      ).href,
     };
   }
   return internalEvent;
@@ -397,7 +403,7 @@ export function handleFallbackFalse(
       event: {
         ...internalEvent,
         rawPath: "/404",
-        url: "/404",
+        url: new URL("/404", new URL(internalEvent.url)).href,
         headers: {
           ...internalEvent.headers,
           "x-invoke-status": "404",

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -92,7 +92,7 @@ export function constructNextUrl(baseUrl: string, path: string) {
 export function extractHostFromHeaders(
   headers: Record<string, string>,
 ): string {
-  return headers["x-forwarded-host"] ?? headers.on ?? "on";
+  return headers["x-forwarded-host"] ?? headers.host ?? "on";
 }
 
 /**

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -75,6 +75,21 @@ export function getUrlParts(url: string, isExternal: boolean) {
 }
 
 /**
+ * Creates an URL to a Next page
+ *
+ * @param baseUrl Used to get the origin
+ * @param path The pathname
+ * @returns The Next URL considering the basePath
+ *
+ * @__PURE__
+ */
+export function constructNextUrl(baseUrl: string, path: string) {
+  const nextBasePath = NextConfig.basePath;
+  const url = new URL(`${nextBasePath}${path}`, baseUrl);
+  return url.href;
+}
+
+/**
  *
  * @__PURE__
  */

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -89,6 +89,12 @@ export function constructNextUrl(baseUrl: string, path: string) {
   return url.href;
 }
 
+export function extractHostFromHeaders(
+  headers: Record<string, string>,
+): string {
+  return headers["x-forwarded-host"] ?? headers.on ?? "on";
+}
+
 /**
  *
  * @__PURE__

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -89,12 +89,6 @@ export function constructNextUrl(baseUrl: string, path: string) {
   return url.href;
 }
 
-export function extractHostFromHeaders(
-  headers: Record<string, string>,
-): string {
-  return headers["x-forwarded-host"] ?? headers.host ?? "on";
-}
-
 /**
  *
  * @__PURE__

--- a/packages/open-next/src/core/routingHandler.ts
+++ b/packages/open-next/src/core/routingHandler.ts
@@ -174,7 +174,7 @@ export default async function routingHandler(
     internalEvent = {
       ...internalEvent,
       rawPath: "/404",
-      url: "/404",
+      url: new URL("/404", new URL(internalEvent.url)).href,
       headers: {
         ...internalEvent.headers,
         "x-middleware-response-cache-control":

--- a/packages/open-next/src/core/routingHandler.ts
+++ b/packages/open-next/src/core/routingHandler.ts
@@ -26,6 +26,7 @@ import {
   dynamicRouteMatcher,
   staticRouteMatcher,
 } from "./routing/routeMatcher";
+import { constructNextUrl } from "./routing/util";
 
 export const MIDDLEWARE_HEADER_PREFIX = "x-middleware-response-";
 export const MIDDLEWARE_HEADER_PREFIX_LEN = MIDDLEWARE_HEADER_PREFIX.length;
@@ -174,7 +175,7 @@ export default async function routingHandler(
     internalEvent = {
       ...internalEvent,
       rawPath: "/404",
-      url: new URL("/404", new URL(internalEvent.url)).href,
+      url: constructNextUrl(internalEvent.url, "/404"),
       headers: {
         ...internalEvent.headers,
         "x-middleware-response-cache-control":

--- a/packages/open-next/src/overrides/converters/aws-apigw-v1.ts
+++ b/packages/open-next/src/overrides/converters/aws-apigw-v1.ts
@@ -4,6 +4,7 @@ import type { Converter } from "types/overrides";
 import { fromReadableStream } from "utils/stream";
 
 import { debug } from "../../adapters/logger";
+import { extractHostFromHeaders } from "../../core/routing/util";
 import { removeUndefinedFromQuery } from "./utils";
 
 function normalizeAPIGatewayProxyEventHeaders(
@@ -62,7 +63,7 @@ async function convertFromAPIGatewayProxyEvent(
     type: "core",
     method: httpMethod,
     rawPath: path,
-    url: `https://${headers["x-forwarded-host"] ?? "on"}${path}${normalizeAPIGatewayProxyEventQueryParams(event)}`,
+    url: `https://${extractHostFromHeaders(headers)}${path}${normalizeAPIGatewayProxyEventQueryParams(event)}`,
     body: Buffer.from(body ?? "", isBase64Encoded ? "base64" : "utf8"),
     headers,
     remoteAddress: requestContext.identity.sourceIp,

--- a/packages/open-next/src/overrides/converters/aws-apigw-v1.ts
+++ b/packages/open-next/src/overrides/converters/aws-apigw-v1.ts
@@ -62,7 +62,7 @@ async function convertFromAPIGatewayProxyEvent(
     type: "core",
     method: httpMethod,
     rawPath: path,
-    url: `https://${headers.host ?? "on"}${path}${normalizeAPIGatewayProxyEventQueryParams(event)}`,
+    url: `https://${headers["x-forwarded-host"] ?? "on"}${path}${normalizeAPIGatewayProxyEventQueryParams(event)}`,
     body: Buffer.from(body ?? "", isBase64Encoded ? "base64" : "utf8"),
     headers,
     remoteAddress: requestContext.identity.sourceIp,

--- a/packages/open-next/src/overrides/converters/aws-apigw-v1.ts
+++ b/packages/open-next/src/overrides/converters/aws-apigw-v1.ts
@@ -4,8 +4,7 @@ import type { Converter } from "types/overrides";
 import { fromReadableStream } from "utils/stream";
 
 import { debug } from "../../adapters/logger";
-import { extractHostFromHeaders } from "../../core/routing/util";
-import { removeUndefinedFromQuery } from "./utils";
+import { extractHostFromHeaders, removeUndefinedFromQuery } from "./utils";
 
 function normalizeAPIGatewayProxyEventHeaders(
   event: APIGatewayProxyEvent,

--- a/packages/open-next/src/overrides/converters/aws-apigw-v1.ts
+++ b/packages/open-next/src/overrides/converters/aws-apigw-v1.ts
@@ -57,13 +57,14 @@ async function convertFromAPIGatewayProxyEvent(
   event: APIGatewayProxyEvent,
 ): Promise<InternalEvent> {
   const { path, body, httpMethod, requestContext, isBase64Encoded } = event;
+  const headers = normalizeAPIGatewayProxyEventHeaders(event);
   return {
     type: "core",
     method: httpMethod,
     rawPath: path,
-    url: path + normalizeAPIGatewayProxyEventQueryParams(event),
+    url: `https://${headers.host ?? "on"}${path}${normalizeAPIGatewayProxyEventQueryParams(event)}`,
     body: Buffer.from(body ?? "", isBase64Encoded ? "base64" : "utf8"),
-    headers: normalizeAPIGatewayProxyEventHeaders(event),
+    headers,
     remoteAddress: requestContext.identity.sourceIp,
     query: removeUndefinedFromQuery(
       event.multiValueQueryStringParameters ?? {},

--- a/packages/open-next/src/overrides/converters/aws-apigw-v2.ts
+++ b/packages/open-next/src/overrides/converters/aws-apigw-v2.ts
@@ -80,7 +80,7 @@ async function convertFromAPIGatewayProxyEventV2(
     type: "core",
     method: requestContext.http.method,
     rawPath,
-    url: `https://${headers.host ?? "on"}${rawPath}${rawQueryString ? `?${rawQueryString}` : ""}`,
+    url: `https://${headers["x-forwarded-host"] ?? "on"}${rawPath}${rawQueryString ? `?${rawQueryString}` : ""}`,
     body: normalizeAPIGatewayProxyEventV2Body(event),
     headers,
     remoteAddress: requestContext.http.sourceIp,

--- a/packages/open-next/src/overrides/converters/aws-apigw-v2.ts
+++ b/packages/open-next/src/overrides/converters/aws-apigw-v2.ts
@@ -8,11 +8,8 @@ import type { Converter } from "types/overrides";
 import { fromReadableStream } from "utils/stream";
 
 import { debug } from "../../adapters/logger";
-import {
-  convertToQuery,
-  extractHostFromHeaders,
-} from "../../core/routing/util";
-import { removeUndefinedFromQuery } from "./utils";
+import { convertToQuery } from "../../core/routing/util";
+import { extractHostFromHeaders, removeUndefinedFromQuery } from "./utils";
 
 // Not sure which one is really needed as this is not documented anywhere but server actions redirect are not working without this,
 // it causes a 500 error from cloudfront itself with a 'x-amzErrortype: InternalFailure' header

--- a/packages/open-next/src/overrides/converters/aws-apigw-v2.ts
+++ b/packages/open-next/src/overrides/converters/aws-apigw-v2.ts
@@ -75,13 +75,14 @@ async function convertFromAPIGatewayProxyEventV2(
   event: APIGatewayProxyEventV2,
 ): Promise<InternalEvent> {
   const { rawPath, rawQueryString, requestContext } = event;
+  const headers = normalizeAPIGatewayProxyEventV2Headers(event);
   return {
     type: "core",
     method: requestContext.http.method,
     rawPath,
-    url: rawPath + (rawQueryString ? `?${rawQueryString}` : ""),
+    url: `https://${headers.host ?? "on"}${rawPath}${rawQueryString ? `?${rawQueryString}` : ""}`,
     body: normalizeAPIGatewayProxyEventV2Body(event),
-    headers: normalizeAPIGatewayProxyEventV2Headers(event),
+    headers,
     remoteAddress: requestContext.http.sourceIp,
     query: removeUndefinedFromQuery(convertToQuery(rawQueryString)),
     cookies:

--- a/packages/open-next/src/overrides/converters/aws-apigw-v2.ts
+++ b/packages/open-next/src/overrides/converters/aws-apigw-v2.ts
@@ -8,7 +8,10 @@ import type { Converter } from "types/overrides";
 import { fromReadableStream } from "utils/stream";
 
 import { debug } from "../../adapters/logger";
-import { convertToQuery } from "../../core/routing/util";
+import {
+  convertToQuery,
+  extractHostFromHeaders,
+} from "../../core/routing/util";
 import { removeUndefinedFromQuery } from "./utils";
 
 // Not sure which one is really needed as this is not documented anywhere but server actions redirect are not working without this,
@@ -80,7 +83,7 @@ async function convertFromAPIGatewayProxyEventV2(
     type: "core",
     method: requestContext.http.method,
     rawPath,
-    url: `https://${headers["x-forwarded-host"] ?? "on"}${rawPath}${rawQueryString ? `?${rawQueryString}` : ""}`,
+    url: `https://${extractHostFromHeaders(headers)}${rawPath}${rawQueryString ? `?${rawQueryString}` : ""}`,
     body: normalizeAPIGatewayProxyEventV2Body(event),
     headers,
     remoteAddress: requestContext.http.sourceIp,

--- a/packages/open-next/src/overrides/converters/aws-cloudfront.ts
+++ b/packages/open-next/src/overrides/converters/aws-cloudfront.ts
@@ -95,7 +95,7 @@ async function convertFromCloudFrontRequestEvent(
     type: "core",
     method,
     rawPath: uri,
-    url: `https://${headers.host ?? "on"}${uri}${querystring ? `?${querystring}` : ""}`,
+    url: `https://${headers["x-forwarded-host"] ?? "on"}${uri}${querystring ? `?${querystring}` : ""}`,
     body: Buffer.from(
       body?.data ?? "",
       body?.encoding === "base64" ? "base64" : "utf8",

--- a/packages/open-next/src/overrides/converters/aws-cloudfront.ts
+++ b/packages/open-next/src/overrides/converters/aws-cloudfront.ts
@@ -17,7 +17,11 @@ import type { Converter } from "types/overrides";
 import { fromReadableStream } from "utils/stream";
 
 import { debug } from "../../adapters/logger";
-import { convertToQuery, convertToQueryString } from "../../core/routing/util";
+import {
+  convertToQuery,
+  convertToQueryString,
+  extractHostFromHeaders,
+} from "../../core/routing/util";
 
 const cloudfrontBlacklistedHeaders = [
   // Disallowed headers, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-function-restrictions-all.html#function-restrictions-disallowed-headers
@@ -95,7 +99,7 @@ async function convertFromCloudFrontRequestEvent(
     type: "core",
     method,
     rawPath: uri,
-    url: `https://${headers["x-forwarded-host"] ?? "on"}${uri}${querystring ? `?${querystring}` : ""}`,
+    url: `https://${extractHostFromHeaders(headers)}${uri}${querystring ? `?${querystring}` : ""}`,
     body: Buffer.from(
       body?.data ?? "",
       body?.encoding === "base64" ? "base64" : "utf8",

--- a/packages/open-next/src/overrides/converters/aws-cloudfront.ts
+++ b/packages/open-next/src/overrides/converters/aws-cloudfront.ts
@@ -17,11 +17,8 @@ import type { Converter } from "types/overrides";
 import { fromReadableStream } from "utils/stream";
 
 import { debug } from "../../adapters/logger";
-import {
-  convertToQuery,
-  convertToQueryString,
-  extractHostFromHeaders,
-} from "../../core/routing/util";
+import { convertToQuery, convertToQueryString } from "../../core/routing/util";
+import { extractHostFromHeaders } from "./utils";
 
 const cloudfrontBlacklistedHeaders = [
   // Disallowed headers, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-function-restrictions-all.html#function-restrictions-disallowed-headers

--- a/packages/open-next/src/overrides/converters/edge.ts
+++ b/packages/open-next/src/overrides/converters/edge.ts
@@ -59,18 +59,7 @@ const converter: Converter<InternalEvent, InternalResult | MiddlewareResult> = {
   },
   convertTo: async (result) => {
     if ("internalEvent" in result) {
-      let url = result.internalEvent.url;
-      if (!result.isExternalRewrite) {
-        if (result.origin) {
-          url = `${result.origin.protocol}://${result.origin.host}${
-            result.origin.port ? `:${result.origin.port}` : ""
-          }${url}`;
-        } else {
-          url = `https://${result.internalEvent.headers.host}${url}`;
-        }
-      }
-
-      const request = new Request(url, {
+      const request = new Request(result.internalEvent.url, {
         body: result.internalEvent.body,
         method: result.internalEvent.method,
         headers: {

--- a/packages/open-next/src/overrides/converters/node.ts
+++ b/packages/open-next/src/overrides/converters/node.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage } from "node:http";
 import { parseCookies } from "http/util";
 import type { InternalResult } from "types/open-next";
 import type { Converter } from "types/overrides";
-import { extractHostFromHeaders } from "../../core/routing/util";
+import { extractHostFromHeaders } from "./utils";
 
 const converter: Converter = {
   convertFrom: async (req: IncomingMessage) => {

--- a/packages/open-next/src/overrides/converters/node.ts
+++ b/packages/open-next/src/overrides/converters/node.ts
@@ -16,13 +16,13 @@ const converter: Converter = {
       });
     });
 
-    const url = new URL(req.url!, `http://${req.headers.host}`);
+    const url = new URL(req.url!, `http://${req.headers.host ?? "on"}`);
     const query = Object.fromEntries(url.searchParams.entries());
     return {
       type: "core",
       method: req.method ?? "GET",
       rawPath: url.pathname,
-      url: url.pathname + url.search,
+      url: url.href,
       body,
       headers: Object.fromEntries(
         Object.entries(req.headers ?? {})

--- a/packages/open-next/src/overrides/converters/utils.ts
+++ b/packages/open-next/src/overrides/converters/utils.ts
@@ -9,3 +9,15 @@ export function removeUndefinedFromQuery(
   }
   return newQuery;
 }
+
+/**
+ * Extract the host from the headers (default to "on")
+ *
+ * @param headers
+ * @returns The host
+ */
+export function extractHostFromHeaders(
+  headers: Record<string, string>,
+): string {
+  return headers["x-forwarded-host"] ?? headers.host ?? "on";
+}

--- a/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
@@ -28,13 +28,7 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
     }
 
     const internalEvent = await converter.convertFrom(request);
-
-    // TODO:
-    // The edge converter populate event.url with the url including the origin.
-    // This is required for middleware to keep track of the protocol (i.e. http with wrangler dev).
-    // However the server expects that the origin is not included.
-    const url = new URL(internalEvent.url);
-    (internalEvent.url as string) = url.href.slice(url.origin.length);
+    const url = new URL(request.url);
 
     const { promise: promiseResponse, resolve: resolveResponse } =
       Promise.withResolvers<Response>();

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -22,6 +22,7 @@ export type BaseEventOrResult<T extends string = string> = {
 export type InternalEvent = {
   readonly method: string;
   readonly rawPath: string;
+  // Full URL - starts with "https://on/" when the host is not available
   readonly url: string;
   readonly body?: Buffer;
   readonly headers: Record<string, string>;

--- a/packages/tests-unit/tests/converters/aws-apigw-v1.test.ts
+++ b/packages/tests-unit/tests/converters/aws-apigw-v1.test.ts
@@ -87,7 +87,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "POST",
       rawPath: "/",
-      url: "/",
+      url: "https://on/",
       body: Buffer.from('{"message":"Hello, world!"}'),
       headers: {
         "content-type": "application/json",
@@ -126,7 +126,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "POST",
       rawPath: "/",
-      url: "/",
+      url: "https://on/",
       body: Buffer.from('{"message":"Hello, world!"}'),
       headers: {
         test: "test1,test2",
@@ -167,7 +167,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "POST",
       rawPath: "/",
-      url: "/?test=test",
+      url: "https://on/?test=test",
       body: Buffer.from('{"message":"Hello, world!"}'),
       headers: {},
       remoteAddress: "::1",
@@ -208,7 +208,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "POST",
       rawPath: "/",
-      url: "/",
+      url: "https://on/",
       body: Buffer.from('{"message":"Hello, world!"}'),
       headers: {
         "content-type": "application/json",
@@ -251,7 +251,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "GET",
       rawPath: "/",
-      url: "/",
+      url: "https://on/",
       body: Buffer.from("Hello, world!"),
       headers: {
         "content-type": "application/json",

--- a/packages/tests-unit/tests/converters/aws-apigw-v2.test.ts
+++ b/packages/tests-unit/tests/converters/aws-apigw-v2.test.ts
@@ -126,7 +126,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "POST",
       rawPath: "/",
-      url: "/",
+      url: "https://on/",
       body: Buffer.from('{"message":"Hello, world!"}'),
       headers: {
         "content-type": "application/json",
@@ -163,7 +163,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "POST",
       rawPath: "/",
-      url: "/",
+      url: "https://on/",
       body: Buffer.from('{"message":"Hello, world!"}'),
       headers: {
         "content-type": "application/json",
@@ -204,7 +204,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "POST",
       rawPath: "/",
-      url: "/?hello=world&foo=1&foo=2",
+      url: "https://on/?hello=world&foo=1&foo=2",
       body: Buffer.from('{"message":"Hello, world!"}'),
       headers: {
         "content-type": "application/json",
@@ -246,7 +246,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "POST",
       rawPath: "/",
-      url: "/",
+      url: "https://on/",
       body: Buffer.from('{"message":"Hello, world!"}'),
       headers: {
         "content-type": "application/json",

--- a/packages/tests-unit/tests/converters/aws-cloudfront.test.ts
+++ b/packages/tests-unit/tests/converters/aws-cloudfront.test.ts
@@ -231,7 +231,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "POST",
       rawPath: "/",
-      url: "/",
+      url: "https://on/",
       body: Buffer.from('{"message":"Hello, world!"}'),
       headers: {
         "content-type": "application/json",
@@ -271,7 +271,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "POST",
       rawPath: "/",
-      url: "/?hello=world&foo=1&foo=2",
+      url: "https://on/?hello=world&foo=1&foo=2",
       body: Buffer.from('{"message":"Hello, world!"}'),
       headers: {
         "content-type": "application/json",
@@ -316,7 +316,7 @@ describe("convertFrom", () => {
       type: "core",
       method: "POST",
       rawPath: "/",
-      url: "/",
+      url: "https://on/",
       body: Buffer.from('{"message":"Hello, world!"}'),
       headers: {
         "content-type": "application/json",

--- a/packages/tests-unit/tests/converters/node.test.ts
+++ b/packages/tests-unit/tests/converters/node.test.ts
@@ -16,7 +16,7 @@ describe("convertFrom", () => {
 
     expect(result).toEqual({
       type: "core",
-      url: "/",
+      url: "http://on/",
       rawPath: "/",
       method: "GET",
       headers: {
@@ -44,7 +44,7 @@ describe("convertFrom", () => {
 
     expect(result).toEqual({
       type: "core",
-      url: "/path",
+      url: "http://localhost/path",
       rawPath: "/path",
       method: "GET",
       headers: {
@@ -71,7 +71,7 @@ describe("convertFrom", () => {
 
     expect(result).toEqual({
       type: "core",
-      url: "/path",
+      url: "http://on/path",
       rawPath: "/path",
       method: "GET",
       headers: {
@@ -99,7 +99,7 @@ describe("convertFrom", () => {
 
     expect(result).toEqual({
       type: "core",
-      url: "/path",
+      url: "http://on/path",
       rawPath: "/path",
       method: "GET",
       headers: {
@@ -128,7 +128,7 @@ describe("convertFrom", () => {
 
     expect(result).toEqual({
       type: "core",
-      url: "/path?search=1",
+      url: "http://localhost/path?search=1",
       rawPath: "/path",
       method: "GET",
       headers: {
@@ -161,7 +161,7 @@ describe("convertFrom", () => {
 
     expect(result).toEqual({
       type: "core",
-      url: "/path",
+      url: "http://on/path",
       rawPath: "/path",
       method: "POST",
       headers: {
@@ -195,7 +195,7 @@ describe("convertFrom", () => {
 
     expect(result).toEqual({
       type: "core",
-      url: "/path",
+      url: "http://on/path",
       rawPath: "/path",
       method: "PUT",
       headers: {

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -21,15 +21,16 @@ type PartialEvent = Partial<
 > & { body?: string };
 
 function createEvent(event: PartialEvent): InternalEvent {
-  const [rawPath, qs] = (event.url ?? "/").split("?", 2);
+  const url = event.url ?? "https://on/";
+  const { pathname, search } = new URL(url);
   return {
     type: "core",
     method: event.method ?? "GET",
-    rawPath,
+    rawPath: pathname,
     url: event.url ?? "/",
     body: Buffer.from(event.body ?? ""),
     headers: event.headers ?? {},
-    query: convertFromQueryString(qs ?? ""),
+    query: convertFromQueryString(search.slice(1)),
     cookies: event.cookies ?? {},
     remoteAddress: event.remoteAddress ?? "::1",
   };
@@ -56,7 +57,7 @@ describe("getNextConfigHeaders", () => {
 
   it("should return request headers for matching / route", () => {
     const event = createEvent({
-      url: "/",
+      url: "https://on/",
     });
 
     const result = getNextConfigHeaders(event, [
@@ -79,7 +80,7 @@ describe("getNextConfigHeaders", () => {
 
   it("should return empty request headers for matching / route with empty headers", () => {
     const event = createEvent({
-      url: "/",
+      url: "https://on/",
     });
 
     const result = getNextConfigHeaders(event, [
@@ -95,7 +96,7 @@ describe("getNextConfigHeaders", () => {
 
   it("should return request headers for matching /* route", () => {
     const event = createEvent({
-      url: "/hello-world",
+      url: "https://on/hello-world",
     });
 
     const result = getNextConfigHeaders(event, [
@@ -123,7 +124,7 @@ describe("getNextConfigHeaders", () => {
 
   it("should return request headers for matching /* route with has condition", () => {
     const event = createEvent({
-      url: "/hello-world",
+      url: "https://on/hello-world",
       cookies: {
         match: "true",
       },
@@ -150,7 +151,7 @@ describe("getNextConfigHeaders", () => {
 
   it("should return request headers for matching /* route with missing condition", () => {
     const event = createEvent({
-      url: "/hello-world",
+      url: "https://on/hello-world",
       cookies: {
         match: "true",
       },
@@ -177,7 +178,7 @@ describe("getNextConfigHeaders", () => {
 
   it("should return request headers for matching /* route with has and missing condition", () => {
     const event = createEvent({
-      url: "/hello-world",
+      url: "https://on/hello-world",
       cookies: {
         match: "true",
       },
@@ -211,18 +212,18 @@ describe("getNextConfigHeaders", () => {
 describe("handleRedirects", () => {
   it("should redirect trailing slash by default", () => {
     const event = createEvent({
-      url: "/api-route/",
+      url: "https://on/api-route/",
     });
 
     const result = handleRedirects(event, []);
 
     expect(result.statusCode).toEqual(308);
-    expect(result.headers.Location).toEqual("/api-route");
+    expect(result.headers.Location).toEqual("https://on/api-route");
   });
 
   it("should not redirect trailing slash when skipTrailingSlashRedirect is true", () => {
     const event = createEvent({
-      url: "/api-route/",
+      url: "https://on/api-route/",
     });
 
     NextConfig.skipTrailingSlashRedirect = true;
@@ -233,7 +234,7 @@ describe("handleRedirects", () => {
 
   it("should redirect matching path", () => {
     const event = createEvent({
-      url: "/api-route",
+      url: "https://on/api-route",
     });
 
     const result = handleRedirects(event, [
@@ -246,12 +247,12 @@ describe("handleRedirects", () => {
       },
     ]);
 
-    expect(result.headers.Location).toBe("/new/api-route");
+    expect(result.headers.Location).toBe("https://on/new/api-route");
   });
 
   it("should redirect matching nested path", () => {
     const event = createEvent({
-      url: "/api-route/secret",
+      url: "https://on/api-route/secret",
     });
 
     const result = handleRedirects(event, [
@@ -264,12 +265,12 @@ describe("handleRedirects", () => {
       },
     ]);
 
-    expect(result.headers.Location).toBe("/new/api-route/secret");
+    expect(result.headers.Location).toBe("https://on/new/api-route/secret");
   });
 
   it("should not redirect unmatched path", () => {
     const event = createEvent({
-      url: "/api-route",
+      url: "https://on/api-route",
     });
 
     const result = handleRedirects(event, [
@@ -287,7 +288,7 @@ describe("handleRedirects", () => {
 
   it("should redirect with + character and query string", () => {
     const event = createEvent({
-      url: "/foo",
+      url: "https://on/foo",
     });
 
     const result = handleRedirects(event, [
@@ -302,7 +303,7 @@ describe("handleRedirects", () => {
 
     expect(result.statusCode).toEqual(308);
     expect(result.headers.Location).toEqual(
-      "/search?bar=hello+world&baz=new%2C+earth",
+      "https://on/search?bar=hello+world&baz=new%2C+earth",
     );
   });
 });
@@ -310,7 +311,7 @@ describe("handleRedirects", () => {
 describe("handleRewrites", () => {
   it("should not rewrite with empty rewrites", () => {
     const event = createEvent({
-      url: "/foo?hellp=world",
+      url: "https://on/foo?hello=world",
     });
 
     const result = handleRewrites(event, []);
@@ -323,7 +324,7 @@ describe("handleRewrites", () => {
 
   it("should rewrite with params", () => {
     const event = createEvent({
-      url: "/albums/foo/bar",
+      url: "https://on/albums/foo/bar",
     });
 
     const rewrites = [
@@ -344,7 +345,7 @@ describe("handleRewrites", () => {
       internalEvent: {
         ...event,
         rawPath: "/rewrite/albums/foo/bar",
-        url: "/rewrite/albums/foo/bar",
+        url: "https://on/rewrite/albums/foo/bar",
       },
       __rewrite: rewrites[1],
       isExternalRewrite: false,
@@ -353,7 +354,7 @@ describe("handleRewrites", () => {
 
   it("should rewrite without params", () => {
     const event = createEvent({
-      url: "/foo",
+      url: "https://on/foo",
     });
 
     const rewrites = [
@@ -369,7 +370,7 @@ describe("handleRewrites", () => {
       internalEvent: {
         ...event,
         rawPath: "/bar",
-        url: "/bar",
+        url: "https://on/bar",
       },
       __rewrite: rewrites[0],
       isExternalRewrite: false,
@@ -378,7 +379,7 @@ describe("handleRewrites", () => {
 
   it("should rewrite externally", () => {
     const event = createEvent({
-      url: "/albums/foo/bar",
+      url: "https://on/albums/foo/bar",
     });
 
     const rewrites = [
@@ -403,7 +404,7 @@ describe("handleRewrites", () => {
 
   it("should rewrite with matching path with has condition", () => {
     const event = createEvent({
-      url: "/albums/foo?has=true",
+      url: "https://on/albums/foo?has=true",
     });
 
     const rewrites = [
@@ -426,7 +427,7 @@ describe("handleRewrites", () => {
       internalEvent: {
         ...event,
         rawPath: "/rewrite/albums/foo",
-        url: "/rewrite/albums/foo?has=true",
+        url: "https://on/rewrite/albums/foo?has=true",
       },
       __rewrite: rewrites[0],
       isExternalRewrite: false,
@@ -435,7 +436,7 @@ describe("handleRewrites", () => {
 
   it("should rewrite with matching path with missing condition", () => {
     const event = createEvent({
-      url: "/albums/foo",
+      url: "https://on/albums/foo",
       headers: {
         has: "true",
       },
@@ -460,7 +461,7 @@ describe("handleRewrites", () => {
       internalEvent: {
         ...event,
         rawPath: "/rewrite/albums/foo",
-        url: "/rewrite/albums/foo",
+        url: "https://on/rewrite/albums/foo",
       },
       __rewrite: rewrites[0],
       isExternalRewrite: false,
@@ -471,7 +472,7 @@ describe("handleRewrites", () => {
 describe("fixDataPage", () => {
   it("should return 404 for data requests that don't match the buildId", () => {
     const event = createEvent({
-      url: "/_next/data/xyz/test",
+      url: "https://on/_next/data/xyz/test",
     });
 
     const response = fixDataPage(event, "abc");
@@ -481,7 +482,7 @@ describe("fixDataPage", () => {
 
   it("should not return 404 for data requests that don't match the buildId", () => {
     const event = createEvent({
-      url: "/_next/data/abc/test",
+      url: "https://on/_next/data/abc/test",
     });
 
     const response = fixDataPage(event, "abc");
@@ -494,7 +495,7 @@ describe("fixDataPage", () => {
     NextConfig.basePath = "/base";
 
     const event = createEvent({
-      url: "/base/_next/data/abc/test",
+      url: "https://on/base/_next/data/abc/test",
     });
 
     const response = fixDataPage(event, "abc");
@@ -507,7 +508,7 @@ describe("fixDataPage", () => {
 
   it("should remove json extension from data requests and add __nextDataReq to query", () => {
     const event = createEvent({
-      url: "/_next/data/abc/test/file.json?hello=world",
+      url: "https://on/_next/data/abc/test/file.json?hello=world",
     });
 
     const response = fixDataPage(event, "abc");
@@ -515,7 +516,7 @@ describe("fixDataPage", () => {
     expect(response).toEqual({
       ...event,
       rawPath: "/test/file",
-      url: "/test/file?hello=world&__nextDataReq=1",
+      url: "https://on/test/file?hello=world&__nextDataReq=1",
     });
   });
 
@@ -523,7 +524,7 @@ describe("fixDataPage", () => {
     NextConfig.basePath = "/base";
 
     const event = createEvent({
-      url: "/base/_next/data/abc/test/file.json?hello=world",
+      url: "https://on/base/_next/data/abc/test/file.json?hello=world",
     });
 
     const response = fixDataPage(event, "abc");
@@ -531,7 +532,7 @@ describe("fixDataPage", () => {
     expect(response).toEqual({
       ...event,
       rawPath: "/test/file",
-      url: "/test/file?hello=world&__nextDataReq=1",
+      url: "https://on/test/file?hello=world&__nextDataReq=1",
     });
 
     NextConfig.basePath = undefined;

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -394,7 +394,7 @@ describe("handleRewrites", () => {
     expect(result).toEqual({
       internalEvent: {
         ...event,
-        rawPath: "https://external.com/search",
+        rawPath: "/search",
         url: "https://external.com/search?album=foo&song=bar",
       },
       __rewrite: rewrites[0],


### PR DESCRIPTION
fixes https://github.com/opennextjs/opennextjs-aws/issues/719

edit: One thing I need to check is the base path, we should probably add it when constructing URLs (i.e. 404, 500)

@conico974 could you please review and maybe run the aws integration tests when this looks ok?
cf tests are green with this PR.
Thanks!