### PR TITLE
Fix middleware fetch

### DIFF
--- a/.changeset/mean-icons-tap.md
+++ b/.changeset/mean-icons-tap.md
@@ -1,0 +1,6 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix issue when returning fetch from the middleware
+Also fix an issue that prevented retunning response with an empty body in the middleware

--- a/examples/app-pages-router/middleware.ts
+++ b/examples/app-pages-router/middleware.ts
@@ -43,6 +43,19 @@ export function middleware(request: NextRequest) {
       },
     });
   }
+
+  if (path === "/head" && request.method === "HEAD") {
+    return new NextResponse(null, {
+      headers: {
+        "x-from-middleware": "true",
+      },
+    });
+  }
+
+  if (path === "/fetch") {
+    // This one test both that we don't modify immutable headers
+    return fetch(new URL("/api/hello", request.url));
+  }
   const rHeaders = new Headers(request.headers);
   const r = NextResponse.next({
     request: {

--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -176,7 +176,7 @@ export async function handleMiddleware(
       statusCode: statusCode,
       headers: resHeaders,
       body,
-      isBase64Encoded: true,
+      isBase64Encoded: false,
     } satisfies InternalResult;
   }
 

--- a/packages/tests-e2e/tests/appPagesRouter/middleware.test.ts
+++ b/packages/tests-e2e/tests/appPagesRouter/middleware.test.ts
@@ -4,8 +4,8 @@ test("should return correctly on HEAD request with an empty body", async ({
   request,
 }) => {
   const response = await request.head("/head");
-  const body = await response.text();
   expect(response.status()).toBe(200);
+  const body = await response.text();
   expect(body).toBe("");
   expect(response.headers()["x-from-middleware"]).toBe("true");
 });
@@ -14,7 +14,7 @@ test("should return correctly for directly returning a fetch response", async ({
   request,
 }) => {
   const response = await request.get("/fetch");
-  const body = await response.json();
   expect(response.status()).toBe(200);
+  const body = await response.json();
   expect(body).toEqual({ hello: "world" });
 });

--- a/packages/tests-e2e/tests/appPagesRouter/middleware.test.ts
+++ b/packages/tests-e2e/tests/appPagesRouter/middleware.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test("should return correctly on HEAD request with an empty body", async ({
   request,

--- a/packages/tests-e2e/tests/appPagesRouter/middleware.test.ts
+++ b/packages/tests-e2e/tests/appPagesRouter/middleware.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+test("should return correctly on HEAD request with an empty body", async ({
+  request,
+}) => {
+  const response = await request.head("/head");
+  const body = await response.text();
+  expect(response.status()).toBe(200);
+  expect(body).toBe("");
+  expect(response.headers()["x-from-middleware"]).toBe("true");
+});
+
+test("should return correctly for directly returning a fetch response", async ({
+  request,
+}) => {
+  const response = await request.get("/fetch");
+  const body = await response.json();
+  expect(response.status()).toBe(200);
+  expect(body).toEqual({ hello: "world" });
+});

--- a/packages/tests-unit/tests/core/routing/middleware.test.ts
+++ b/packages/tests-unit/tests/core/routing/middleware.test.ts
@@ -177,9 +177,7 @@ describe("handleMiddleware", () => {
       ...event,
       rawPath: "/rewrite",
       url: "http://localhost/rewrite",
-      responseHeaders: {
-        "x-middleware-rewrite": "http://localhost/rewrite",
-      },
+      responseHeaders: {},
       isExternalRewrite: false,
     });
   });
@@ -203,9 +201,7 @@ describe("handleMiddleware", () => {
       ...event,
       rawPath: "/rewrite",
       url: "http://localhost/rewrite?newKey=value",
-      responseHeaders: {
-        "x-middleware-rewrite": "http://localhost/rewrite?newKey=value",
-      },
+      responseHeaders: {},
       query: {
         __nextDataReq: "1",
         newKey: "value",
@@ -232,9 +228,7 @@ describe("handleMiddleware", () => {
       ...event,
       rawPath: "/rewrite",
       url: "http://external/rewrite",
-      responseHeaders: {
-        "x-middleware-rewrite": "http://external/rewrite",
-      },
+      responseHeaders: {},
       isExternalRewrite: true,
     });
   });
@@ -244,6 +238,7 @@ describe("handleMiddleware", () => {
     middleware.mockResolvedValue({
       headers: new Headers({
         "x-middleware-request-custom-header": "value",
+        "x-middleware-next": "1",
       }),
     });
     const result = await handleMiddleware(event, "", middlewareLoader);


### PR DESCRIPTION
Fix 2 small issues with the middleware.
- Directly returning a fetch from the middleware crashed because of immutable headers
- Returning a `Response` with an empty body which was not a redirect was not working