### PR TITLE
fix(express-dev): Disable x-powered-by header

### DIFF
--- a/.changeset/tame-seas-raise.md
+++ b/.changeset/tame-seas-raise.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(express-dev): Disable x-powered-by header

--- a/examples/app-router/app/api/isr/route.ts
+++ b/examples/app-router/app/api/isr/route.ts
@@ -15,10 +15,13 @@ export async function GET(request: NextRequest) {
   const manifest = JSON.parse(prerenderManifest);
   const previewId = manifest.preview.previewModeId;
 
-  const result = await fetch(`https://${request.headers.get("host")}/isr`, {
-    headers: { "x-prerender-revalidate": previewId },
-    method: "HEAD",
-  });
+  const result = await fetch(
+    `${request.headers.get("x-forwarded-proto") ?? "https"}://${request.headers.get("host")}/isr`,
+    {
+      headers: { "x-prerender-revalidate": previewId },
+      method: "HEAD",
+    },
+  );
 
   return NextResponse.json({
     status: 200,

--- a/packages/open-next/src/overrides/wrappers/express-dev.ts
+++ b/packages/open-next/src/overrides/wrappers/express-dev.ts
@@ -8,6 +8,9 @@ import { getMonorepoRelativePath } from "utils/normalize-path";
 
 const wrapper: WrapperHandler = async (handler, converter) => {
   const app = express();
+  // We disable this cause we wanna use it ourself
+  // https://stackoverflow.com/a/13055495/16587222
+  app.disable("x-powered-by");
   // To serve static assets
   const basePath = NextConfig.basePath ?? "";
   app.use(


### PR DESCRIPTION
For #958 

This is to make the E2E work when ran locally.