### PR TITLE
Fix edge functions bundle path and add additionalInject option support

### DIFF
--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -220,6 +220,7 @@ export async function generateEdgeBundle(
     additionalExternals: options.config.edgeExternals,
     name,
     additionalPlugins,
+    additionalInject: fnOptions.additionalInject,
   });
 }
 

--- a/packages/open-next/src/build/generateOutput.ts
+++ b/packages/open-next/src/build/generateOutput.ts
@@ -181,7 +181,7 @@ export async function generateOutput(options: BuildOptions) {
   Object.entries(config.functions ?? {}).forEach(async ([key, value]) => {
     if (value.placement === "global") {
       edgeFunctions[key] = {
-        bundle: `.open-next/functions/${key}`,
+        bundle: `.open-next/server-functions/${key}`,
         handler: indexHandler,
         ...(await extractOverrideFn(value.override)),
       };

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -361,6 +361,15 @@ export interface SplittedFunctionOptions extends FunctionOptions {
    * @default []
    */
   patterns: string[];
+
+
+  /**
+   * Additional inject code for the function.
+   * This is used to inject code into the function.
+   * Used when code needs to be directly injected into the banner section during esbuild. Should be used with caution.
+   * @default undefined
+   */
+  additionalInject?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR includes two main improvements to the OpenNext edge functions handling:

1. **Fix edge functions bundle path**: Corrects the bundle path from `.open-next/functions` to `.open-next/server-functions` to match the actual build output location.

2. **Add additionalInject option support**: Introduces a new `additionalInject` option for injecting custom code directly into the esbuild banner section.

## Changes
- **Fix**: Updated edge functions bundle path in `generateOutput.ts` to use the correct server-functions directory
- **Feature**: Added `additionalInject` option support in `createEdgeBundle.ts` 
- **Documentation**: Added comprehensive JSDoc documentation for the new `additionalInject` option with usage guidelines and caution notes

## Breaking Changes
None. These changes are backward compatible.

## Notes
- The `additionalInject` option should be used with caution as it directly injects code into the esbuild banner section
- The bundle path fix ensures edge functions are correctly located during deployment

## Testing
- [ ] Verified edge functions bundle path matches build output
- [ ] Tested additionalInject option functionality
- [ ] Confirmed backward compatibility