### PR TITLE
fix(converters):  we remove leading forward slashes from url

### DIFF
--- a/packages/open-next/src/overrides/converters/node.ts
+++ b/packages/open-next/src/overrides/converters/node.ts
@@ -25,7 +25,10 @@ const converter: Converter = {
         ])
         .filter(([key]) => key),
     );
-    const url = new URL(req.url!, `http://${extractHostFromHeaders(headers)}`);
+    const url = new URL(
+      req.url!.replace(/^\/\/+/, "/"),
+      `http://${extractHostFromHeaders(headers)}`,
+    );
     const query = getQueryFromSearchParams(url.searchParams);
     return {
       type: "core",


### PR DESCRIPTION
We should remove leading slashes from `req.url` before passing it in to `new URL()` to prevent URL parsing attack. (protocol-relative URL)