### PR TITLE
Optimize tag writing process

### DIFF
--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -3,7 +3,11 @@ import type {
   IncrementalCacheContext,
   IncrementalCacheValue,
 } from "types/cache";
-import { getTagsFromValue, hasBeenRevalidated } from "utils/cache";
+import {
+  addTagToWrite,
+  getTagsFromValue,
+  hasBeenRevalidated,
+} from "utils/cache";
 import { isBinaryContentType } from "../utils/binary";
 import { debug, error, warn } from "./logger";
 
@@ -326,7 +330,7 @@ export default class Cache {
       if (globalThis.tagCache.mode === "nextMode") {
         const paths = (await globalThis.tagCache.getPathsByTags?.(_tags)) ?? [];
 
-        await globalThis.tagCache.writeTags(_tags);
+        addTagToWrite(_tags);
         if (paths.length > 0) {
           // TODO: we should introduce a new method in cdnInvalidationHandler to invalidate paths by tags for cdn that supports it
           // It also means that we'll need to provide the tags used in every request to the wrapper or converter.
@@ -378,7 +382,7 @@ export default class Cache {
         }
 
         // Update all keys with the given tag with revalidatedAt set to now
-        await globalThis.tagCache.writeTags(toInsert);
+        addTagToWrite(toInsert);
 
         // We can now invalidate all paths in the CDN
         // This only applies to `revalidateTag`, not to `res.revalidate()`
@@ -442,7 +446,7 @@ export default class Cache {
     const storedTags = await globalThis.tagCache.getByPath(key);
     const tagsToWrite = derivedTags.filter((tag) => !storedTags.includes(tag));
     if (tagsToWrite.length > 0) {
-      await globalThis.tagCache.writeTags(
+      addTagToWrite(
         tagsToWrite.map((tag) => ({
           path: key,
           tag: tag,

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -3,11 +3,7 @@ import type {
   IncrementalCacheContext,
   IncrementalCacheValue,
 } from "types/cache";
-import {
-  addTagToWrite,
-  getTagsFromValue,
-  hasBeenRevalidated,
-} from "utils/cache";
+import { getTagsFromValue, hasBeenRevalidated, writeTags } from "utils/cache";
 import { isBinaryContentType } from "../utils/binary";
 import { debug, error, warn } from "./logger";
 
@@ -330,7 +326,7 @@ export default class Cache {
       if (globalThis.tagCache.mode === "nextMode") {
         const paths = (await globalThis.tagCache.getPathsByTags?.(_tags)) ?? [];
 
-        addTagToWrite(_tags);
+        await writeTags(_tags);
         if (paths.length > 0) {
           // TODO: we should introduce a new method in cdnInvalidationHandler to invalidate paths by tags for cdn that supports it
           // It also means that we'll need to provide the tags used in every request to the wrapper or converter.
@@ -382,7 +378,7 @@ export default class Cache {
         }
 
         // Update all keys with the given tag with revalidatedAt set to now
-        addTagToWrite(toInsert);
+        await writeTags(toInsert);
 
         // We can now invalidate all paths in the CDN
         // This only applies to `revalidateTag`, not to `res.revalidate()`
@@ -446,7 +442,7 @@ export default class Cache {
     const storedTags = await globalThis.tagCache.getByPath(key);
     const tagsToWrite = derivedTags.filter((tag) => !storedTags.includes(tag));
     if (tagsToWrite.length > 0) {
-      addTagToWrite(
+      await writeTags(
         tagsToWrite.map((tag) => ({
           path: key,
           tag: tag,

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -27,6 +27,7 @@ import routingHandler, {
   MIDDLEWARE_HEADER_PREFIX_LEN,
 } from "./routingHandler";
 import { requestHandler, setNextjsPrebundledReact } from "./util";
+import { executeTagCacheWrite } from "utils/cache";
 
 // This is used to identify requests in the cache
 globalThis.__openNextAls = new AsyncLocalStorage();
@@ -209,6 +210,10 @@ export async function openNextHandler(
         body,
         isBase64Encoded,
       };
+
+      // Last thing we do is to write the tags to the tag cache if we are in the main function
+      // This is done inside a pending promise runner so that it can be awaited
+      executeTagCacheWrite();
 
       return internalResult;
     },

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -27,7 +27,6 @@ import routingHandler, {
   MIDDLEWARE_HEADER_PREFIX_LEN,
 } from "./routingHandler";
 import { requestHandler, setNextjsPrebundledReact } from "./util";
-import { executeTagCacheWrite } from "utils/cache";
 
 // This is used to identify requests in the cache
 globalThis.__openNextAls = new AsyncLocalStorage();
@@ -210,10 +209,6 @@ export async function openNextHandler(
         body,
         isBase64Encoded,
       };
-
-      // Last thing we do is to write the tags to the tag cache if we are in the main function
-      // This is done inside a pending promise runner so that it can be awaited
-      executeTagCacheWrite();
 
       return internalResult;
     },

--- a/packages/open-next/src/types/global.ts
+++ b/packages/open-next/src/types/global.ts
@@ -4,6 +4,7 @@ import type { OutgoingHttpHeaders } from "node:http";
 import type {
   CDNInvalidationHandler,
   IncrementalCache,
+  OriginalTagCacheWriteInput,
   ProxyExternalRequest,
   Queue,
   TagCache,
@@ -63,6 +64,8 @@ interface OpenNextRequestContext {
   // Last modified time of the page (used in main functions, only available for ISR/SSG).
   lastModified?: number;
   waitUntil?: WaitUntil;
+  /** We use this to deduplicate write of the tags - It's a string if the tag cache is in NextMode */
+  pendingTagToWrite: Map<string, string | OriginalTagCacheWriteInput>;
 }
 
 declare global {

--- a/packages/open-next/src/types/global.ts
+++ b/packages/open-next/src/types/global.ts
@@ -4,7 +4,6 @@ import type { OutgoingHttpHeaders } from "node:http";
 import type {
   CDNInvalidationHandler,
   IncrementalCache,
-  OriginalTagCacheWriteInput,
   ProxyExternalRequest,
   Queue,
   TagCache,
@@ -64,8 +63,8 @@ interface OpenNextRequestContext {
   // Last modified time of the page (used in main functions, only available for ISR/SSG).
   lastModified?: number;
   waitUntil?: WaitUntil;
-  /** We use this to deduplicate write of the tags - It's a string if the tag cache is in NextMode */
-  pendingTagToWrite: Map<string, string | OriginalTagCacheWriteInput>;
+  /** We use this to deduplicate write of the tags*/
+  writtenTags: Set<string>;
 }
 
 declare global {

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -144,6 +144,12 @@ export type NextModeTagCache = BaseTagCache & {
   getPathsByTags?: (tags: string[]) => Promise<string[]>;
 };
 
+export interface OriginalTagCacheWriteInput {
+  tag: string;
+  path: string;
+  revalidatedAt?: number;
+}
+
 /**
  * On get :
 We just check for the cache key in the tag cache. If it has been revalidated we just return null, otherwise we continue
@@ -168,9 +174,7 @@ export type OriginalTagCache = BaseTagCache & {
   getByTag(tag: string): Promise<string[]>;
   getByPath(path: string): Promise<string[]>;
   getLastModified(path: string, lastModified?: number): Promise<number>;
-  writeTags(
-    tags: { tag: string; path: string; revalidatedAt?: number }[],
-  ): Promise<void>;
+  writeTags(tags: OriginalTagCacheWriteInput[]): Promise<void>;
 };
 
 export type TagCache = NextModeTagCache | OriginalTagCache;

--- a/packages/open-next/src/utils/promise.ts
+++ b/packages/open-next/src/utils/promise.ts
@@ -1,6 +1,5 @@
 import type { WaitUntil } from "types/open-next";
 import { debug, error } from "../adapters/logger";
-import type { OriginalTagCacheWriteInput } from "types/overrides";
 
 /**
  * A `Promise.withResolvers` implementation that exposes the `resolve` and
@@ -120,7 +119,7 @@ export function runWithOpenNextRequestContext<T>(
       pendingPromiseRunner: new DetachedPromiseRunner(),
       isISRRevalidation,
       waitUntil,
-      pendingTagToWrite: new Map<string, string | OriginalTagCacheWriteInput>(),
+      writtenTags: new Set<string>(),
     },
     async () => {
       provideNextAfterProvider();

--- a/packages/open-next/src/utils/promise.ts
+++ b/packages/open-next/src/utils/promise.ts
@@ -1,5 +1,6 @@
 import type { WaitUntil } from "types/open-next";
 import { debug, error } from "../adapters/logger";
+import type { OriginalTagCacheWriteInput } from "types/overrides";
 
 /**
  * A `Promise.withResolvers` implementation that exposes the `resolve` and
@@ -119,6 +120,7 @@ export function runWithOpenNextRequestContext<T>(
       pendingPromiseRunner: new DetachedPromiseRunner(),
       isISRRevalidation,
       waitUntil,
+      pendingTagToWrite: new Map<string, string | OriginalTagCacheWriteInput>(),
     },
     async () => {
       provideNextAfterProvider();

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -56,6 +56,7 @@ describe("CacheHandler", () => {
           resolve: vi.fn(),
         }),
       },
+      writtenTags: new Set(),
     }),
   };
 


### PR DESCRIPTION
Enhance the tag caching mechanism by ensuring tags are written are written only once. Before that same tags were written both for the composable cache and the incremental cache.

Improve the composable cache read by reading from the pending set promise first.