### PR TITLE
Add shouldBypassTagCache option for incremental caches

### DIFF
--- a/.changeset/rich-pumas-shop.md
+++ b/.changeset/rich-pumas-shop.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Add a new option to bypass checking the tag cache from an incremental cache get

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -63,11 +63,9 @@ export default class Cache {
 
       const _tags = [...(tags ?? []), ...(softTags ?? [])];
       const _lastModified = cachedEntry.lastModified ?? Date.now();
-      const _hasBeenRevalidated = cachedEntry.shouldBypassTagCache ? false : await hasBeenRevalidated(
-        key,
-        _tags,
-        cachedEntry,
-      );
+      const _hasBeenRevalidated = cachedEntry.shouldBypassTagCache
+        ? false
+        : await hasBeenRevalidated(key, _tags, cachedEntry);
 
       if (_hasBeenRevalidated) return null;
 
@@ -82,11 +80,13 @@ export default class Cache {
             !tag.endsWith("page"),
         );
         if (path) {
-          const hasPathBeenUpdated = cachedEntry.shouldBypassTagCache ? false : await hasBeenRevalidated(
-            path.replace("_N_T_/", ""),
-            [],
-            cachedEntry,
-          );
+          const hasPathBeenUpdated = cachedEntry.shouldBypassTagCache
+            ? false
+            : await hasBeenRevalidated(
+                path.replace("_N_T_/", ""),
+                [],
+                cachedEntry,
+              );
           if (hasPathBeenUpdated) {
             // In case the path has been revalidated, we don't want to use the fetch cache
             return null;
@@ -118,11 +118,9 @@ export default class Cache {
       const meta = cacheData.meta;
       const tags = getTagsFromValue(cacheData);
       const _lastModified = cachedEntry.lastModified ?? Date.now();
-      const _hasBeenRevalidated = cachedEntry.shouldBypassTagCache ? false : await hasBeenRevalidated(
-        key,
-        tags,
-        cachedEntry,
-      );
+      const _hasBeenRevalidated = cachedEntry.shouldBypassTagCache
+        ? false
+        : await hasBeenRevalidated(key, tags, cachedEntry);
       if (_hasBeenRevalidated) return null;
 
       const store = globalThis.__openNextAls.getStore();

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -362,7 +362,9 @@ export default class Cache {
           for (const path of paths) {
             // We need to find all hard tags for a given path
             const _tags = await globalThis.tagCache.getByPath(path);
-            const hardTags = _tags.filter((t) => !t.startsWith(SOFT_TAG_PREFIX));
+            const hardTags = _tags.filter(
+              (t) => !t.startsWith(SOFT_TAG_PREFIX),
+            );
             // For every hard tag, we need to find all paths and revalidate them
             for (const hardTag of hardTags) {
               const _paths = await globalThis.tagCache.getByTag(hardTag);

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -63,7 +63,7 @@ export default class Cache {
 
       const _tags = [...(tags ?? []), ...(softTags ?? [])];
       const _lastModified = cachedEntry.lastModified ?? Date.now();
-      const _hasBeenRevalidated = await hasBeenRevalidated(
+      const _hasBeenRevalidated = cachedEntry.shouldBypassTagCache ? false : await hasBeenRevalidated(
         key,
         _tags,
         cachedEntry,
@@ -82,7 +82,7 @@ export default class Cache {
             !tag.endsWith("page"),
         );
         if (path) {
-          const hasPathBeenUpdated = await hasBeenRevalidated(
+          const hasPathBeenUpdated = cachedEntry.shouldBypassTagCache ? false : await hasBeenRevalidated(
             path.replace("_N_T_/", ""),
             [],
             cachedEntry,
@@ -118,7 +118,7 @@ export default class Cache {
       const meta = cacheData.meta;
       const tags = getTagsFromValue(cacheData);
       const _lastModified = cachedEntry.lastModified ?? Date.now();
-      const _hasBeenRevalidated = await hasBeenRevalidated(
+      const _hasBeenRevalidated = cachedEntry.shouldBypassTagCache ? false : await hasBeenRevalidated(
         key,
         tags,
         cachedEntry,

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -28,20 +28,23 @@ export default {
         globalThis.tagCache.mode === "nextMode" &&
         result.value.tags.length > 0
       ) {
-        const hasBeenRevalidated = result.shouldBypassTagCache ? false : await globalThis.tagCache.hasBeenRevalidated(
-          result.value.tags,
-          result.lastModified,
-        );
+        const hasBeenRevalidated = result.shouldBypassTagCache
+          ? false
+          : await globalThis.tagCache.hasBeenRevalidated(
+              result.value.tags,
+              result.lastModified,
+            );
         if (hasBeenRevalidated) return undefined;
       } else if (
         globalThis.tagCache.mode === "original" ||
         globalThis.tagCache.mode === undefined
       ) {
-        const hasBeenRevalidated = result.shouldBypassTagCache ? false : 
-          (await globalThis.tagCache.getLastModified(
-            cacheKey,
-            result.lastModified,
-          )) === -1;
+        const hasBeenRevalidated = result.shouldBypassTagCache
+          ? false
+          : (await globalThis.tagCache.getLastModified(
+              cacheKey,
+              result.lastModified,
+            )) === -1;
         if (hasBeenRevalidated) return undefined;
       }
 

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -28,7 +28,7 @@ export default {
         globalThis.tagCache.mode === "nextMode" &&
         result.value.tags.length > 0
       ) {
-        const hasBeenRevalidated = await globalThis.tagCache.hasBeenRevalidated(
+        const hasBeenRevalidated = result.shouldBypassTagCache ? false : await globalThis.tagCache.hasBeenRevalidated(
           result.value.tags,
           result.lastModified,
         );
@@ -37,7 +37,7 @@ export default {
         globalThis.tagCache.mode === "original" ||
         globalThis.tagCache.mode === undefined
       ) {
-        const hasBeenRevalidated =
+        const hasBeenRevalidated = result.shouldBypassTagCache ? false : 
           (await globalThis.tagCache.getLastModified(
             cacheKey,
             result.lastModified,

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -93,6 +93,11 @@ export type CachedFetchValue = {
 export type WithLastModified<T> = {
   lastModified?: number;
   value?: T;
+  /**
+   * If set to true, we will not check the tag cache for this entry.
+   * `revalidateTag` and `revalidatePath` may not work as expected.
+   */
+  shouldBypassTagCache?: boolean;
 };
 
 export type CacheEntryType = Extension;

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import Cache, {SOFT_TAG_PREFIX} from "@opennextjs/aws/adapters/cache.js";
+import Cache, { SOFT_TAG_PREFIX } from "@opennextjs/aws/adapters/cache.js";
 import { vi } from "vitest";
 
 declare global {

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import Cache from "@opennextjs/aws/adapters/cache.js";
+import Cache, {SOFT_TAG_PREFIX} from "@opennextjs/aws/adapters/cache.js";
 import { vi } from "vitest";
 
 declare global {
@@ -553,13 +553,13 @@ describe("CacheHandler", () => {
     it("Should call invalidateCdnHandler.invalidatePaths", async () => {
       globalThis.tagCache.getByTag.mockResolvedValueOnce(["/path"]);
       globalThis.tagCache.getByPath.mockResolvedValueOnce([]);
-      await cache.revalidateTag("_N_T_/path");
+      await cache.revalidateTag(`${SOFT_TAG_PREFIX}path`);
 
       expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
       expect(tagCache.writeTags).toHaveBeenCalledWith([
         {
           path: "/path",
-          tag: "_N_T_/path",
+          tag: `${SOFT_TAG_PREFIX}path`,
         },
       ]);
 
@@ -731,7 +731,7 @@ describe("CacheHandler", () => {
 
         const result = await cache.get("key", {
           kind: "FETCH",
-          softTags: ["_N_T_/path"],
+          softTags: [`${SOFT_TAG_PREFIX}path`],
         });
 
         expect(getFetchCacheSpy).toHaveBeenCalled();


### PR DESCRIPTION
Introduce a new option to bypass tag cache validation from the incremental caches, along with unit tests to ensure expected behavior.

This is useful in 2 situations: 
- When you don't need the tag cache only for some routes/data cache entry
- When you're sure that a route has not been revalidated. For example in cloudflare when a cache entry is coming from the cache api and that you have automatic cache invalidation.