### PR TITLE
Fix rewrite query not forwarded and api destination

### DIFF
--- a/.changeset/red-starfishes-wave.md
+++ b/.changeset/red-starfishes-wave.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix api rewrite destination with i18n and query not forwarded on rewrite

--- a/examples/pages-router/next.config.ts
+++ b/examples/pages-router/next.config.ts
@@ -26,6 +26,7 @@ const nextConfig: NextConfig = {
   ],
   rewrites: async () => [
     { source: "/rewrite", destination: "/", locale: false },
+    { source: "/rewriteWithQuery", destination: "/api/query?q=1" },
     {
       source: "/rewriteUsingQuery",
       destination: "/:destination/",

--- a/examples/pages-router/src/pages/api/query.ts
+++ b/examples/pages-router/src/pages/api/query.ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json({ query: req.query });
+}

--- a/packages/tests-e2e/tests/pagesRouter/rewrite.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/rewrite.test.ts
@@ -23,3 +23,15 @@ test("Rewrite to external image", async ({ request }) => {
   expect(response.headers()["content-type"]).toBe("image/png");
   expect(validateMd5(await response.body(), EXT_PNG_MD5)).toBe(true);
 });
+
+test("Rewrite with query in destination", async ({ request }) => {
+  const response = await request.get("/rewriteWithQuery");
+  expect(response.status()).toBe(200);
+  expect(await response.json()).toEqual({ query: { q: "1" } });
+});
+
+test("Rewrite with query should merge query params", async ({ request }) => {
+  const response = await request.get("/rewriteWithQuery?b=2");
+  expect(response.status()).toBe(200);
+  expect(await response.json()).toEqual({ query: { q: "1", b: "2" } });
+});

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -395,6 +395,10 @@ describe("handleRewrites", () => {
     expect(result).toEqual({
       internalEvent: {
         ...event,
+        query: {
+          album: "foo",
+          song: "bar",
+        },
         rawPath: "/search",
         url: "https://external.com/search?album=foo&song=bar",
       },


### PR DESCRIPTION
This PR fix #766

They were 2 different issues described there: 
- Query params defined in the destination of a rewrite were not forwarded as expected
-  Internal destination that are api route should be stripped from the appended locale. (If `locale` is not set to false, next will always transform in rewrite with an appended locale, but it expects the api route to be not locale prefixed)

@nicholas-c Could you confirm that it fixes your issue