### PR TITLE
fix(middleware): Support wasm in bundled middleware

### DIFF
--- a/.changeset/perfect-cobras-move.md
+++ b/.changeset/perfect-cobras-move.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(middleware): copy wasm files for bundled middleware

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import type { FunctionOptions, SplittedFunctionOptions } from "types/open-next";
 
+import { loadMiddlewareManifest } from "config/util.js";
 import type { Plugin } from "esbuild";
 import logger from "../logger.js";
 import { minifyAll } from "../minimize-js.js";
@@ -135,12 +136,14 @@ async function generateBundle(
   //       `.next/standalone/package/path` (ie. `.next`, `server.js`).
   //       We need to output the handler file inside the package path.
   const packagePath = buildHelper.getPackagePath(options);
-  fs.mkdirSync(path.join(outputPath, packagePath), { recursive: true });
+  const outPackagePath = path.join(outputPath, packagePath);
+
+  fs.mkdirSync(outPackagePath, { recursive: true });
 
   const ext = fnOptions.runtime === "deno" ? "mjs" : "cjs";
   fs.copyFileSync(
     path.join(options.buildDir, `cache.${ext}`),
-    path.join(outputPath, packagePath, "cache.cjs"),
+    path.join(outPackagePath, "cache.cjs"),
   );
 
   if (fnOptions.runtime === "deno") {
@@ -150,7 +153,7 @@ async function generateBundle(
   // Bundle next server if necessary
   const isBundled = fnOptions.experimentalBundledNextServer ?? false;
   if (isBundled) {
-    await bundleNextServer(path.join(outputPath, packagePath), appPath, {
+    await bundleNextServer(outPackagePath, appPath, {
       minify: options.minify,
     });
   }
@@ -159,15 +162,26 @@ async function generateBundle(
   if (!config.middleware?.external) {
     fs.copyFileSync(
       path.join(options.buildDir, "middleware.mjs"),
-      path.join(outputPath, packagePath, "middleware.mjs"),
+      path.join(outPackagePath, "middleware.mjs"),
     );
+
+    const middlewareManifest = loadMiddlewareManifest(
+      path.join(options.appBuildOutputPath, ".next"),
+    );
+    const wasmFiles = middlewareManifest.middleware["/"]?.wasm ?? [];
+    if (wasmFiles.length > 0) {
+      fs.mkdirSync(path.join(outPackagePath, "wasm"), { recursive: true });
+      for (const wasmFile of wasmFiles) {
+        fs.copyFileSync(
+          path.join(options.appBuildOutputPath, ".next", wasmFile.filePath),
+          path.join(outPackagePath, `wasm/${wasmFile.name}.wasm`),
+        );
+      }
+    }
   }
 
   // Copy open-next.config.mjs
-  buildHelper.copyOpenNextConfig(
-    options.buildDir,
-    path.join(outputPath, packagePath),
-  );
+  buildHelper.copyOpenNextConfig(options.buildDir, outPackagePath);
 
   // Copy env files
   buildHelper.copyEnvFile(appBuildOutputPath, packagePath, outputPath);

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -14,7 +14,10 @@ import { getCrossPlatformPathRegex } from "../utils/regex.js";
 import { bundleNextServer } from "./bundleNextServer.js";
 import { compileCache } from "./compileCache.js";
 import { copyTracedFiles } from "./copyTracedFiles.js";
-import { generateEdgeBundle } from "./edge/createEdgeBundle.js";
+import {
+  copyMiddlewareResources,
+  generateEdgeBundle,
+} from "./edge/createEdgeBundle.js";
 import * as buildHelper from "./helper.js";
 import { installDependencies } from "./installDeps.js";
 import { type CodePatcher, applyCodePatches } from "./patch/codePatcher.js";
@@ -168,16 +171,12 @@ async function generateBundle(
     const middlewareManifest = loadMiddlewareManifest(
       path.join(options.appBuildOutputPath, ".next"),
     );
-    const wasmFiles = middlewareManifest.middleware["/"]?.wasm ?? [];
-    if (wasmFiles.length > 0) {
-      fs.mkdirSync(path.join(outPackagePath, "wasm"), { recursive: true });
-      for (const wasmFile of wasmFiles) {
-        fs.copyFileSync(
-          path.join(options.appBuildOutputPath, ".next", wasmFile.filePath),
-          path.join(outPackagePath, `wasm/${wasmFile.name}.wasm`),
-        );
-      }
-    }
+
+    copyMiddlewareResources(
+      options,
+      middlewareManifest.middleware["/"],
+      outPackagePath,
+    );
   }
 
   // Copy open-next.config.mjs

--- a/packages/open-next/src/plugins/edge.ts
+++ b/packages/open-next/src/plugins/edge.ts
@@ -139,15 +139,18 @@ if (!globalThis.URLPattern) {
 `
 }
 ${wasmFiles
-  .map((file) =>
+  .map((file, i) =>
     isInCloudfare
-      ? `import ${file.name} from './wasm/${file.name}.wasm';`
+      ? // Decorate the name to avoid name collisions
+        `import __OpenNextWasm${i} from './wasm/${file.name}.wasm';
+globalThis.${file.name} = __OpenNextWasm${i}`
       : `const ${file.name} = readFileSync(path.join(__dirname,'/wasm/${file.name}.wasm'));`,
   )
   .join("\n")}
 ${entryFiles.map((file) => `require("${file}");`).join("\n")}
 ${contents}
         `;
+
           return {
             contents,
           };

--- a/packages/open-next/src/plugins/edge.ts
+++ b/packages/open-next/src/plugins/edge.ts
@@ -24,19 +24,19 @@ import { getCrossPlatformPathRegex } from "../utils/regex.js";
 export interface IPluginSettings {
   nextDir: string;
   middlewareInfo?: MiddlewareInfo;
-  isInCloudfare?: boolean;
+  isInCloudflare?: boolean;
 }
 
 /**
  * @param opts.nextDir - The path to the .next directory
  * @param opts.middlewareInfo - Information about the middleware
- * @param opts.isInCloudfare - Whether the code runs on the cloudflare runtime
+ * @param opts.isInCloudflare - Whether the code runs on the cloudflare runtime
  * @returns
  */
 export function openNextEdgePlugins({
   nextDir,
   middlewareInfo,
-  isInCloudfare,
+  isInCloudflare,
 }: IPluginSettings): Plugin {
   const entryFiles =
     middlewareInfo?.files.map((file: string) => path.join(nextDir, file)) ?? [];
@@ -94,7 +94,7 @@ globalThis.self = globalThis;
 globalThis._ROUTES = ${JSON.stringify(routes)};
 
 ${
-  isInCloudfare
+  isInCloudflare
     ? ""
     : `
 import {readFileSync} from "node:fs";
@@ -138,15 +138,7 @@ if (!globalThis.URLPattern) {
 }
 `
 }
-${wasmFiles
-  .map((file, i) =>
-    isInCloudfare
-      ? // Decorate the name to avoid name collisions
-        `import __OpenNextWasm${i} from './wasm/${file.name}.wasm';
-globalThis.${file.name} = __OpenNextWasm${i}`
-      : `const ${file.name} = readFileSync(path.join(__dirname,'/wasm/${file.name}.wasm'));`,
-  )
-  .join("\n")}
+${importWasm(wasmFiles, { isInCloudflare })}
 ${entryFiles.map((file) => `require("${file}");`).join("\n")}
 ${contents}
         `;
@@ -204,4 +196,23 @@ ${contents}
       );
     },
   };
+}
+
+function importWasm(
+  files: MiddlewareInfo["wasm"],
+  { isInCloudflare }: { isInCloudflare?: boolean },
+) {
+  return files
+    .map(({ name }) => {
+      if (isInCloudflare) {
+        // As `.next/server/src/middleware.js` references the name,
+        // using `import ${name} from '...'` would cause ESBuild to rename the import.
+        // We use `globalThis.${name}` to make sure `middleware.js` reference name will match.
+        return `import __onw_${name}__ from './wasm/${name}.wasm'
+globalThis.${name} = __onw_${name}__`;
+      }
+
+      return `const ${name} = readFileSync(path.join(__dirname,'/wasm/${name}.wasm'));`;
+    })
+    .join("\n");
 }


### PR DESCRIPTION
Related to https://github.com/opennextjs/opennextjs-cloudflare/issues/471

2 fixes in this PR:

- For bundled middleware, we do copy the source file (in `createServerBundle` but we also need to copy .wasm files
- The second fix is specific for the edge, the file name is used in Next middleware source, then if we re-use the same name to import the same file, ESBulid will append a 2 and Next can not reference this import.

