### PR TITLE
fix: Add automatic response cleanup via AbortSignal

### DIFF
--- a/.changeset/eleven-moose-heal.md
+++ b/.changeset/eleven-moose-heal.md
@@ -3,3 +3,5 @@
 ---
 
 fix(dev-overrides): Add automatic response cleanup via onClose callback
+
+This changes will make `request.signal.onabort` work in route handlers for `node` and `express-dev` wrappers.

--- a/.changeset/eleven-moose-heal.md
+++ b/.changeset/eleven-moose-heal.md
@@ -2,6 +2,6 @@
 "@opennextjs/aws": patch
 ---
 
-fix(dev-overrides): Add automatic response cleanup via onClose callback
+fix: Add automatic response cleanup via AbortSignal
 
-This changes will make `request.signal.onabort` work in route handlers for `node` and `express-dev` wrappers.
+These changes will make `request.signal.onabort` work in route handlers for `node`, `cloudflare-node` and `express-dev` wrappers.

--- a/.changeset/eleven-moose-heal.md
+++ b/.changeset/eleven-moose-heal.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(dev-overrides): Add automatic response cleanup via onClose callback

--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -87,8 +87,8 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
 
     // We want to destroy this response when the original response is closed. (i.e when the client disconnects)
     // This is to support `request.signal.onabort` in route handlers
-    if (streamCreator?.onClose) {
-      streamCreator.onClose(() => {
+    if (streamCreator?.abortSignal) {
+      streamCreator.abortSignal.addEventListener("abort", () => {
         this.destroy();
       });
     }

--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -85,6 +85,7 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
       this.statusCode = statusCode;
     }
 
+    // https://github.com/vercel/next.js/blob/ea08bf2/packages/next/src/server/web/spec-extension/adapters/next-request.ts#L46-L54
     // We want to destroy this response when the original response/request is closed. (i.e when the client disconnects)
     // This is to support `request.signal.onabort` in route handlers
     streamCreator?.abortSignal?.addEventListener("abort", () => {

--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -88,7 +88,7 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
     // We want to destroy this response when the original response/request is closed. (i.e when the client disconnects)
     // This is to support `request.signal.onabort` in route handlers
     streamCreator?.abortSignal?.addEventListener("abort", () => {
-        this.destroy();
+      this.destroy();
     });
   }
 

--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -84,6 +84,14 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
     ) {
       this.statusCode = statusCode;
     }
+
+    // We want to destroy this response when the original response is closed. (i.e when the client disconnects)
+    // This is to support `request.signal.onabort` in route handlers
+    if (streamCreator?.onClose) {
+      streamCreator.onClose(() => {
+        this.destroy();
+      });
+    }
   }
 
   // Necessary for next 12

--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -85,13 +85,11 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
       this.statusCode = statusCode;
     }
 
-    // We want to destroy this response when the original response is closed. (i.e when the client disconnects)
+    // We want to destroy this response when the original response/request is closed. (i.e when the client disconnects)
     // This is to support `request.signal.onabort` in route handlers
-    if (streamCreator?.abortSignal) {
-      streamCreator.abortSignal.addEventListener("abort", () => {
+    streamCreator?.abortSignal?.addEventListener("abort", () => {
         this.destroy();
-      });
-    }
+    });
   }
 
   // Necessary for next 12

--- a/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
@@ -66,6 +66,9 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
 
         return Writable.fromWeb(writable);
       },
+      // For some reason the signal from `request` here did not work.
+      // @ts-expect-error This is defined in init from cloudflare
+      abortSignal: globalThis[Symbol.for("__cloudflare-context__")].signal,
     };
 
     ctx.waitUntil(

--- a/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
@@ -16,9 +16,9 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
     request: Request,
     env: Record<string, string>,
     ctx: any,
+    abortSignal: AbortSignal,
   ): Promise<Response> => {
     globalThis.process = process;
-
     // Set the environment variables
     // Cloudflare suggests to not override the process.env object but instead apply the values to it
     for (const [key, value] of Object.entries(env)) {
@@ -66,9 +66,10 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
 
         return Writable.fromWeb(writable);
       },
-      // For some reason the signal from `request` here did not work.
-      // @ts-expect-error This is defined in init from cloudflare
-      abortSignal: globalThis[Symbol.for("__cloudflare-context__")].signal,
+      // This is for passing along the original abort signal from the initial Request you retrieve in your worker
+      // Ensures that the response we pass to NextServer is aborted if the request is aborted
+      // By doing this `request.signal.onabort` will work in route handlers
+      abortSignal: abortSignal,
     };
 
     ctx.waitUntil(

--- a/packages/open-next/src/overrides/wrappers/node.ts
+++ b/packages/open-next/src/overrides/wrappers/node.ts
@@ -8,7 +8,7 @@ import { debug, error } from "../../adapters/logger";
 const wrapper: WrapperHandler = async (handler, converter) => {
   const server = createServer(async (req, res) => {
     const internalEvent = await converter.convertFrom(req);
-    
+
     let onCloseCallback: (() => void) | undefined;
     const streamCreator: StreamCreator = {
       writeHeaders: (prelude) => {

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -49,6 +49,8 @@ export interface StreamCreator {
   // Just to fix an issue with aws lambda streaming with empty body
   onWrite?: () => void;
   onFinish?: (length: number) => void;
+  // This is called when the wrappers response is closed, i.e. when the client disconnects
+  onClose?: (callback: () => void) => void;
 }
 
 export type WaitUntil = (promise: Promise<void>) => void;

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -49,8 +49,7 @@ export interface StreamCreator {
   // Just to fix an issue with aws lambda streaming with empty body
   onWrite?: () => void;
   onFinish?: (length: number) => void;
-  // This is called when the wrappers response is closed, i.e. when the client disconnects
-  onClose?: (callback: () => void) => void;
+  abortSignal?: AbortSignal;
 }
 
 export type WaitUntil = (promise: Promise<void>) => void;


### PR DESCRIPTION
To make `request.signal.onabort` work in route handlers. Currently only works for `cloudflare-node`, `node` and `express-dev`. It will close the `OpenNextNodeResponse` we pass into `NextServer`'s request handler when the original response in the wrapper is closed. This will ensure that the AbortSignal associated with `request.signal` is properly triggered when a client disconnects during a streaming response.

I did try to get it to work with `awsLambda.streamifyResponse`. It looks like we get no event emitted on `responseStream` when a client disconnects. I even tried with a barebone Lambda like this:
```ts
exports.handler = awslambda.streamifyResponse(
    async (event, responseStream, context) => {
        responseStream.setContentType('text/event-stream')
        responseStream.on("close", ()=> {
          // this never gets emitted at any point of time
          console.log("responseStream closed");
        });
        for (let i = 0; i < 20; i++) {
            await sleep(1000);
            responseStream.write(`event: ping\n`);
            responseStream.write(`data: ${i}\n\n`);
        }
        responseStream.end();
    }
);