### PR TITLE
refactor the code patcher

### DIFF
--- a/.changeset/forty-paws-nail.md
+++ b/.changeset/forty-paws-nail.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+refactor the CodePatcher

--- a/packages/open-next/src/build/patch/patches/patchBackgroundRevalidation.ts
+++ b/packages/open-next/src/build/patch/patches/patchBackgroundRevalidation.ts
@@ -21,10 +21,8 @@ export const patchBackgroundRevalidation = {
     {
       // TODO: test for earlier versions of Next
       versions: ">=14.1.0",
-      field: {
-        pathFilter: getCrossPlatformPathRegex("server/response-cache/index.js"),
-        patchCode: createPatchCode(rule),
-      },
+      pathFilter: getCrossPlatformPathRegex("server/response-cache/index.js"),
+      patchCode: createPatchCode(rule),
     },
   ],
 } satisfies CodePatcher;

--- a/packages/open-next/src/build/patch/patches/patchEnvVar.ts
+++ b/packages/open-next/src/build/patch/patches/patchEnvVar.ts
@@ -27,32 +27,24 @@ export const patchEnvVars: CodePatcher = {
     // This patch will set the `NEXT_RUNTIME` env var to "node" to avoid loading unnecessary edge deps at runtime
     {
       versions: ">=15.0.0",
-      field: {
-        pathFilter: /module\.compiled\.js$/,
-        contentFilter: /process\.env\.NEXT_RUNTIME/,
-        patchCode: createPatchCode(envVarRuleCreator("NEXT_RUNTIME", '"node"')),
-      },
+      pathFilter: /module\.compiled\.js$/,
+      contentFilter: /process\.env\.NEXT_RUNTIME/,
+      patchCode: createPatchCode(envVarRuleCreator("NEXT_RUNTIME", '"node"')),
     },
     // This patch will set `NODE_ENV` to production to avoid loading unnecessary dev deps at runtime
     {
       versions: ">=15.0.0",
-      field: {
-        pathFilter:
-          /(module\.compiled|react\/index|react\/jsx-runtime|react-dom\/index)\.js$/,
-        contentFilter: /process\.env\.NODE_ENV/,
-        patchCode: createPatchCode(
-          envVarRuleCreator("NODE_ENV", '"production"'),
-        ),
-      },
+      pathFilter:
+        /(module\.compiled|react\/index|react\/jsx-runtime|react-dom\/index)\.js$/,
+      contentFilter: /process\.env\.NODE_ENV/,
+      patchCode: createPatchCode(envVarRuleCreator("NODE_ENV", '"production"')),
     },
     // This patch will set `TURBOPACK` env to false to avoid loading turbopack related deps at runtime
     {
       versions: ">=15.0.0",
-      field: {
-        pathFilter: /module\.compiled\.js$/,
-        contentFilter: /process\.env\.TURBOPACK/,
-        patchCode: createPatchCode(envVarRuleCreator("TURBOPACK", "false")),
-      },
+      pathFilter: /module\.compiled\.js$/,
+      contentFilter: /process\.env\.TURBOPACK/,
+      patchCode: createPatchCode(envVarRuleCreator("TURBOPACK", "false")),
     },
   ],
 };

--- a/packages/open-next/src/build/patch/patches/patchFetchCacheISR.ts
+++ b/packages/open-next/src/build/patch/patches/patchFetchCacheISR.ts
@@ -11,7 +11,7 @@ rule:
     kind: ternary_expression
     all:
       - has: {kind: 'null'}
-      - has: 
+      - has:
           kind: await_expression
           has:
             kind: call_expression
@@ -51,7 +51,7 @@ rule:
       kind: statement_block
       has:
         kind: variable_declarator
-        has: 
+        has:
           kind: await_expression
           has:
             kind: call_expression
@@ -84,13 +84,13 @@ rule:
   pattern: $STORE_OR_CACHE.isOnDemandRevalidate
   inside:
     kind: binary_expression
-    has: 
+    has:
       kind: member_expression
       pattern: $STORE_OR_CACHE.isDraftMode
     inside:
       kind: if_statement
       stopBy: end
-      has: 
+      has:
         kind: return_statement
         any:
           - has:
@@ -106,14 +106,12 @@ export const patchFetchCacheForISR: CodePatcher = {
   patches: [
     {
       versions: ">=14.0.0",
-      field: {
-        pathFilter: getCrossPlatformPathRegex(
-          String.raw`(server/chunks/.*\.js|.*\.runtime\..*\.js|patch-fetch\.js)$`,
-          { escape: false },
-        ),
-        contentFilter: /\.isOnDemandRevalidate/,
-        patchCode: createPatchCode(fetchRule, Lang.JavaScript),
-      },
+      pathFilter: getCrossPlatformPathRegex(
+        String.raw`(server/chunks/.*\.js|.*\.runtime\..*\.js|patch-fetch\.js)$`,
+        { escape: false },
+      ),
+      contentFilter: /\.isOnDemandRevalidate/,
+      patchCode: createPatchCode(fetchRule, Lang.JavaScript),
     },
   ],
 };
