### PR TITLE
fix: Avoid merging Location header on response when its an array

### DIFF
--- a/.changeset/seven-ducks-breathe.md
+++ b/.changeset/seven-ducks-breathe.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: Avoid merging Location header on response when its an array

--- a/packages/open-next/src/http/util.ts
+++ b/packages/open-next/src/http/util.ts
@@ -12,7 +12,8 @@ export const parseHeaders = (
     if (value === undefined) {
       continue;
     }
-    // Next can sometimes return an Array for the Location header
+    // Next can return an Array for the Location header
+    // We dont want to merge that into a comma-separated string
     // See: https://github.com/opennextjs/opennextjs-cloudflare/issues/875#issuecomment-3258248276
     if (key.toLowerCase() === "location" && Array.isArray(value)) {
       result[key.toLowerCase()] = value[0];

--- a/packages/open-next/src/http/util.ts
+++ b/packages/open-next/src/http/util.ts
@@ -15,7 +15,7 @@ export const parseHeaders = (
     }
     const keyLower = key.toLowerCase();
     /**
-     * Next can return an Array for the Location header
+     * Next can return an Array for the Location header when you return null from a get in the cacheHandler on a page that has a redirect()
      * We dont want to merge that into a comma-separated string
      * If they are the same just return one of them
      * Otherwise return the last one

--- a/packages/open-next/src/http/util.ts
+++ b/packages/open-next/src/http/util.ts
@@ -1,4 +1,5 @@
 import type http from "node:http";
+import logger from "../logger";
 
 export const parseHeaders = (
   headers?: http.OutgoingHttpHeader[] | http.OutgoingHttpHeaders,
@@ -25,6 +26,9 @@ export const parseHeaders = (
       if (value[0] === value[1]) {
         result[keyLower] = value[0];
       } else {
+        logger.warn(
+          "Multiple different values for Location header found. Using the last one",
+        );
         result[keyLower] = value[value.length - 1];
       }
       continue;

--- a/packages/open-next/src/http/util.ts
+++ b/packages/open-next/src/http/util.ts
@@ -12,14 +12,24 @@ export const parseHeaders = (
     if (value === undefined) {
       continue;
     }
-    // Next can return an Array for the Location header
-    // We dont want to merge that into a comma-separated string
-    // See: https://github.com/opennextjs/opennextjs-cloudflare/issues/875#issuecomment-3258248276
-    if (key.toLowerCase() === "location" && Array.isArray(value)) {
-      result[key.toLowerCase()] = value[0];
+    const keyLower = key.toLowerCase();
+    /**
+     * Next can return an Array for the Location header
+     * We dont want to merge that into a comma-separated string
+     * If they are the same just return one of them
+     * Otherwise return the last one
+     * See: https://github.com/opennextjs/opennextjs-cloudflare/issues/875#issuecomment-3258248276
+     * and https://github.com/opennextjs/opennextjs-aws/pull/977#issuecomment-3261763114
+     */
+    if (keyLower === "location" && Array.isArray(value)) {
+      if (value[0] === value[1]) {
+        result[keyLower] = value[0];
+      } else {
+        result[keyLower] = value[value.length - 1];
+      }
       continue;
     }
-    result[key.toLowerCase()] = convertHeader(value);
+    result[keyLower] = convertHeader(value);
   }
 
   return result;

--- a/packages/open-next/src/http/util.ts
+++ b/packages/open-next/src/http/util.ts
@@ -12,6 +12,12 @@ export const parseHeaders = (
     if (value === undefined) {
       continue;
     }
+    // Next can sometimes return an Array for the Location header
+    // See: https://github.com/opennextjs/opennextjs-cloudflare/issues/875#issuecomment-3258248276
+    if (key.toLowerCase() === "location" && Array.isArray(value)) {
+      result[key.toLowerCase()] = value[0];
+      continue;
+    }
     result[key.toLowerCase()] = convertHeader(value);
   }
 

--- a/packages/tests-unit/tests/http/utils.test.ts
+++ b/packages/tests-unit/tests/http/utils.test.ts
@@ -1,6 +1,9 @@
 import type http from "node:http";
 
-import { parseHeaders, parseSetCookieHeader } from "@opennextjs/aws/http/util.js";
+import {
+  parseHeaders,
+  parseSetCookieHeader,
+} from "@opennextjs/aws/http/util.js";
 
 describe("parseSetCookieHeader", () => {
   it("returns an empty list if cookies is emptyish", () => {

--- a/packages/tests-unit/tests/http/utils.test.ts
+++ b/packages/tests-unit/tests/http/utils.test.ts
@@ -1,4 +1,6 @@
-import { parseSetCookieHeader } from "@opennextjs/aws/http/util.js";
+import type http from "node:http";
+
+import { parseHeaders, parseSetCookieHeader } from "@opennextjs/aws/http/util.js";
 
 describe("parseSetCookieHeader", () => {
   it("returns an empty list if cookies is emptyish", () => {
@@ -41,5 +43,23 @@ describe("parseSetCookieHeader", () => {
       "cookie1=value1; HttpOnly; Secure; Path=/",
       "cookie2=value2; HttpOnly=false; Secure=True; Domain=example.com; Path=/api",
     ]);
+  });
+});
+
+describe("parseHeaders", () => {
+  it("parses headers correctly", () => {
+    const headers = parseHeaders({
+      location: ["/target", "/target"],
+      "x-custom-header": "customValue",
+      "x-multiple-values": ["value1", "value2"],
+      "x-undefined-header": undefined,
+      "x-opennext": "is-so-cool",
+    } as unknown as http.OutgoingHttpHeaders);
+    expect(headers).toEqual({
+      location: "/target",
+      "x-custom-header": "customValue",
+      "x-multiple-values": "value1,value2",
+      "x-opennext": "is-so-cool",
+    });
   });
 });


### PR DESCRIPTION
This is for https://github.com/opennextjs/opennextjs-cloudflare/issues/875#issuecomment-3258248276

Next will return a header like `Location: ["/target", "/target"];` on the response for a `redirect("/target");` in a static `page.tsx` when you dont have an `incrementalCache`. We should not merge that header's value with `join(",");` 

Affected line in Next: https://github.com/vercel/next.js/blob/ea08bf27/packages/next/src/server/base-server.ts#L1521

This is me `console.log(res._res.headers)` before and after that line with a reproduction:
<img width="1254" height="453" alt="image" src="https://github.com/user-attachments/assets/5f0a330c-60d6-47bc-92de-0ca469330fc8" />
