### PR TITLE
Fix NODE_ENV in edge config compilation

### DIFF
--- a/.changeset/bright-pants-drum.md
+++ b/.changeset/bright-pants-drum.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+set process.env.NODE_ENV to production during edge config compilation

--- a/packages/open-next/src/build/compileConfig.ts
+++ b/packages/open-next/src/build/compileConfig.ts
@@ -118,5 +118,9 @@ export function compileOpenNextConfigEdge(
     conditions: ["worker", "browser"],
     platform: "browser",
     external: externals,
+    define: {
+      // with the default esbuild config, the NODE_ENV will be set to "development", we don't want that
+      "process.env.NODE_ENV": "production",
+    },
   });
 }


### PR DESCRIPTION
Set `process.env.NODE_ENV` to production during edge config compilation to avoid defaulting to development.