### PR TITLE
fix(dev-overrides): Make Image optimization work locally

### DIFF
--- a/.changeset/long-ears-worry.md
+++ b/.changeset/long-ears-worry.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(fs-dev): Make Image optimization work locally

--- a/packages/open-next/src/build/createImageOptimizationBundle.ts
+++ b/packages/open-next/src/build/createImageOptimizationBundle.ts
@@ -116,7 +116,7 @@ export async function createImageOptimizationBundle(
     outputPath,
     config.imageOptimization?.install ?? {
       packages: [`sharp@${sharpVersion}`],
-      arch: "arm64",
+      arch: config.imageOptimization?.loader === "fs-dev" ? undefined : "arm64",
       nodeVersion: "18",
       libc: "glibc",
     },

--- a/packages/open-next/src/build/createImageOptimizationBundle.ts
+++ b/packages/open-next/src/build/createImageOptimizationBundle.ts
@@ -116,6 +116,7 @@ export async function createImageOptimizationBundle(
     outputPath,
     config.imageOptimization?.install ?? {
       packages: [`sharp@${sharpVersion}`],
+      // By not specifying an arch, `npm install` will choose one for us (i.e. our system one)
       arch: config.imageOptimization?.loader === "fs-dev" ? undefined : "arm64",
       nodeVersion: "18",
       libc: "glibc",


### PR DESCRIPTION
This is the only thing we need I think to make it work locally. By not specifying an `arch`, `npm install` command will choose it for us. (i.e our system one)