### PR TITLE
fix(e2e): add await in middleware rewrite

### DIFF
--- a/packages/tests-e2e/tests/appPagesRouter/middleware.rewrite.test.ts
+++ b/packages/tests-e2e/tests/appPagesRouter/middleware.rewrite.test.ts
@@ -39,6 +39,6 @@ test.describe("Middleware Rewrite", () => {
     await expect(el).toBeVisible();
     el = page.getByText("multi:", { exact: true });
     await expect(el).toBeVisible();
-    expect(el).toHaveText("multi:");
+    await expect(el).toHaveText("multi:");
   });
 });


### PR DESCRIPTION
This caused some issues running the E2E locally for me. If I ran the test with `test.only()` it would work. Not sure why it works in our GitHub Actions either. Anyhow, that line should be awaited.