@@ -123,14 +121,12 @@ export const patchUnstableCacheForISR: CodePatcher = {
   patches: [
     {
       versions: ">=14.2.0",
-      field: {
-        pathFilter: getCrossPlatformPathRegex(
-          String.raw`(server/chunks/.*\.js|.*\.runtime\..*\.js|spec-extension/unstable-cache\.js)$`,
-          { escape: false },
-        ),
-        contentFilter: /\.isOnDemandRevalidate/,
-        patchCode: createPatchCode(unstable_cacheRule, Lang.JavaScript),
-      },
+      pathFilter: getCrossPlatformPathRegex(
+        String.raw`(server/chunks/.*\.js|.*\.runtime\..*\.js|spec-extension/unstable-cache\.js)$`,
+        { escape: false },
+      ),
+      contentFilter: /\.isOnDemandRevalidate/,
+      patchCode: createPatchCode(unstable_cacheRule, Lang.JavaScript),
     },
   ],
 };
@@ -140,14 +136,12 @@ export const patchUseCacheForISR: CodePatcher = {
   patches: [
     {
       versions: ">=15.3.0",
-      field: {
-        pathFilter: getCrossPlatformPathRegex(
-          String.raw`(server/chunks/.*\.js|\.runtime\..*\.js|use-cache/use-cache-wrapper\.js)$`,
-          { escape: false },
-        ),
-        contentFilter: /\.isOnDemandRevalidate/,
-        patchCode: createPatchCode(useCacheRule, Lang.JavaScript),
-      },
+      pathFilter: getCrossPlatformPathRegex(
+        String.raw`(server/chunks/.*\.js|\.runtime\..*\.js|use-cache/use-cache-wrapper\.js)$`,
+        { escape: false },
+      ),
+      contentFilter: /\.isOnDemandRevalidate/,
+      patchCode: createPatchCode(useCacheRule, Lang.JavaScript),
     },
   ],
 };

--- a/packages/open-next/src/build/patch/patches/patchFetchCacheWaitUntil.ts
+++ b/packages/open-next/src/build/patch/patches/patchFetchCacheWaitUntil.ts
@@ -29,14 +29,12 @@ export const patchFetchCacheSetMissingWaitUntil: CodePatcher = {
   patches: [
     {
       versions: ">=15.0.0",
-      field: {
-        pathFilter: getCrossPlatformPathRegex(
-          String.raw`(server/chunks/.*\.js|.*\.runtime\..*\.js|patch-fetch\.js)$`,
-          { escape: false },
-        ),
-        contentFilter: /arrayBuffer\(\)\s*\.then/,
-        patchCode: createPatchCode(rule),
-      },
+      pathFilter: getCrossPlatformPathRegex(
+        String.raw`(server/chunks/.*\.js|.*\.runtime\..*\.js|patch-fetch\.js)$`,
+        { escape: false },
+      ),
+      contentFilter: /arrayBuffer\(\)\s*\.then/,
+      patchCode: createPatchCode(rule),
     },
   ],
 };

