### PR TITLE
fix(converters): Ensure x-forwarded-proto is set to http when running locally

### DIFF
--- a/.changeset/fair-pillows-yawn.md
+++ b/.changeset/fair-pillows-yawn.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(expres-dev): Ensure x-forwarded-proto and \_\_NEXT_PRIVATE_ORIGIN is set

--- a/packages/open-next/src/overrides/wrappers/express-dev.ts
+++ b/packages/open-next/src/overrides/wrappers/express-dev.ts
@@ -34,6 +34,12 @@ const wrapper: WrapperHandler = async (handler, converter) => {
   });
 
   app.all("*paths", async (req, res) => {
+    if (req.protocol === "http" && req.hostname === "localhost") {
+      // This is used internally by Next.js during redirects in server actions. We need to set it to the origin of the request.
+      process.env.__NEXT_PRIVATE_ORIGIN = `${req.protocol}://${req.hostname}`;
+      // This is to make `next-auth` and other libraries that rely on this header to work locally out of the box.
+      req.headers["x-forwarded-proto"] = req.protocol;
+    }
     const internalEvent = await converter.convertFrom(req);
     const streamCreator: StreamCreator = {
       writeHeaders: (prelude) => {


### PR DESCRIPTION
Discussed in [#686](https://github.com/opennextjs/opennextjs-cloudflare/issues/686) over at `opennextjs-cloudflare`

`next-auth` and possibly more libraries rely on the `x-forwarded-proto` header to be `http` to work out of the box when run locally. In `next start` or `next dev` they set this to `http` when ran locally. 

To make `opennextjs-cloudflarejs preview` and our node converter when running OpenNext locally behave the same we would want to set this header to `http`. This would make the user not have to set an [`AUTH_URL`](https://authjs.dev/getting-started/deployment#auth_url) in those modes.