### PR TITLE
fix(middleware): copy wasm files for middleware

### DIFF
--- a/.changeset/popular-candles-watch.md
+++ b/.changeset/popular-candles-watch.md
@@ -1,5 +1,5 @@
 ---
-"@opennextjs/aws": major
+"@opennextjs/aws": patch
 ---
 
-fix(middleware): copy wasm files for bundled middleware
+fix(middleware): copy wasm files for the external middleware

--- a/.changeset/popular-candles-watch.md
+++ b/.changeset/popular-candles-watch.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": major
+---
+
+fix(middleware): copy wasm files for bundled middleware

--- a/packages/open-next/src/build/createMiddleware.ts
+++ b/packages/open-next/src/build/createMiddleware.ts
@@ -7,7 +7,7 @@ import {
 } from "config/util.js";
 import logger from "../logger.js";
 import type { MiddlewareInfo } from "../types/next-types.js";
-import { buildEdgeBundle } from "./edge/createEdgeBundle.js";
+import { buildEdgeBundle, copyMiddlewareResources } from "./edge/createEdgeBundle.js";
 import * as buildHelper from "./helper.js";
 import { installDependencies } from "./installDeps.js";
 import {
@@ -51,8 +51,10 @@ export async function createMiddleware(
     }
   }
 
+  const outputPath = path.join(outputDir, "middleware");
+  copyMiddlewareResources(options, edgeMiddlewareInfo, outputPath);
+
   if (config.middleware?.external) {
-    const outputPath = path.join(outputDir, "middleware");
     fs.mkdirSync(outputPath, { recursive: true });
 
     // Copy open-next.config.mjs

--- a/packages/open-next/src/build/createMiddleware.ts
+++ b/packages/open-next/src/build/createMiddleware.ts
@@ -7,7 +7,10 @@ import {
 } from "config/util.js";
 import logger from "../logger.js";
 import type { MiddlewareInfo } from "../types/next-types.js";
-import { buildEdgeBundle, copyMiddlewareResources } from "./edge/createEdgeBundle.js";
+import {
+  buildEdgeBundle,
+  copyMiddlewareResources,
+} from "./edge/createEdgeBundle.js";
 import * as buildHelper from "./helper.js";
 import { installDependencies } from "./installDeps.js";
 import {
@@ -51,10 +54,10 @@ export async function createMiddleware(
     }
   }
 
-  const outputPath = path.join(outputDir, "middleware");
-  copyMiddlewareResources(options, edgeMiddlewareInfo, outputPath);
-
   if (config.middleware?.external) {
+    const outputPath = path.join(outputDir, "middleware");
+    copyMiddlewareResources(options, edgeMiddlewareInfo, outputPath);
+
     fs.mkdirSync(outputPath, { recursive: true });
 
     // Copy open-next.config.mjs


### PR DESCRIPTION
prisma's wasm was not being copied into the middleware directory, which was throwing errors when prisma was being used in the middleware with the authjs database adaptor.

added the copyMiddlewareResources which is already being used in createServerBundle