### PR TITLE
fix: external rewrite for streaming

### DIFF
--- a/.changeset/heavy-moles-share.md
+++ b/.changeset/heavy-moles-share.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix external rewrite for streaming

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -138,7 +138,7 @@ export async function openNextHandler(
               origin: false,
               initialURL: internalEvent.url,
             },
-            headers,
+            routingResult.headers,
             options.streamCreator,
           );
           response.statusCode = routingResult.statusCode;


### PR DESCRIPTION
Closes #789

Turns out we were not passing the correct headers to the response when streaming is used.