### PR TITLE
chore(e2e): Revert back tests we skipped

### DIFF
--- a/packages/tests-e2e/tests/appRouter/og.test.ts
+++ b/packages/tests-e2e/tests/appRouter/og.test.ts
@@ -6,7 +6,7 @@ const OG_MD5 = "83cfda4e78b037aa3d9ab465292550ef";
 const API_OG_MD5 = "6a22b4ff74e0dd8c377e2640dafe3e40";
 
 // We skip this test for now until Next fixes https://github.com/vercel/next.js/issues/81655
-test.skip("Open-graph image to be in metatags and present", async ({
+test("Open-graph image to be in metatags and present", async ({
   page,
   request,
 }) => {

--- a/packages/tests-e2e/tests/appRouter/og.test.ts
+++ b/packages/tests-e2e/tests/appRouter/og.test.ts
@@ -5,7 +5,6 @@ import { validateMd5 } from "../utils";
 const OG_MD5 = "83cfda4e78b037aa3d9ab465292550ef";
 const API_OG_MD5 = "6a22b4ff74e0dd8c377e2640dafe3e40";
 
-// We skip this test for now until Next fixes https://github.com/vercel/next.js/issues/81655
 test("Open-graph image to be in metatags and present", async ({
   page,
   request,

--- a/packages/tests-e2e/tests/pagesRouter/head.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/head.test.ts
@@ -6,7 +6,6 @@ test.describe("next/head", () => {
     const title = await page.title();
     expect(title).toBe("OpenNext head");
   });
-  // We skip this test for now until Next fixes https://github.com/vercel/next.js/issues/81655
   test("should have the correct meta tags", async ({ page }) => {
     await page.goto("/head");
     const ogTitle = await page

--- a/packages/tests-e2e/tests/pagesRouter/head.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/head.test.ts
@@ -7,7 +7,7 @@ test.describe("next/head", () => {
     expect(title).toBe("OpenNext head");
   });
   // We skip this test for now until Next fixes https://github.com/vercel/next.js/issues/81655
-  test.skip("should have the correct meta tags", async ({ page }) => {
+  test("should have the correct meta tags", async ({ page }) => {
     await page.goto("/head");
     const ogTitle = await page
       .locator('meta[property="og:title"]')


### PR DESCRIPTION
These issues have been resolved upstream now. Released in [`15.4.2`](https://github.com/vercel/next.js/releases/tag/v15.4.2). Should be fine to add them back now.