### PR TITLE
fix: remove internal next headers in middleware response

### DIFF
--- a/.changeset/metal-news-watch.md
+++ b/.changeset/metal-news-watch.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: remove internal next headers in middleware response

--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -110,7 +110,7 @@ export async function handleMiddleware(
   const resHeaders: Record<string, string | string[]> = {};
 
   responseHeaders.delete("x-middleware-override-headers");
-  /* Next will set the header `x-middleware-set-cookie` when you `set-cookie` in the middleware.
+  /*  Next will set the header `x-middleware-set-cookie` when you `set-cookie` in the middleware.
    *  We can delete it here since it will be set in `set-cookie` aswell. Next removes this header in the response themselves.
    * `x-middleware-next` is set when you invoke `NextResponse.next()`. We can delete it here aswell.
    */

--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -116,7 +116,7 @@ export async function handleMiddleware(
    */
   responseHeaders.delete("x-middleware-set-cookie");
   responseHeaders.delete("x-middleware-next");
-  
+
   const xMiddlewareKey = "x-middleware-request-";
   responseHeaders.forEach((value, key) => {
     if (key.startsWith(xMiddlewareKey)) {

--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -110,6 +110,13 @@ export async function handleMiddleware(
   const resHeaders: Record<string, string | string[]> = {};
 
   responseHeaders.delete("x-middleware-override-headers");
+  /* Next will set the header `x-middleware-set-cookie` when you `set-cookie` in the middleware.
+   *  We can delete it here since it will be set in `set-cookie` aswell. Next removes this header in the response themselves.
+   * `x-middleware-next` is set when you invoke `NextResponse.next()`. We can delete it here aswell.
+   */
+  responseHeaders.delete("x-middleware-set-cookie");
+  responseHeaders.delete("x-middleware-next");
+  
   const xMiddlewareKey = "x-middleware-request-";
   responseHeaders.forEach((value, key) => {
     if (key.startsWith(xMiddlewareKey)) {


### PR DESCRIPTION
For #772

Internally Next uses `x-middleware-set-cookie` and `x-middleware-next`. These are then removed on the response by Next code, but since we have a custom middleware we need to remove it our self. 