### PR TITLE
Add a `compileEdge` parameter to `compileOpenNextConfig`

### DIFF
--- a/.changeset/gorgeous-rocks-appear.md
+++ b/.changeset/gorgeous-rocks-appear.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Add a `compileEdge` parameter to `compileOpenNextConfig`

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -34,7 +34,7 @@ export async function build(
   const { config, buildDir } = await compileOpenNextConfig(
     baseDir,
     openNextConfigPath,
-    nodeExternals,
+    { nodeExternals },
   );
 
   // Initialize options

--- a/packages/open-next/src/build/compileConfig.ts
+++ b/packages/open-next/src/build/compileConfig.ts
@@ -53,13 +53,13 @@ export async function compileOpenNextConfig(
   const usesEdgeRuntime =
     (config.middleware?.external && config.middleware.runtime !== "node") ||
     Object.values(config.functions || {}).some((fn) => fn.runtime === "edge");
-  if (!(usesEdgeRuntime || compileEdge)) {
+  if (usesEdgeRuntime || compileEdge) {
+    compileOpenNextConfigEdge(sourcePath, buildDir, config.edgeExternals ?? []);
+  } else {
     // Skip compiling for the edge runtime.
     logger.debug(
       "No edge runtime found in the open-next.config.ts. Using default config.",
     );
-  } else {
-    compileOpenNextConfigEdge(sourcePath, buildDir, config.edgeExternals ?? []);
   }
 
   return { config, buildDir };

--- a/packages/open-next/src/build/compileConfig.ts
+++ b/packages/open-next/src/build/compileConfig.ts
@@ -15,13 +15,14 @@ import { validateConfig } from "./validateConfig.js";
  *
  * @param baseDir Directory where to look for the configuration.
  * @param openNextConfigPath Override the default configuration when provided. Relative to baseDir.
- * @param nodeExternals Externals for the Node.js compilation.
+ * @param nodeExternals Coma separated list of Externals for the Node.js compilation.
+ * @param compileEdge Force compiling for the edge runtime when true
  * @return The configuration and the build directory.
  */
 export async function compileOpenNextConfig(
   baseDir: string,
   openNextConfigPath?: string,
-  nodeExternals?: string,
+  { nodeExternals = "", compileEdge = false } = {},
 ) {
   const sourcePath = path.join(
     baseDir,
@@ -32,7 +33,7 @@ export async function compileOpenNextConfig(
   let configPath = compileOpenNextConfigNode(
     sourcePath,
     buildDir,
-    nodeExternals ? nodeExternals.split(",") : [],
+    nodeExternals.split(","),
   );
 
   // On Windows, we need to use file:// protocol to load the config file using import()
@@ -52,11 +53,11 @@ export async function compileOpenNextConfig(
   const usesEdgeRuntime =
     (config.middleware?.external && config.middleware.runtime !== "node") ||
     Object.values(config.functions || {}).some((fn) => fn.runtime === "edge");
-  if (!usesEdgeRuntime) {
+  if (!(usesEdgeRuntime || compileEdge)) {
+    // Skip compiling for the edge runtime.
     logger.debug(
       "No edge runtime found in the open-next.config.ts. Using default config.",
     );
-    //Nothing to do here
   } else {
     compileOpenNextConfigEdge(sourcePath, buildDir, config.edgeExternals ?? []);
   }


### PR DESCRIPTION
The cloudflare adapter will move away from using an internal middleware.

With this change we can still force the compilation of an edge configuration when the middleware is part of the server bundle.

(Longer term we might want to find a better solution to detect this)