### PR TITLE
fix(build): Refactor fallback values to be dummy overrides in createEdgeBundle

### DIFF
--- a/.changeset/lovely-goats-rest.md
+++ b/.changeset/lovely-goats-rest.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(build): Support function-valued overrides in override helper

--- a/.changeset/lovely-goats-rest.md
+++ b/.changeset/lovely-goats-rest.md
@@ -2,4 +2,4 @@
 "@opennextjs/aws": patch
 ---
 
-fix(build): Support function-valued overrides in override helper
+fix(build): Refactor fallback values to be dummy overrides in createEdgeBundle

--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -59,7 +59,8 @@ export async function buildEdgeBundle({
 }: BuildEdgeBundleOptions) {
   const isInCloudflare = await isEdgeRuntime(overrides);
   function override<T extends keyof Override>(target: T) {
-    return typeof overrides?.[target] === "string"
+    return typeof overrides?.[target] === "string" ||
+      typeof overrides?.[target] === "function"
       ? overrides[target]
       : undefined;
   }

--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -59,8 +59,7 @@ export async function buildEdgeBundle({
 }: BuildEdgeBundleOptions) {
   const isInCloudflare = await isEdgeRuntime(overrides);
   function override<T extends keyof Override>(target: T) {
-    return typeof overrides?.[target] === "string" ||
-      typeof overrides?.[target] === "function"
+    return typeof overrides?.[target] === "string"
       ? overrides[target]
       : undefined;
   }
@@ -83,9 +82,9 @@ export async function buildEdgeBundle({
             converter: override("converter") ?? defaultConverter,
             ...(includeCache
               ? {
-                  tagCache: override("tagCache") ?? "dynamodb-lite",
-                  incrementalCache: override("incrementalCache") ?? "s3-lite",
-                  queue: override("queue") ?? "sqs-lite",
+                  tagCache: override("tagCache") ?? "dummy",
+                  incrementalCache: override("incrementalCache") ?? "dummy",
+                  queue: override("queue") ?? "dummy",
                 }
               : {}),
             originResolver: override("originResolver") ?? "pattern-env",

--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -59,7 +59,8 @@ export async function buildEdgeBundle({
 }: BuildEdgeBundleOptions) {
   const isInCloudflare = await isEdgeRuntime(overrides);
   function override<T extends keyof Override>(target: T) {
-    return typeof overrides?.[target] === "string"
+    return typeof overrides?.[target] === "string" ||
+      typeof overrides?.[target] === "function"
       ? overrides[target]
       : undefined;
   }
@@ -82,9 +83,9 @@ export async function buildEdgeBundle({
             converter: override("converter") ?? defaultConverter,
             ...(includeCache
               ? {
-                  tagCache: override("tagCache") ?? "dummy",
-                  incrementalCache: override("incrementalCache") ?? "dummy",
-                  queue: override("queue") ?? "dummy",
+                  tagCache: override("tagCache") ?? "dynamodb-lite",
+                  incrementalCache: override("incrementalCache") ?? "s3-lite",
+                  queue: override("queue") ?? "sqs-lite",
                 }
               : {}),
             originResolver: override("originResolver") ?? "pattern-env",


### PR DESCRIPTION
If you have `enableCacheInterception` enabled `includeCache` will be true there, meaning `esbuild` will potentially bundle `aws4fetch` and the fallback overrides(`sqs-lite`, `dynamodb-lite` & `s3-lite`) in the middleware handler file. This can happen if you build from the Cloudflare adapter cause the `overrides` can contain anonymous functions and the `override` function would return `undefined`.

To see this your self, build the `examples/e2e/app-router` in cloudflare repo and look for `aws4fetch`, `sqs-lite` etc.. in the middleware handler file. Do we really need to pass any values [here](https://github.com/sommeeeer/opennextjs-aws/blob/0e962f1a006449df2d7444ed021a9b6b9a287fd2/packages/open-next/src/build/edge/createEdgeBundle.ts#L86-L91) tho? I can't find any of them bundled in the middleware handler, even with this fix.

```bash
# before
124K    .open-next/middleware/handler.mjs
# after
104K    .open-next/middleware/handler.mjs
```