### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ OpenNext takes the Next.js build output and converts it into packages that can b
 
 ## Features
 
-OpenNext aims to support all Next.js 14 features. Some features are work in progress. If you are running into any problems make sure to check the [docs](https://opennext.js.org/aws) first before you open a [new issue](/issues/new) or visit our [Discord](https://discord.gg/opennextjs) to let us know!
+OpenNext aims to support all Next.js 15 features. Some features are work in progress. If you are running into any problems make sure to check the [docs](https://opennext.js.org/aws) first before you open a [new issue](/issues/new) or visit our [Discord](https://discord.gg/opennextjs) to let us know!
 
 - [x] App & Pages Router
 - [x] API routes


### PR DESCRIPTION
In the [docs](https://opennext.js.org/aws) you have the Next.js 15 instead of 14. 
![image](https://github.com/user-attachments/assets/d434bd2d-1563-4240-8202-30ff44c96a6d)
