### PR TITLE
fix: should return 400 in image optimization when Next passes errorMessage

### DIFF
--- a/.changeset/unlucky-shrimps-lick.md
+++ b/.changeset/unlucky-shrimps-lick.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: return 400 when validateImageParams from Next passes an errorMessage

--- a/packages/open-next/src/adapters/image-optimization-adapter.ts
+++ b/packages/open-next/src/adapters/image-optimization-adapter.ts
@@ -82,6 +82,10 @@ export async function defaultHandler(
     // We return a 400 here if imageParams returns an errorMessage
     // https://github.com/vercel/next.js/blob/512d8283054407ab92b2583ecce3b253c3be7b85/packages/next/src/server/next-server.ts#L937-L941
     if ("errorMessage" in imageParams) {
+      error(
+        "Error during validation of image params",
+        imageParams.errorMessage,
+      );
       return buildFailureResponse(
         imageParams.errorMessage,
         options?.streamCreator,

--- a/packages/open-next/src/adapters/image-optimization-adapter.ts
+++ b/packages/open-next/src/adapters/image-optimization-adapter.ts
@@ -202,7 +202,6 @@ function buildFailureResponse(
     response.writeHead(statusCode, {
       Vary: "Accept",
       "Cache-Control": "public,max-age=60,immutable",
-      "Content-Type": "application/json",
     });
     response.end(e?.message || e?.toString() || "An error occurred");
   }
@@ -214,7 +213,6 @@ function buildFailureResponse(
       Vary: "Accept",
       // For failed images, allow client to retry after 1 minute.
       "Cache-Control": "public,max-age=60,immutable",
-      "Content-Type": "application/json",
     },
     body: toReadableStream(e?.message || e?.toString() || "An error occurred"),
   };

--- a/packages/tests-e2e/tests/appRouter/image-optimization.test.ts
+++ b/packages/tests-e2e/tests/appRouter/image-optimization.test.ts
@@ -19,7 +19,7 @@ test("Image Optimization", async ({ page }) => {
   await expect(el).not.toHaveJSProperty("naturalWidth", 0);
 });
 
-test("should return 400 on bad request", async ({ request }) => {
+test("should return 400 when validateParams returns an errorMessage", async ({ request }) => {
   const res = await request.get("/_next/image");
   expect(res.status()).toBe(400);
   expect(res.headers()["cache-control"]).toBe("public,max-age=60,immutable");

--- a/packages/tests-e2e/tests/appRouter/image-optimization.test.ts
+++ b/packages/tests-e2e/tests/appRouter/image-optimization.test.ts
@@ -18,3 +18,10 @@ test("Image Optimization", async ({ page }) => {
   await expect(el).toHaveJSProperty("complete", true);
   await expect(el).not.toHaveJSProperty("naturalWidth", 0);
 });
+
+test("should return 400 on bad request", async ({ request }) => {
+  const res = await request.get("/_next/image");
+  expect(res.status()).toBe(400);
+  expect(res.headers()["cache-control"]).toBe("public,max-age=60,immutable");
+  expect(await res.text()).toBe(`"url" parameter is required`);
+});

--- a/packages/tests-e2e/tests/appRouter/image-optimization.test.ts
+++ b/packages/tests-e2e/tests/appRouter/image-optimization.test.ts
@@ -19,7 +19,9 @@ test("Image Optimization", async ({ page }) => {
   await expect(el).not.toHaveJSProperty("naturalWidth", 0);
 });
 
-test("should return 400 when validateParams returns an errorMessage", async ({ request }) => {
+test("should return 400 when validateParams returns an errorMessage", async ({
+  request,
+}) => {
   const res = await request.get("/_next/image");
   expect(res.status()).toBe(400);
   expect(res.headers()["cache-control"]).toBe("public,max-age=60,immutable");


### PR DESCRIPTION
For #826 

In versions 13, 14, and 15, `next start` returns a 400 Bad Request if `validateImageParams` returns an `errorMessage`. We should align with this behavior.
