### PR TITLE
fix(build): Add 22.18.0 to affected nodeVersion in dereference symlink

### DIFF
--- a/.changeset/nine-geese-lie.md
+++ b/.changeset/nine-geese-lie.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(build): Add 22.18.0 to affected nodeVersion in dereference symlink workaround"

--- a/packages/open-next/src/build/installDeps.ts
+++ b/packages/open-next/src/build/installDeps.ts
@@ -7,6 +7,8 @@ import type { InstallOptions } from "types/open-next";
 
 import logger from "../logger.js";
 
+const AFFECTED_NODE_VERSIONS = ["22.17.0", "22.17.1", "22.18.0"];
+
 export function installDependencies(
   outputDir: string,
   installOptions?: InstallOptions,
@@ -54,7 +56,7 @@ export function installDependencies(
     // This is a workaround for Node `22.17.0` and `22.17.1`
     // https://github.com/nodejs/node/issues/59168
     const nodeVersion = process.version;
-    if (nodeVersion === "v22.17.0" || nodeVersion === "v22.17.1") {
+    if (AFFECTED_NODE_VERSIONS.includes(nodeVersion)) {
       const tempBinDir = path.join(tempInstallDir, "node_modules", ".bin");
       const outputBinDir = path.join(outputDir, "node_modules", ".bin");
 


### PR DESCRIPTION
`22.18.0` is also affected. Should we consider skipping the `.bin` folder? I cannot see a reason for having it in the bundle.