### PR TITLE
Add request ID handling

### DIFF
--- a/.changeset/orange-badgers-cross.md
+++ b/.changeset/orange-badgers-cross.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+add the OPEN_NEXT_REQUEST_ID_HEADER env variable that allow to always have the request id header

--- a/examples/sst/stacks/AppRouter.ts
+++ b/examples/sst/stacks/AppRouter.ts
@@ -6,18 +6,10 @@ export function AppRouter({ stack }) {
     path: "../app-router",
     environment: {
       OPEN_NEXT_FORCE_NON_EMPTY_RESPONSE: "true",
+      // We want to always add the request ID header
+      OPEN_NEXT_REQUEST_ID_HEADER: "true",
     },
   });
-  // const site = new NextjsSite(stack, "approuter", {
-  //   path: "../app-router",
-  //   buildCommand: "npm run openbuild",
-  //   bind: [],
-  //   environment: {},
-  //   timeout: "20 seconds",
-  //   experimental: {
-  //     streaming: true,
-  //   },
-  // });
 
   stack.addOutputs({
     url: `https://${site.distribution.domainName}`,

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -281,6 +281,8 @@ export function addOpenNextHeader(headers: OutgoingHttpHeaders) {
   }
   if (globalThis.openNextDebug) {
     headers["X-OpenNext-Version"] = globalThis.openNextVersion;
+  }
+  if (process.env.OPEN_NEXT_REQUEST_ID_HEADER || globalThis.openNextDebug) {
     headers["X-OpenNext-RequestId"] =
       globalThis.__openNextAls.getStore()?.requestId;
   }

--- a/packages/open-next/src/core/routingHandler.ts
+++ b/packages/open-next/src/core/routingHandler.ts
@@ -35,6 +35,7 @@ export const INTERNAL_HEADER_PREFIX = "x-opennext-";
 export const INTERNAL_HEADER_INITIAL_URL = `${INTERNAL_HEADER_PREFIX}initial-url`;
 export const INTERNAL_HEADER_LOCALE = `${INTERNAL_HEADER_PREFIX}locale`;
 export const INTERNAL_HEADER_RESOLVED_ROUTES = `${INTERNAL_HEADER_PREFIX}resolved-routes`;
+export const INTERNAL_EVENT_REQUEST_ID = `${INTERNAL_HEADER_PREFIX}request-id`;
 
 // Geolocation headers starting from Nextjs 15
 // See https://github.com/vercel/vercel/blob/7714b1c/packages/functions/src/headers.ts

--- a/packages/open-next/src/utils/promise.ts
+++ b/packages/open-next/src/utils/promise.ts
@@ -105,17 +105,19 @@ export function runWithOpenNextRequestContext<T>(
   {
     isISRRevalidation,
     waitUntil,
+    requestId = Math.random().toString(36),
   }: {
     // Whether we are in ISR revalidation
     isISRRevalidation: boolean;
     // Extends the liftetime of the runtime after the response is returned.
     waitUntil?: WaitUntil;
+    requestId?: string;
   },
   fn: () => Promise<T>,
 ): Promise<T> {
   return globalThis.__openNextAls.run(
     {
-      requestId: Math.random().toString(36),
+      requestId,
       pendingPromiseRunner: new DetachedPromiseRunner(),
       isISRRevalidation,
       waitUntil,

--- a/packages/tests-e2e/tests/appRouter/headers.test.ts
+++ b/packages/tests-e2e/tests/appRouter/headers.test.ts
@@ -24,4 +24,7 @@ test("Headers", async ({ page }) => {
   // Both these headers should not be present cause poweredByHeader is false in appRouter
   expect(headers["x-powered-by"]).toBeFalsy();
   expect(headers["x-opennext"]).toBeFalsy();
+
+  // Request ID header should be set
+  expect(headers["x-opennext-requestid"]).not.toBeFalsy();
 });

--- a/packages/tests-e2e/tests/pagesRouter/header.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/header.test.ts
@@ -11,4 +11,7 @@ test("should test if poweredByHeader adds the correct headers ", async ({
   // Both these headers should be present cause poweredByHeader is true in pagesRouter
   expect(headers?.["x-powered-by"]).toBe("Next.js");
   expect(headers?.["x-opennext"]).toBe("1");
+
+  // Request ID header should not be set
+  expect(headers?.["x-opennext-requestid"]).toBeUndefined();
 });


### PR DESCRIPTION
Introduce an environment variable `OPEN_NEXT_REQUEST_ID_HEADER` to append the request ID to headers.

The requestId is also now shared between the middleware and the server in case of an external middleware

Close #913 