### PR TITLE
return res.statusCode on "Server failed to respond."

### DIFF
--- a/.changeset/pretty-dodos-end.md
+++ b/.changeset/pretty-dodos-end.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+set the correct 500 status code on internal server error

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -345,6 +345,8 @@ async function tryRenderError(
     await requestHandler(requestMetadata)(_req, res);
   } catch (e) {
     error("NextJS request failed.", e);
+    const statusCode = type === "404" ? 404 : 500;
+    res.statusCode = statusCode;
     res.setHeader("Content-Type", "application/json");
     res.end(
       JSON.stringify(

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -327,7 +327,6 @@ async function tryRenderError(
   res: OpenNextNodeResponse,
   internalEvent: InternalEvent,
 ) {
-  const statusCode = type === "404" ? 404 : 500;
   try {
     const _req = new IncomingMessage({
       method: "GET",
@@ -339,14 +338,14 @@ async function tryRenderError(
     // By setting this it will allow us to bypass and directly render the 404 or 500 page
     const requestMetadata = {
       // By setting invokePath and invokeQuery we can bypass some of the routing logic in Next.js
-      invokePath: `/${statusCode}`,
-      invokeStatus: statusCode,
+      invokePath: type === "404" ? "/404" : "/500",
+      invokeStatus: type === "404" ? 404 : 500,
       middlewareInvoke: false,
     };
     await requestHandler(requestMetadata)(_req, res);
   } catch (e) {
     error("NextJS request failed.", e);
-    res.statusCode = statusCode;
+    res.statusCode = 500;
     res.setHeader("Content-Type", "application/json");
     res.end(
       JSON.stringify(

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -327,6 +327,7 @@ async function tryRenderError(
   res: OpenNextNodeResponse,
   internalEvent: InternalEvent,
 ) {
+  const statusCode = type === "404" ? 404 : 500;
   try {
     const _req = new IncomingMessage({
       method: "GET",
@@ -338,14 +339,13 @@ async function tryRenderError(
     // By setting this it will allow us to bypass and directly render the 404 or 500 page
     const requestMetadata = {
       // By setting invokePath and invokeQuery we can bypass some of the routing logic in Next.js
-      invokePath: type === "404" ? "/404" : "/500",
-      invokeStatus: type === "404" ? 404 : 500,
+      invokePath: `/${statusCode}`,
+      invokeStatus: statusCode,
       middlewareInvoke: false,
     };
     await requestHandler(requestMetadata)(_req, res);
   } catch (e) {
     error("NextJS request failed.", e);
-    const statusCode = type === "404" ? 404 : 500;
     res.statusCode = statusCode;
     res.setHeader("Content-Type", "application/json");
     res.end(


### PR DESCRIPTION
This fixes https://github.com/opennextjs/opennextjs-aws/issues/936

Upgrading to Next 15.4.4 broke our site but no alerts went off because the response returned a 200 versus a 500. We've reverted and pinned 15.3.5, but we still want the response to be correct.