### PR TITLE
fix(tagCache): do not call writeTags with an empty list

### DIFF
--- a/.changeset/lemon-needles-fold.md
+++ b/.changeset/lemon-needles-fold.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(tagCache): do not call writeTags with an empty list

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -311,8 +311,12 @@ export default class Cache {
     if (config?.disableTagCache || config?.disableIncrementalCache) {
       return;
     }
+    const _tags = Array.isArray(tags) ? tags : [tags];
+    if (_tags.length === 0) {
+      return;
+    }
+
     try {
-      const _tags = Array.isArray(tags) ? tags : [tags];
       if (globalThis.tagCache.mode === "nextMode") {
         const paths = (await globalThis.tagCache.getPathsByTags?.(_tags)) ?? [];
 
@@ -336,6 +340,7 @@ export default class Cache {
         }
         return;
       }
+
       for (const tag of _tags) {
         debug("revalidateTag", tag);
         // Find all keys with the given tag

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -587,6 +587,14 @@ describe("CacheHandler", () => {
       expect(invalidateCdnHandler.invalidatePaths).not.toHaveBeenCalled();
     });
 
+    it("Should not call writeTags when the tag list is empty for nextMode", async () => {
+      globalThis.tagCache.mode = "nextMode";
+      await cache.revalidateTag([]);
+
+      expect(tagCache.writeTags).not.toHaveBeenCalled();
+      expect(invalidateCdnHandler.invalidatePaths).not.toHaveBeenCalled();
+    });
+
     it("Should call writeTags and invalidateCdnHandler.invalidatePaths for nextMode that supports getPathsByTags", async () => {
       globalThis.tagCache.mode = "nextMode";
       globalThis.tagCache.getPathsByTags = vi


### PR DESCRIPTION
See https://github.com/opennextjs/opennextjs-cloudflare/issues/576

Called from `node_modules/next/dist/compiled/next-server/app-route.runtime.dev.js`

```js
_workStore_incrementalCache.revalidateTag(workStore.revalidatedTags||[])
```