### PR TITLE
Fix remove prefetch header for Next 14.1+

### DIFF
--- a/.changeset/eleven-phones-smash.md
+++ b/.changeset/eleven-phones-smash.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+remove prefetch header for next 14.1+

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -253,6 +253,7 @@ async function generateBundle(
         ...(disableNextPrebundledReact ? ["applyNextjsPrebundledReact"] : []),
         ...(disableRouting ? ["withRouting"] : []),
         ...(isAfter142 ? ["patchAsyncStorage"] : []),
+        ...(isAfter141 ? ["appendPrefetch"] : []),
       ],
     }),
     openNextReplacementPlugin({

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -28,6 +28,7 @@ import {
   patchNextServer,
   patchUnstableCacheForISR,
 } from "./patch/patches/index.js";
+import { patchBackgroundRevalidation } from "./patch/patches/patchBackgroundRevalidation.js";
 
 interface CodeCustomization {
   // These patches are meant to apply on user and next generated code
@@ -204,6 +205,7 @@ async function generateBundle(
     patchUnstableCacheForISR,
     patchNextServer,
     patchEnvVars,
+    patchBackgroundRevalidation,
     ...additionalCodePatches,
   ]);
 

--- a/packages/open-next/src/build/patch/patches/patchBackgroundRevalidation.ts
+++ b/packages/open-next/src/build/patch/patches/patchBackgroundRevalidation.ts
@@ -12,10 +12,6 @@ rule:
     -  has:
          kind: member_expression
          regex: "context.isPrefetch"
-    - inside:
-        kind: parenthesized_expression
-        inside:
-          kind: if_statement
 fix:
   'true'`;
 
@@ -23,7 +19,8 @@ export const patchBackgroundRevalidation = {
   name: "patchBackgroundRevalidation",
   patches: [
     {
-      versions: ">=14.0.0",
+      // TODO: test for earlier versions of Next
+      versions: ">=14.1.0",
       field: {
         pathFilter: getCrossPlatformPathRegex("server/response-cache/index.js"),
         patchCode: createPatchCode(rule),

--- a/packages/open-next/src/build/patch/patches/patchBackgroundRevalidation.ts
+++ b/packages/open-next/src/build/patch/patches/patchBackgroundRevalidation.ts
@@ -1,0 +1,33 @@
+import { getCrossPlatformPathRegex } from "utils/regex.js";
+import type { CodePatcher } from "../codePatcher.js";
+import { createPatchCode } from "../astCodePatcher.js";
+
+export const rule = `
+rule:
+  kind: binary_expression
+  all:
+    - has:
+        kind: unary_expression
+        regex: "!cachedResponse.isStale"
+    -  has:
+         kind: member_expression
+         regex: "context.isPrefetch"
+    - inside:
+        kind: parenthesized_expression
+        inside:
+          kind: if_statement
+fix:
+  'true'`;
+
+export const patchBackgroundRevalidation = {
+  name: "patchBackgroundRevalidation",
+  patches: [
+    {
+      versions: ">=14.0.0",
+      field: {
+        pathFilter: getCrossPlatformPathRegex("server/response-cache/index.js"),
+        patchCode: createPatchCode(rule),
+      },
+    },
+  ],
+} satisfies CodePatcher;

--- a/packages/open-next/src/build/patch/patches/patchBackgroundRevalidation.ts
+++ b/packages/open-next/src/build/patch/patches/patchBackgroundRevalidation.ts
@@ -1,6 +1,6 @@
 import { getCrossPlatformPathRegex } from "utils/regex.js";
-import type { CodePatcher } from "../codePatcher.js";
 import { createPatchCode } from "../astCodePatcher.js";
+import type { CodePatcher } from "../codePatcher.js";
 
 export const rule = `
 rule:

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -161,7 +161,12 @@ export async function openNextHandler(
         // 1. We could just let the revalidation go as normal, but due to race conditions the revalidation will be unreliable
         // 2. We could alter the lastModified time of our cache to make next believe that the cache is fresh, but this could cause issues with stale data since the cdn will cache the stale data as if it was fresh
         // 3. OUR CHOICE: We could pass a purpose prefetch header to the serverless function to make next believe that the request is a prefetch request and not trigger revalidation (This could potentially break in the future if next changes the behavior of prefetch requests)
-        headers: { ...headers, purpose: "prefetch" },
+        headers: {
+          ...headers,
+          //#override appendPrefetch
+          purpose: "prefetch",
+          //#endOverride
+        },
         body: preprocessedEvent.body,
         remoteAddress: preprocessedEvent.remoteAddress,
       };

--- a/packages/tests-unit/tests/build/patch/patches/patchBackgroundRevalidation.test.ts
+++ b/packages/tests-unit/tests/build/patch/patches/patchBackgroundRevalidation.test.ts
@@ -1,0 +1,43 @@
+import { patchCode } from "@opennextjs/aws/build/patch/astCodePatcher.js";
+import { rule } from "@opennextjs/aws/build/patch/patches/patchBackgroundRevalidation.js";
+import { describe, it } from "vitest";
+
+const codeToPatch = `if (cachedResponse && !isOnDemandRevalidate) {
+                    var _cachedResponse_value;
+                    if (((_cachedResponse_value = cachedResponse.value) == null ? void 0 : _cachedResponse_value.kind) === _types.CachedRouteKind.FETCH) {
+                        throw new Error(\`invariant: unexpected cachedResponse of kind fetch in response cache\`);
+                    }
+                    resolve({
+                        ...cachedResponse,
+                        revalidate: cachedResponse.curRevalidate
+                    });
+                    resolved = true;
+                    if (!cachedResponse.isStale || context.isPrefetch) {
+                        // The cached value is still valid, so we don't need
+                        // to update it yet.
+                        return null;
+                    }
+                }`;
+
+describe("patchBackgroundRevalidation", () => {
+  it("Should patch code for Next 14+", () => {
+    expect(
+      patchCode(codeToPatch, rule),
+    ).toMatchInlineSnapshot(`"if (cachedResponse && !isOnDemandRevalidate) {
+                    var _cachedResponse_value;
+                    if (((_cachedResponse_value = cachedResponse.value) == null ? void 0 : _cachedResponse_value.kind) === _types.CachedRouteKind.FETCH) {
+                        throw new Error(\`invariant: unexpected cachedResponse of kind fetch in response cache\`);
+                    }
+                    resolve({
+                        ...cachedResponse,
+                        revalidate: cachedResponse.curRevalidate
+                    });
+                    resolved = true;
+                    if (true) {
+                        // The cached value is still valid, so we don't need
+                        // to update it yet.
+                        return null;
+                    }
+                }"`);
+  });
+});


### PR DESCRIPTION
For Next 14.1, we'll rely on a patch to disable background revalidation instead of adding a `purpose:prefetch` header to every request.
Should fix https://github.com/opennextjs/opennextjs-cloudflare/issues/567