### PR TITLE
trace node packages

### DIFF
--- a/.changeset/smooth-tomatoes-compete.md
+++ b/.changeset/smooth-tomatoes-compete.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+trace node packages


### PR DESCRIPTION
In the cloudflare adapter, we want to copy files used via the "workerd" build conditions.

To be able to do this this PR updates `copyTracedFiles` to return a map of traced node packages.
It maps the original path of the package to the path in `.open-next`.

As a follow up, we might integrate that better with the patch system.
Today, `applyCodePatches` assumes that a patch will update file content.
We could modify `applyCodePatches` to take a list of `Patch`. 
The `Patch` class would be instantiated with `options, tracedFiles, manifests, nodePackages, nextVersion` and have a public `apply` method.
We could then have derived `PatchFileContent`, `PatchCopyFile`, ... classes.



