### PR TITLE
Pass `revalidate` value to the incremental cache for ISR/SSG route

### DIFF
--- a/.changeset/lucky-ghosts-knock.md
+++ b/.changeset/lucky-ghosts-knock.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+pass revalidate for ISR/SSG cache

--- a/packages/open-next/src/types/cache.ts
+++ b/packages/open-next/src/types/cache.ts
@@ -98,7 +98,7 @@ export type TagCacheMetaFile = {
   revalidatedAt: { N: string };
 };
 
-// Cache context since https://github.com/vercel/next.js/pull/76207
+// Cache context since vercel/next.js#76207
 interface SetIncrementalFetchCacheContext {
   fetchCache: true;
   fetchUrl?: string;
@@ -124,14 +124,14 @@ interface SetIncrementalResponseCacheContext {
   isFallback?: boolean;
 }
 
-// Before #76207 revalidate was passed this way
+// Before vercel/next.js#76207 revalidate was passed this way
 interface SetIncrementalCacheContext {
   revalidate?: number | false;
   isRoutePPREnabled?: boolean;
   isFallback?: boolean;
 }
 
-// Before https://github.com/vercel/next.js/pull/53321 context on set was just the revalidate
+// Before vercel/next.js#53321 context on set was just the revalidate
 type OldSetIncrementalCacheContext = number | false | undefined;
 
 export type IncrementalCacheContext =

--- a/packages/open-next/src/types/cache.ts
+++ b/packages/open-next/src/types/cache.ts
@@ -98,10 +98,44 @@ export type TagCacheMetaFile = {
   revalidatedAt: { N: string };
 };
 
-export type IncrementalCacheContext = {
-  revalidate?: number | false | undefined;
-  fetchCache?: boolean | undefined;
-  fetchUrl?: string | undefined;
-  fetchIdx?: number | undefined;
-  tags?: string[] | undefined;
-};
+// Cache context since https://github.com/vercel/next.js/pull/76207
+interface SetIncrementalFetchCacheContext {
+  fetchCache: true;
+  fetchUrl?: string;
+  fetchIdx?: number;
+  tags?: string[];
+}
+
+interface SetIncrementalResponseCacheContext {
+  fetchCache?: false;
+  cacheControl?: {
+    revalidate: number | false;
+    expire?: number;
+  };
+
+  /**
+   * True if the route is enabled for PPR.
+   */
+  isRoutePPREnabled?: boolean;
+
+  /**
+   * True if this is a fallback request.
+   */
+  isFallback?: boolean;
+}
+
+// Before #76207 revalidate was passed this way
+interface SetIncrementalCacheContext {
+  revalidate?: number | false;
+  isRoutePPREnabled?: boolean;
+  isFallback?: boolean;
+}
+
+// Before https://github.com/vercel/next.js/pull/53321 context on set was just the revalidate
+type OldSetIncrementalCacheContext = number | false | undefined;
+
+export type IncrementalCacheContext =
+  | OldSetIncrementalCacheContext
+  | SetIncrementalCacheContext
+  | SetIncrementalFetchCacheContext
+  | SetIncrementalResponseCacheContext;

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -79,7 +79,12 @@ export type WithLastModified<T> = {
 
 export type CacheValue<IsFetch extends boolean> = (IsFetch extends true
   ? CachedFetchValue
-  : CachedFile) & { revalidate?: number | false };
+  : CachedFile) & {
+  /**
+   * This is available for page cache entry, but only at runtime.
+   */
+  revalidate?: number | false;
+};
 
 export type IncrementalCache = {
   get<IsFetch extends boolean = false>(


### PR DESCRIPTION
This PR will compute the correct revalidate value at runtime for ISR/SSG route to be used by the incremental cache

It depends on #832, just to avoid deleting and recreating a cloudfront distribution every time i switch branch.
I'll rebased #820 on this as well