### PR TITLE
refactor: re-export the handler by name

### DIFF
--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -348,7 +348,7 @@ function addMonorepoEntrypoint(outputPath: string, packagePath: string) {
   const packagePosixPath = packagePath.split(path.sep).join(path.posix.sep);
   fs.writeFileSync(
     path.join(outputPath, "index.mjs"),
-    `export * from "./${packagePosixPath}/index.mjs";`,
+    `export { handler } from "./${packagePosixPath}/index.mjs";`,
   );
 }
 


### PR DESCRIPTION
This caused an issue in Cloudflare, see https://github.com/opennextjs/opennextjs-cloudflare/pull/509