### PR TITLE
fix: Ensure middleware rewrite status code is properly propagated in cache interceptor

### DIFF
--- a/.changeset/angry-ways-approve.md
+++ b/.changeset/angry-ways-approve.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: Ensure middleware rewrite status code is properly propagated to cache interceptor

--- a/packages/open-next/src/adapters/middleware.ts
+++ b/packages/open-next/src/adapters/middleware.ts
@@ -125,7 +125,10 @@ const defaultHandler = async (
         }
       }
 
-      result.headers[INTERNAL_EVENT_REQUEST_ID] = requestId;
+      if (process.env.OPEN_NEXT_REQUEST_ID_HEADER || globalThis.openNextDebug) {
+        result.headers[INTERNAL_EVENT_REQUEST_ID] = requestId;
+      }
+
       debug("Middleware response", result);
       return result;
     },

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -63,7 +63,7 @@ export async function openNextHandler(
       }
       debug("internalEvent", internalEvent);
 
-      // These 2 will get overwritten by the routing handler if not using an external middleware
+      // These 3 will get overwritten by the routing handler if not using an external middleware
       const internalHeaders = {
         initialPath:
           initialHeaders[INTERNAL_HEADER_INITIAL_URL] ?? internalEvent.rawPath,

--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -6,7 +6,11 @@ import {
   NextConfig,
   PrerenderManifest,
 } from "config/index.js";
-import type { InternalEvent, InternalResult } from "types/open-next.js";
+import type {
+  InternalEvent,
+  InternalResult,
+  MiddlewareEvent,
+} from "types/open-next.js";
 import { emptyReadableStream } from "utils/stream.js";
 
 import { getQueryFromSearchParams } from "../../overrides/converters/utils.js";
@@ -27,12 +31,6 @@ const middleMatch = getMiddlewareMatch(
 );
 
 const REDIRECTS = new Set([301, 302, 303, 307, 308]);
-
-type MiddlewareEvent = InternalEvent & {
-  responseHeaders?: Record<string, string | string[]>;
-  isExternalRewrite?: boolean;
-  rewriteStatusCode?: number;
-};
 
 type Middleware = (request: Request) => Response | Promise<Response>;
 type MiddlewareLoader = () => Promise<{ default: Middleware }>;
@@ -198,6 +196,7 @@ export async function handleMiddleware(
     cookies: internalEvent.cookies,
     remoteAddress: internalEvent.remoteAddress,
     isExternalRewrite,
-    rewriteStatusCode: statusCode,
+    rewriteStatusCode:
+      rewriteUrl && !isExternalRewrite ? statusCode : undefined,
   } satisfies MiddlewareEvent;
 }

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -32,6 +32,12 @@ export type InternalEvent = {
   readonly remoteAddress: string;
 } & BaseEventOrResult<"core">;
 
+export type MiddlewareEvent = InternalEvent & {
+  responseHeaders?: Record<string, string | string[]>;
+  isExternalRewrite?: boolean;
+  rewriteStatusCode?: number;
+};
+
 export type InternalResult = {
   statusCode: number;
   headers: Record<string, string | string[]>;

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -39,7 +39,10 @@ export function getTagsFromValue(value?: CacheValue<"cache">) {
   }
   // The try catch is necessary for older version of next.js that may fail on this
   try {
-    return value.meta?.headers?.["x-next-cache-tags"]?.split(",") ?? [];
+    const cacheTags =
+      value.meta?.headers?.["x-next-cache-tags"]?.split(",") ?? [];
+    delete value.meta?.headers?.["x-next-cache-tags"];
+    return cacheTags;
   } catch (e) {
     return [];
   }

--- a/packages/tests-e2e/tests/appRouter/middleware.rewrite.test.ts
+++ b/packages/tests-e2e/tests/appRouter/middleware.rewrite.test.ts
@@ -23,7 +23,6 @@ test("Middleware Rewrite", async ({ page }) => {
 });
 
 test("Middleware Rewrite External Image", async ({ page }) => {
-  await page.goto("/rewrite-external");
   page.on("response", async (response) => {
     expect(response.status()).toBe(200);
     expect(response.headers()["content-type"]).toBe("image/png");
@@ -31,13 +30,18 @@ test("Middleware Rewrite External Image", async ({ page }) => {
     const bodyBuffer = await response.body();
     expect(validateMd5(bodyBuffer, OPENNEXT_PNG_MD5)).toBe(true);
   });
+  await page.goto("/rewrite-external");
 });
 
 test("Middleware Rewrite Status Code", async ({ page }) => {
+  page.on("response", async (response) => {
+    // Need to set up the event before navigating to the page to avoid missing it
+    // We need to check the URL here also cause there will be multiple responses (i.e the fonts, css, js, etc)
+    if (response.url() === "/rewrite-status-code") {
+      expect(response.status()).toBe(403);
+    }
+  });
   await page.goto("/rewrite-status-code");
   const el = page.getByText("Rewritten Destination", { exact: true });
   await expect(el).toBeVisible();
-  page.on("response", async (response) => {
-    expect(response.status()).toBe(403);
-  });
 });


### PR DESCRIPTION
When you have a rewrite in middleware like this:
```ts
return NextResponse.rewrite(u, {
  status: 403,
});
```
The rewrite status code is not propogated to the cache interceptor's responses when you have an external middleware. 

We can also safely remove the `x-next-cache-tags` header on the response.

I did update some tests that were flakey aswell. We need to register the event listener before the navigation.