### PR TITLE
refactor: export patchBackgroundRevalidation from patches/index.js

### DIFF
--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -22,13 +22,13 @@ import * as buildHelper from "./helper.js";
 import { installDependencies } from "./installDeps.js";
 import { type CodePatcher, applyCodePatches } from "./patch/codePatcher.js";
 import {
+  patchBackgroundRevalidation,
   patchEnvVars,
   patchFetchCacheForISR,
   patchFetchCacheSetMissingWaitUntil,
   patchNextServer,
   patchUnstableCacheForISR,
 } from "./patch/patches/index.js";
-import { patchBackgroundRevalidation } from "./patch/patches/patchBackgroundRevalidation.js";
 
 interface CodeCustomization {
   // These patches are meant to apply on user and next generated code

--- a/packages/open-next/src/build/patch/patches/index.ts
+++ b/packages/open-next/src/build/patch/patches/index.ts
@@ -5,3 +5,4 @@ export {
   patchUnstableCacheForISR,
 } from "./patchFetchCacheISR.js";
 export { patchFetchCacheSetMissingWaitUntil } from "./patchFetchCacheWaitUntil.js";
+export { patchBackgroundRevalidation } from "./patchBackgroundRevalidation.js";


### PR DESCRIPTION
sorry @conico974 I missed that during the review