### PR TITLE
feat: add css files to server bundle for optimizeCss feature to work

### DIFF
--- a/.changeset/stale-years-arrive.md
+++ b/.changeset/stale-years-arrive.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/aws": patch
+---
+
+- add css files to server bundle for optimizeCss feature to work
+
+- load all manifests and configs in copyTracedFiles in one place once

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -2,6 +2,7 @@ import url from "node:url";
 
 import {
   copyFileSync,
+  cpSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -359,6 +360,14 @@ File ${serverPath} does not exist
       .filter((file) => file.endsWith(".html"))
       .forEach((file) => copyStaticFile(`server/${file}`));
   }
+
+  // Copy .next/static/css from standalone to output dir
+  // needed for optimizeCss feature to work
+  cpSync(
+    path.join(standaloneNextDir, "static", "css"),
+    path.join(outputNextDir, "static", "css"),
+    { recursive: true },
+  );
 
   logger.debug("copyTracedFiles:", Date.now() - tsStart, "ms");
 

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -361,19 +361,25 @@ File ${serverPath} does not exist
       .forEach((file) => copyStaticFile(`server/${file}`));
   }
 
+  const manifests = getManifests(standaloneNextDir);
+
+  const { optimizeCss } = manifests.config.experimental;
+
   // Copy .next/static/css from standalone to output dir
   // needed for optimizeCss feature to work
-  cpSync(
-    path.join(standaloneNextDir, "static", "css"),
-    path.join(outputNextDir, "static", "css"),
-    { recursive: true },
-  );
+  if (optimizeCss) {
+    cpSync(
+      path.join(standaloneNextDir, "static", "css"),
+      path.join(outputNextDir, "static", "css"),
+      { recursive: true },
+    );
+  }
 
   logger.debug("copyTracedFiles:", Date.now() - tsStart, "ms");
 
   return {
     tracedFiles,
     nodePackages,
-    manifests: getManifests(standaloneNextDir),
+    manifests,
   };
 }

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -332,17 +332,17 @@ File ${serverPath} does not exist
       );
     }
   };
+
+  const manifests = getManifests(standaloneNextDir);
+  const { config, prerenderManifest, pagesManifest } = manifests;
+
   // Get all the static files - Should be only for pages dir
   // Ideally we would filter only those that might get accessed in this specific functions
   // Maybe even move this to s3 directly
   if (hasPageDir) {
     // First we get truly static files - i.e. pages without getStaticProps
-    const staticFiles: Array<string> = Object.values(
-      loadPagesManifest(standaloneNextDir),
-    );
+    const staticFiles: Array<string> = Object.values(pagesManifest);
     // Then we need to get all fallback: true dynamic routes html
-    const prerenderManifest = loadPrerenderManifest(standaloneNextDir);
-    const config = loadConfig(standaloneNextDir);
     const locales = config.i18n?.locales;
     Object.values(prerenderManifest.dynamicRoutes).forEach((route) => {
       if (typeof route.fallback === "string") {
@@ -361,13 +361,9 @@ File ${serverPath} does not exist
       .forEach((file) => copyStaticFile(`server/${file}`));
   }
 
-  const manifests = getManifests(standaloneNextDir);
-
-  const { optimizeCss } = manifests.config.experimental;
-
   // Copy .next/static/css from standalone to output dir
   // needed for optimizeCss feature to work
-  if (optimizeCss) {
+  if (config.experimental.optimizeCss) {
     cpSync(
       path.join(standaloneNextDir, "static", "css"),
       path.join(outputNextDir, "static", "css"),

--- a/packages/open-next/src/types/next-types.ts
+++ b/packages/open-next/src/types/next-types.ts
@@ -82,6 +82,7 @@ export interface NextConfig {
   experimental: {
     serverActions?: boolean;
     appDir?: boolean;
+    optimizeCss?: boolean;
   };
   images: ImageConfig;
   poweredByHeader?: boolean;


### PR DESCRIPTION
## Description

The inlining of Critical CSS with the optimizeCss feature doesn't work when using Next.js 15.3.3 (Page Router) and @opennextjs/aws 3.6.5.

The optimizeCss feature relies on the CSS files being present in the server-function bundle. During page rendering (e.g., during ISR or revalidation), a server function using the Critters library attempts to locate the CSS files used on the page and inline them in the HTML. Without these files in the server-function bundle, the inlining process fails.

These changes make the bundling process include `.next/static/css` files in the server-function bundle.

Detailed information is in the attached issue below.

## GitHub issue

https://github.com/opennextjs/opennextjs-aws/issues/903
