### PR TITLE
add(patches): Drop babel from getting pulled in by node-environment

### DIFF
--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -206,6 +206,7 @@ async function generateBundle(
     patches.patchEnvVars,
     patches.patchBackgroundRevalidation,
     patches.patchUseCacheForISR,
+    patches.patchNodeEnvironment,
     ...additionalCodePatches,
   ]);
 

--- a/packages/open-next/src/build/patch/patches/index.ts
+++ b/packages/open-next/src/build/patch/patches/index.ts
@@ -7,3 +7,4 @@ export {
 } from "./patchFetchCacheISR.js";
 export { patchFetchCacheSetMissingWaitUntil } from "./patchFetchCacheWaitUntil.js";
 export { patchBackgroundRevalidation } from "./patchBackgroundRevalidation.js";
+export { patchNodeEnvironment } from "./patchNodeEnvironment.js";

--- a/packages/open-next/src/build/patch/patches/patchNextServer.ts
+++ b/packages/open-next/src/build/patch/patches/patchNextServer.ts
@@ -53,17 +53,6 @@ fix: |-
 `;
 }
 
-/**
- * Drops `require("./node-environment-extensions/error-inspect");`
- */
-export const errorInspectRule = `
-rule:
-  pattern: require("./node-environment-extensions/error-inspect");
-fix: |-
-  // Removed by OpenNext
-  // require("./node-environment-extensions/error-inspect");
-`;
-
 const pathFilter = getCrossPlatformPathRegex(
   String.raw`/next/dist/server/next-server\.js$`,
   {
@@ -90,12 +79,6 @@ const babelPatches = [
     pathFilter,
     contentFilter: /runEdgeFunction\(/,
     patchCode: createPatchCode(createEmptyBodyRule("runEdgeFunction")),
-  },
-  // Drop `error-inspect` that pulls babel
-  {
-    pathFilter,
-    contentFilter: /error-inspect/,
-    patchCode: createPatchCode(errorInspectRule),
   },
 ];
 

--- a/packages/open-next/src/build/patch/patches/patchNodeEnvironment.ts
+++ b/packages/open-next/src/build/patch/patches/patchNodeEnvironment.ts
@@ -1,0 +1,34 @@
+import { Lang } from "@ast-grep/napi";
+import { getCrossPlatformPathRegex } from "utils/regex.js";
+import { createPatchCode } from "../astCodePatcher.js";
+import type { CodePatcher } from "../codePatcher.js";
+
+/**
+ * Drops `require("./node-environment-extensions/error-inspect");`
+ *
+ * This is to avoid pulling babel (~4MB)
+ */
+export const rule = `
+rule:
+  pattern: require("./node-environment-extensions/error-inspect");
+fix: |-
+  // Removed by OpenNext
+  // require("./node-environment-extensions/error-inspect");
+`;
+
+export const patchNodeEnvironment: CodePatcher = {
+  name: "patch-node-environment-error-inspect",
+  patches: [
+    {
+      pathFilter: getCrossPlatformPathRegex(
+        String.raw`/next/dist/server/node-environment\.js$`,
+        {
+          escape: false,
+        },
+      ),
+      contentFilter: /error-inspect/,
+      patchCode: createPatchCode(rule, Lang.JavaScript),
+      versions: ">=15.0.0",
+    },
+  ],
+};


### PR DESCRIPTION
Closes #947

I applied it on `>=15.0.0`. 