### PR TITLE
add timeout in revalidatePath test as locally can run too fast

### DIFF
--- a/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
+++ b/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
@@ -79,6 +79,7 @@ test("Revalidate path", async ({ page, request }) => {
   elLayout = page.getByText("Date:");
   const initialDate = await elLayout.textContent();
 
+  // Wait so that enough time passes for the data on the page to update when revalidating
   await page.waitForTimeout(2000);
 
   // Send revalidate path request

--- a/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
+++ b/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
@@ -79,6 +79,8 @@ test("Revalidate path", async ({ page, request }) => {
   elLayout = page.getByText("Date:");
   const initialDate = await elLayout.textContent();
 
+  await page.waitForTimeout(2000);
+
   // Send revalidate path request
   const result = await request.get("/api/revalidate-path");
   expect(result.status()).toEqual(200);


### PR DESCRIPTION
I was seeing some flakiness when running the e2es locally in Cloudflare purely due to the fact that the test ran in less than 1 second and so the seconds in the date did not change.

![image](https://github.com/user-attachments/assets/1b23d490-3056-4b77-9034-d71d4a4d1844)
