### PR TITLE
fix for fully-static pages router page

### DIFF
--- a/.changeset/grumpy-pens-shake.md
+++ b/.changeset/grumpy-pens-shake.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix cache-control header for fully static page router route

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -243,7 +243,11 @@ export function fixCacheHeaderForHtmlPages(
   const localizedPath = localizePath(internalEvent);
   // WORKAROUND: `NextServer` does not set cache headers for HTML pages
   // https://opennext.js.org/aws/v2/advanced/workaround#workaround-nextserver-does-not-set-cache-headers-for-html-pages
-  if (HtmlPages.includes(localizedPath)) {
+  // We need to not cache if the request contains an `x-middleware-prefetch` header
+  if (
+    HtmlPages.includes(localizedPath) &&
+    !internalEvent.headers["x-middleware-prefetch"]
+  ) {
     headers[CommonHeaders.CACHE_CONTROL] =
       "public, max-age=0, s-maxage=31536000, must-revalidate";
   }

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -243,7 +243,7 @@ export function fixCacheHeaderForHtmlPages(
   const localizedPath = localizePath(internalEvent);
   // WORKAROUND: `NextServer` does not set cache headers for HTML pages
   // https://opennext.js.org/aws/v2/advanced/workaround#workaround-nextserver-does-not-set-cache-headers-for-html-pages
-  // We need to not cache if the request contains an `x-middleware-prefetch` header
+  // Requests containing an `x-middleware-prefetch` header must not be cached
   if (
     HtmlPages.includes(localizedPath) &&
     !internalEvent.headers["x-middleware-prefetch"]

--- a/packages/tests-unit/tests/core/routing/util.test.ts
+++ b/packages/tests-unit/tests/core/routing/util.test.ts
@@ -487,6 +487,7 @@ describe("fixCacheHeaderForHtmlPages", () => {
     fixCacheHeaderForHtmlPages(
       {
         rawPath: "/my-html-page",
+        headers: {},
       },
       headers,
     );
@@ -494,6 +495,23 @@ describe("fixCacheHeaderForHtmlPages", () => {
     expect(headers["cache-control"]).toBe(
       "public, max-age=0, s-maxage=31536000, must-revalidate",
     );
+  });
+
+  it("should not add cache-control header for html page but with an `x-middleware-prefetch` header", () => {
+    const headers: Record<string, string> = {};
+    config.HtmlPages.push("/my-html-page");
+
+    fixCacheHeaderForHtmlPages(
+      {
+        rawPath: "/my-html-page",
+        headers: {
+          "x-middleware-prefetch": "1",
+        },
+      },
+      headers,
+    );
+
+    expect(headers).not.toHaveProperty("cache-control");
   });
 
   it("should not add cache-control header for non html page", () => {


### PR DESCRIPTION
Fully static pages router page (without `getStaticProps`) can get an incorrect cache-control headers if the `x-middleware-prefetch` header is present