### PR TITLE
fix: merge request headers in middleware in app-router example

### DIFF
--- a/examples/app-router/middleware.ts
+++ b/examples/app-router/middleware.ts
@@ -28,7 +28,7 @@ export function middleware(request: NextRequest) {
     const u = new URL("https://opennext.js.org/share.png");
     return NextResponse.rewrite(u);
   }
-  const requestHeaders = new Headers();
+  const requestHeaders = new Headers(request.headers);
   // Setting the Request Headers, this should be available in RSC
   requestHeaders.set("request-header", "request-header");
   requestHeaders.set(

--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -151,11 +151,13 @@ export async function handleMiddleware(
   // If the middleware returned a Rewrite, set the `url` to the pathname of the rewrite
   // NOTE: the header was added to `req` from above
   const rewriteUrl = responseHeaders.get("x-middleware-rewrite");
+  let rewritten = false;
   let isExternalRewrite = false;
   let middlewareQueryString = internalEvent.query;
   let newUrl = internalEvent.url;
   if (rewriteUrl) {
     newUrl = rewriteUrl;
+    rewritten = true;
     // If not a string, it should probably throw
     if (isExternal(newUrl, internalEvent.headers.host as string)) {
       isExternalRewrite = true;

--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -151,13 +151,11 @@ export async function handleMiddleware(
   // If the middleware returned a Rewrite, set the `url` to the pathname of the rewrite
   // NOTE: the header was added to `req` from above
   const rewriteUrl = responseHeaders.get("x-middleware-rewrite");
-  let rewritten = false;
   let isExternalRewrite = false;
   let middlewareQueryString = internalEvent.query;
   let newUrl = internalEvent.url;
   if (rewriteUrl) {
     newUrl = rewriteUrl;
-    rewritten = true;
     // If not a string, it should probably throw
     if (isExternal(newUrl, internalEvent.headers.host as string)) {
       isExternalRewrite = true;


### PR DESCRIPTION
When doing `pnpm build && pnpm start` in `app-router`. You will get an error when trying to run the e2e test locally for `/methods/post/formdata`:

`⨯ TypeError: Content-Type was not one of "multipart/form-data" or "application/x-www-form-urlencoded".`

The reason is this line: https://github.com/opennextjs/opennextjs-aws/blob/fbe09aed4280a5c0820efda74230a12c7cd5bf2c/examples/app-router/middleware.ts#L31

I guess we need to pass in the request headers already coming in. Reason it works once deployed is because OpenNext doesn't remove them like `next start`.

I also removed an unused variable in `/src/core/routing/middleware.ts`