### PR TITLE
fix: Ensure redirects are properly encoded and relative/absolute

### DIFF
--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -15,6 +15,7 @@ import {
   convertBodyToReadableStream,
   getMiddlewareMatch,
   isExternal,
+  normalizeLocationHeader,
 } from "./util.js";
 
 const middlewareManifest = MiddlewareManifest;
@@ -94,6 +95,15 @@ export async function handleMiddleware(
     url,
     body: convertBodyToReadableStream(internalEvent.method, internalEvent.body),
   } as unknown as Request);
+  if (result.headers.has("Location")) {
+    result.headers.set(
+      "Location",
+      normalizeLocationHeader(
+        result.headers.get("Location") as string,
+        internalEvent.url,
+      ),
+    );
+  }
   const statusCode = result.status;
 
   /* Apply override headers from middleware

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -437,3 +437,27 @@ export async function invalidateCDNOnRequest(
     ]);
   }
 }
+
+/**
+ * Normalizes the Location header to either be a relative path or a full URL.
+ * If the Location header is relative to the host, it will return a relative path.
+ * If it is an absolute URL, it will return the full URL.
+ * Both cases will ensure that the URL is properly encoded according to RFC
+ *
+ * @param location The Location header value
+ * @param url The original request URL
+ * @returns A normalized Location header value
+ */
+export function normalizeLocationHeader(location: string, url: string): string {
+  const locationUrl = new URL(location);
+  const host = new URL(url).host;
+  
+  // Encode the search parameters to ensure they are valid according to RFC
+  const encodedSearch = locationUrl.searchParams.toString() ? `?${locationUrl.searchParams.toString()}` : '';
+  const href = locationUrl.origin + locationUrl.pathname + encodedSearch + locationUrl.hash;
+  if (locationUrl.host === host) {
+    // If the location is relative to the host
+    return href.replace(locationUrl.origin, "");
+  }
+  return href;
+}

--- a/packages/open-next/src/core/routingHandler.ts
+++ b/packages/open-next/src/core/routingHandler.ts
@@ -28,7 +28,7 @@ import {
   dynamicRouteMatcher,
   staticRouteMatcher,
 } from "./routing/routeMatcher";
-import { constructNextUrl } from "./routing/util";
+import { constructNextUrl, normalizeLocationHeader } from "./routing/util";
 
 export const MIDDLEWARE_HEADER_PREFIX = "x-middleware-response-";
 export const MIDDLEWARE_HEADER_PREFIX_LEN = MIDDLEWARE_HEADER_PREFIX.length;
@@ -110,13 +110,13 @@ export default async function routingHandler(
     if (redirect) {
       // We need to encode the value in the Location header to make sure it is valid according to RFC
       // https://stackoverflow.com/a/7654605/16587222
-      redirect.headers.Location = new URL(
+      redirect.headers.Location = normalizeLocationHeader(
         redirect.headers.Location as string,
-      ).href;
+        event.url,
+      );
       debug("redirect", redirect);
       return redirect;
     }
-
     const middlewareEventOrResult = await handleMiddleware(
       eventOrResult,
       // We need to pass the initial search without any decoding


### PR DESCRIPTION
Currently in draft mode. It will pass all our tests, but requires more manual testing. Especially the middleware part.

For #940 and https://github.com/opennextjs/opennextjs-cloudflare/issues/809

For redirects coming from next config we want that the `Location` header value is encoded properly according to RFC. In `next start` and deployed to Vercel the header can also be relative or absolute. 

I am a bit unsure what to do about `NextResponse.redirect()` coming from the middleware. Should we encode it aswell? I'll keep investigating this but are open for suggestions.