### PR TITLE
Redirect requests with repeated slashes

### DIFF
--- a/.changeset/cuddly-dingos-walk.md
+++ b/.changeset/cuddly-dingos-walk.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+feat: redirect requests with repeated slashes

--- a/packages/open-next/src/core/routing/matcher.ts
+++ b/packages/open-next/src/core/routing/matcher.ts
@@ -263,6 +263,10 @@ export function handleRewrites<T extends RewriteDefinition>(
   };
 }
 
+// Normalizes repeated slashes in the path e.g. hello//world -> hello/world
+// or backslashes to forward slashes. This prevents requests such as //domain
+// from invoking the middleware with `request.url === "domain"`.
+// See: https://github.com/vercel/next.js/blob/3ecf087f10fdfba4426daa02b459387bc9c3c54f/packages/next/src/server/base-server.ts#L1016-L1020
 function handleRepeatedSlashRedirect(
   event: InternalEvent,
 ): false | InternalResult {

--- a/packages/open-next/src/core/routing/matcher.ts
+++ b/packages/open-next/src/core/routing/matcher.ts
@@ -10,7 +10,7 @@ import type {
 } from "types/next-types";
 import type { InternalEvent, InternalResult } from "types/open-next";
 import { emptyReadableStream, toReadableStream } from "utils/stream";
-import { normalizePath } from "utils/normalize-path"
+import { normalizeRepeatedSlashes } from "utils/normalize-path"
 
 import { debug } from "../../adapters/logger";
 import { handleLocaleRedirect, localizePath } from "./i18n";
@@ -267,15 +267,12 @@ function handleRepeatedSlashRedirect(
   event: InternalEvent,
 ): false | InternalResult {
   // Redirect `https://example.com//foo` to `https://example.com/foo`.
-  const url = new URL(event.url);
-  if (url.pathname.match(/(\\|\/\/)/)) {
+  if (event.rawPath.match(/(\\|\/\/)/)) {
     return {
       type: event.type,
       statusCode: 308,
       headers: {
-        Location: `${url.protocol}//${url.host}${normalizePath(url.pathname)}${
-          url.search
-        }`,
+        Location: normalizeRepeatedSlashes(new URL(event.url)),
       },
       body: emptyReadableStream(),
       isBase64Encoded: false,

--- a/packages/open-next/src/core/routing/matcher.ts
+++ b/packages/open-next/src/core/routing/matcher.ts
@@ -9,8 +9,8 @@ import type {
   RouteHas,
 } from "types/next-types";
 import type { InternalEvent, InternalResult } from "types/open-next";
+import { normalizeRepeatedSlashes } from "utils/normalize-path";
 import { emptyReadableStream, toReadableStream } from "utils/stream";
-import { normalizeRepeatedSlashes } from "utils/normalize-path"
 
 import { debug } from "../../adapters/logger";
 import { handleLocaleRedirect, localizePath } from "./i18n";

--- a/packages/open-next/src/utils/normalize-path.ts
+++ b/packages/open-next/src/utils/normalize-path.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 
 export function normalizePath(path: string) {
-  return path.replace(/\\/g, "/");
+  return path.replace(/\\/g, "/").replace(/\/\/+/g, "/");
 }
 
 export function getMonorepoRelativePath(relativePath = "../.."): string {

--- a/packages/open-next/src/utils/normalize-path.ts
+++ b/packages/open-next/src/utils/normalize-path.ts
@@ -1,7 +1,14 @@
 import path from "node:path";
 
 export function normalizePath(path: string) {
-  return path.replace(/\\/g, "/").replace(/\/\/+/g, "/");
+  return path.replace(/\\/g, "/");
+}
+
+export function normalizeRepeatedSlashes(url: URL) {
+  const urlNoQuery = url.host + url.pathname;
+  return `${url.protocol}//${urlNoQuery
+    .replace(/\\/g, "/")
+    .replace(/\/\/+/g, "/")}${url.search}`;
 }
 
 export function getMonorepoRelativePath(relativePath = "../.."): string {

--- a/packages/open-next/src/utils/normalize-path.ts
+++ b/packages/open-next/src/utils/normalize-path.ts
@@ -4,6 +4,7 @@ export function normalizePath(path: string) {
   return path.replace(/\\/g, "/");
 }
 
+// See: https://github.com/vercel/next.js/blob/3ecf087f10fdfba4426daa02b459387bc9c3c54f/packages/next/src/shared/lib/utils.ts#L348
 export function normalizeRepeatedSlashes(url: URL) {
   const urlNoQuery = url.host + url.pathname;
   return `${url.protocol}//${urlNoQuery

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -271,6 +271,17 @@ describe("getNextConfigHeaders", () => {
 });
 
 describe("handleRedirects", () => {
+  it("should redirect repeated slashes", () => {
+    const event = createEvent({
+      url: "https://on/api-route//foo",
+    });
+
+    const result = handleRedirects(event, []);
+
+    expect(result.statusCode).toEqual(308);
+    expect(result.headers.Location).toEqual("https://on/api-route/foo");
+  });
+
   it("should redirect trailing slash by default", () => {
     const event = createEvent({
       url: "https://on/api-route/",


### PR DESCRIPTION
Let's say you had the following middleware function:
```ts
export async function middleware(request: NextRequest) {
  return NextResponse.redirect(new URL("/foo", request.url))
}
```
A request to `https://yourdomain.com//evil.com` would result in `request.url ===  "https://evil.com"`, leading to a malicious redirect. Here we redirect these bad requests containing repeated slashes to a sanitised path.