### PR TITLE
fix: ignore @img in copyTracedFiles

### DIFF
--- a/.changeset/tall-pets-hammer.md
+++ b/.changeset/tall-pets-hammer.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix: Ignore packages under the @img/\* scope to exclude sharp from the server bundle. 

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -198,7 +198,10 @@ File ${fullFilePath} does not exist
       //TODO: we need to figure which packages we could safely remove
       from.includes(path.join("node_modules", "caniuse-lite")) ||
       // from.includes("jest-worker") || This ones seems necessary for next 12
-      from.includes(path.join("node_modules", "sharp"))
+      from.includes(path.join("node_modules", "sharp")) ||
+      // This seems to be only in Next 15
+      // Some of sharp deps are under the @img scope
+      from.includes(path.join("node_modules", "@img"))
     ) {
       return;
     }

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -14,6 +14,7 @@ import {
 import path from "node:path";
 
 import { loadConfig, loadPrerenderManifest } from "config/util.js";
+import { getCrossPlatformPathRegex } from "utils/regex.js";
 import logger from "../logger.js";
 import { MIDDLEWARE_TRACE_FILE } from "./constant.js";
 
@@ -30,9 +31,7 @@ const EXCLUDED_PACKAGES = [
 
 function isExcluded(srcPath: string) {
   return EXCLUDED_PACKAGES.some((excluded) =>
-    new RegExp(`${path.sep}node_modules${path.sep}${excluded}${path.sep}`).test(
-      srcPath,
-    ),
+    srcPath.match(getCrossPlatformPathRegex(`/node_modules/${excluded}/`)),
   );
 }
 


### PR DESCRIPTION
In Next `15.2.2` (and maybe earlier minor and patch) sharp seems have some deps under the scope `@img/*`. (i.e [@img/sharp-linux-x64](https://www.npmjs.com/package/@img/sharp-linux-x64)) 

The issue was discovered in this [comment](https://github.com/sst/sst/issues/5534#issuecomment-2713713849). 

Without this fix the default server function might end up being 32mb+ larger than it has to.