### PR TITLE
fix stream not returning data in node 21+ with node wrapper

### DIFF
--- a/.changeset/fair-ducks-shake.md
+++ b/.changeset/fair-ducks-shake.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix stream not returning in node 21+

--- a/packages/open-next/src/overrides/wrappers/node.ts
+++ b/packages/open-next/src/overrides/wrappers/node.ts
@@ -13,7 +13,6 @@ const wrapper: WrapperHandler = async (handler, converter) => {
         res.setHeader("Set-Cookie", prelude.cookies);
         res.writeHead(prelude.statusCode, prelude.headers);
         res.flushHeaders();
-        res.uncork();
         return res;
       },
     };


### PR DESCRIPTION
Since this PR: https://github.com/nodejs/node/pull/50167 merged in node 21, calling `.uncork()` without having called `.cork()`before seems to block future write to the stream.