--- a/packages/open-next/src/build/patch/patches/patchNextServer.ts
+++ b/packages/open-next/src/build/patch/patches/patchNextServer.ts
@@ -81,27 +81,21 @@ const pathFilter = getCrossPlatformPathRegex(
 const babelPatches = [
   // Empty the body of `NextServer#runMiddleware`
   {
-    field: {
-      pathFilter,
-      contentFilter: /runMiddleware\(/,
-      patchCode: createPatchCode(createEmptyBodyRule("runMiddleware")),
-    },
+    pathFilter,
+    contentFilter: /runMiddleware\(/,
+    patchCode: createPatchCode(createEmptyBodyRule("runMiddleware")),
   },
   // Empty the body of `NextServer#runEdgeFunction`
   {
-    field: {
-      pathFilter,
-      contentFilter: /runEdgeFunction\(/,
-      patchCode: createPatchCode(createEmptyBodyRule("runEdgeFunction")),
-    },
+    pathFilter,
+    contentFilter: /runEdgeFunction\(/,
+    patchCode: createPatchCode(createEmptyBodyRule("runEdgeFunction")),
   },
   // Drop `error-inspect` that pulls babel
   {
-    field: {
-      pathFilter,
-      contentFilter: /error-inspect/,
-      patchCode: createPatchCode(errorInspectRule),
-    },
+    pathFilter,
+    contentFilter: /error-inspect/,
+    patchCode: createPatchCode(errorInspectRule),
   },
 ];
 
@@ -110,30 +104,24 @@ export const patchNextServer: CodePatcher = {
   patches: [
     // Empty the body of `NextServer#imageOptimizer` - unused in OpenNext
     {
-      field: {
-        pathFilter,
-        contentFilter: /imageOptimizer\(/,
-        patchCode: createPatchCode(createEmptyBodyRule("imageOptimizer")),
-      },
+      pathFilter,
+      contentFilter: /imageOptimizer\(/,
+      patchCode: createPatchCode(createEmptyBodyRule("imageOptimizer")),
     },
     // Disable Next background preloading done at creation of `NextServer`
     {
       versions: ">=14.0.0",
-      field: {
-        pathFilter,
-        contentFilter: /this\.nextConfig\.experimental\.preloadEntriesOnStart/,
-        patchCode: createPatchCode(disablePreloadingRule),
-      },
+      pathFilter,
+      contentFilter: /this\.nextConfig\.experimental\.preloadEntriesOnStart/,
+      patchCode: createPatchCode(disablePreloadingRule),
     },
     // Don't match edge functions in `NextServer`
     {
       // Next 12 and some version of 13 use the bundled middleware/edge function
       versions: ">=14.0.0",
-      field: {
-        pathFilter,
-        contentFilter: /getMiddlewareManifest/,
-        patchCode: createPatchCode(removeMiddlewareManifestRule),
-      },
+      pathFilter,
+      contentFilter: /getMiddlewareManifest/,
+      patchCode: createPatchCode(removeMiddlewareManifestRule),
     },
     ...babelPatches,
   ],

--- a/packages/tests-unit/tests/build/patch/codePatcher.test.ts
+++ b/packages/tests-unit/tests/build/patch/codePatcher.test.ts
@@ -1,84 +1,71 @@
-import { extractVersionedField } from "@opennextjs/aws/build/patch/codePatcher.js";
+import {
+  isVersionInRange,
+  parseVersions,
+} from "@opennextjs/aws/build/patch/codePatcher.js";
 
-describe("extractVersionedField", () => {
-  it("should return the field if the version is between before and after", () => {
-    const result = extractVersionedField(
-      [{ versions: ">=15.0.0 <=16.0.0", field: 0 }],
-      "15.5.0",
-    );
-
-    expect(result).toEqual([0]);
+describe("isVersionInRange", () => {
+  test("before", () => {
+    expect(isVersionInRange("14.5", "<=16.0.0")).toBe(true);
+    expect(isVersionInRange("14.5.0", "<=16.0.0")).toBe(true);
+    expect(isVersionInRange("15", "<=16.0.0")).toBe(true);
+    expect(isVersionInRange("15.0", "<=16.0.0")).toBe(true);
+    expect(isVersionInRange("15.0.0", "<=16.0.0")).toBe(true);
+    expect(isVersionInRange("15.5", "<=16.0.0")).toBe(true);
+    expect(isVersionInRange("15.5.0", "<=16.0.0")).toBe(true);
+    expect(isVersionInRange("16", "<=16.0.0")).toBe(true);
+    expect(isVersionInRange("16.0", "<=16.0.0")).toBe(true);
+    expect(isVersionInRange("16.0.0", "<=16.0.0")).toBe(true);
+    expect(isVersionInRange("16.5", "<=16.0.0")).toBe(false);
+    expect(isVersionInRange("16.5.0", "<=16.0.0")).toBe(false);
   });
 
-  it("should return an empty array if the version is not between before and after", () => {
-    const result = extractVersionedField(
-      [{ versions: ">=15.0.0 <=16.0.0", field: 0 }],
-      "14.0.0",
-    );
-
-    expect(result).toEqual([]);
+  test("after", () => {
+    expect(isVersionInRange("14.5", ">=15.0.0")).toBe(false);
+    expect(isVersionInRange("14.5.0", ">=15.0.0")).toBe(false);
+    expect(isVersionInRange("15", ">=15.0.0")).toBe(true);
+    expect(isVersionInRange("15.0", ">=15.0.0")).toBe(true);
+    expect(isVersionInRange("15.0.0", ">=15.0.0")).toBe(true);
+    expect(isVersionInRange("15.5", ">=15.0.0")).toBe(true);
+    expect(isVersionInRange("15.5.0", ">=15.0.0")).toBe(true);
+    expect(isVersionInRange("16", ">=15.0.0")).toBe(true);
+    expect(isVersionInRange("16.0", ">=15.0.0")).toBe(true);
+    expect(isVersionInRange("16.0.0", ">=15.0.0")).toBe(true);
+    expect(isVersionInRange("16.5", ">=15.0.0")).toBe(true);
+    expect(isVersionInRange("16.5.0", ">=15.0.0")).toBe(true);
   });
 
-  it("should return the field if the version is equal to before", () => {
-    const result = extractVersionedField(
-      [{ versions: "<=15.0.0", field: 0 }],
-      "15.0.0",
-    );
-
-    expect(result).toEqual([0]);
+  test("before and after", () => {
+    expect(isVersionInRange("14.5", ">=15.0.0 <=16.0.0")).toBe(false);
+    expect(isVersionInRange("14.5.0", ">=15.0.0 <=16.0.0")).toBe(false);
+    expect(isVersionInRange("15", ">=15.0.0 <=16.0.0")).toBe(true);
+    expect(isVersionInRange("15.0", ">=15.0.0 <=16.0.0")).toBe(true);
+    expect(isVersionInRange("15.0.0", ">=15.0.0 <=16.0.0")).toBe(true);
+    expect(isVersionInRange("15.5", ">=15.0.0 <=16.0.0")).toBe(true);
+    expect(isVersionInRange("15.5.0", ">=15.0.0 <=16.0.0")).toBe(true);
+    expect(isVersionInRange("16", ">=15.0.0 <=16.0.0")).toBe(true);
+    expect(isVersionInRange("16.0", ">=15.0.0 <=16.0.0")).toBe(true);
+    expect(isVersionInRange("16.0.0", ">=15.0.0 <=16.0.0")).toBe(true);
+    expect(isVersionInRange("16.5", ">=15.0.0 <=16.0.0")).toBe(false);
+    expect(isVersionInRange("16.5.0", ">=15.0.0 <=16.0.0")).toBe(false);
   });
 
-  it("should return the field if the version is greater than after", () => {
-    const result = extractVersionedField(
-      [{ versions: ">=16.0.0", field: 0 }],
-      "16.5.0",
-    );
-
-    expect(result).toEqual([0]);
+  test("undefined range", () => {
+    expect(isVersionInRange("14.5", undefined)).toBe(true);
   });
+});
 
-  it("should return the field if the version is less than before", () => {
-    const result = extractVersionedField(
-      [{ versions: "<=15.0.0", field: 0 }],
-      "14.0.0",
-    );
-
-    expect(result).toEqual([0]);
-  });
-
-  it("should return an empty array if version is after before", () => {
-    const result = extractVersionedField(
-      [{ versions: "<=15.0.0", field: 0 }],
-      "15.1.0",
-    );
-
-    expect(result).toEqual([]);
-  });
-
-  it("should return the field when versions is not specified", () => {
-    const result = extractVersionedField([{ field: 0 }], "15.1.0");
-
-    expect(result).toEqual([0]);
-  });
-
+describe("parseVersions", () => {
   it("should throw an error if a single version range is invalid because of a space before", () => {
-    expect(() =>
-      extractVersionedField([{ versions: "<= 15.0.0", field: 0 }], "15.0.0"),
-    ).toThrow("Invalid version range");
+    expect(() => parseVersions("<= 15.0.0")).toThrow("Invalid version range");
   });
 
   it("should throw an error if a single version range is invalid because of a space inside version", () => {
-    expect(() =>
-      extractVersionedField([{ versions: ">=16.   0.0", field: 0 }], "15.0.0"),
-    ).toThrow("Invalid version range");
+    expect(() => parseVersions(">=16.   0.0")).toThrow("Invalid version range");
   });
 
   it("should throw an error if one of the version range is invalid because of a space before the version", () => {
-    expect(() =>
-      extractVersionedField(
-        [{ versions: ">=16.0.0 <= 15.0.0", field: 0 }],
-        "15.0.0",
-      ),
-    ).toThrow("Invalid version range");
+    expect(() => parseVersions(">=16.0.0 <= 15.0.0")).toThrow(
+      "Invalid version range",
+    );
   });
 });


### PR DESCRIPTION
Remove the `VersionedField` in favor of an optional `versions` field on a patch.

--

There are 2 ways to patch the code in aws/cloudflare:

- the `CodePatcher` is used to patch the files before the build
- the `ContentUpdater` is used to patch the files within an ESBuild build

They are similar but do not have feature parity.

The Cf adapter mostly uses the `ContentUpdater` but does not really use the version range for now.
With the recent release of 15.4, the need to apply different patches according to the Next version is becoming more important.

What I'd like to do with this PR (and some follow up PRs) is to unify the 2 mechanisms.

Next steps:
- The version range is pretty limited, I'd like to introduce a predicate in addition to the current string to allow for more flexibiliy, i.e. using the semver package - For example, we do not currently support ">", "<", "15" but only ">=", "<=", "15.0.0"
- Try to unify and share as much code as possible, keeping the 2 ways to apply the patches. Either before or during ESBuild.

