### PR TITLE
fix(build): Improve regex in copy traced files to skip symbolic links

### DIFF
--- a/.changeset/tiny-points-fry.md
+++ b/.changeset/tiny-points-fry.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(build): Improve regex in copy traced files to skip symbolic links

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -50,7 +50,7 @@ export function isExcluded(srcPath: string): boolean {
     // `pnpm` can create a symbolic link that points to the pnpm store folder
     // This will live under `/node_modules/sharp`. We need to handle this in our regex
     srcPath.match(
-      getCrossPlatformPathRegex(`\/node_modules\/${excluded}(\/|$)`, {
+      getCrossPlatformPathRegex(`/node_modules/${excluded}(?:/|$)`, {
         escape: false,
       }),
     ),

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -45,9 +45,15 @@ const EXCLUDED_PACKAGES = [
   "next/dist/compiled/amphtml-validator",
 ];
 
-function isExcluded(srcPath: string): boolean {
+export function isExcluded(srcPath: string): boolean {
   return EXCLUDED_PACKAGES.some((excluded) =>
-    srcPath.match(getCrossPlatformPathRegex(`/node_modules/${excluded}/`)),
+    // `pnpm` can create a symbolic link that points to the pnpm store folder
+    // This will live under `/node_modules/sharp`. We need to handle this in our regex
+    srcPath.match(
+      getCrossPlatformPathRegex(`\/node_modules\/${excluded}(\/|$)`, {
+        escape: false,
+      }),
+    ),
   );
 }
 

--- a/packages/open-next/src/build/installDeps.ts
+++ b/packages/open-next/src/build/installDeps.ts
@@ -85,7 +85,7 @@ export function installDependencies(
     fs.rmSync(tempInstallDir, { recursive: true, force: true });
     logger.info(`Dependencies installed for ${name}`);
   } catch (e: any) {
-    logger.error(e.stdout.toString());
+    logger.error(e.toString());
     logger.error("Could not install dependencies");
   }
 }

--- a/packages/tests-unit/tests/build/copyTracedFiles.test.ts
+++ b/packages/tests-unit/tests/build/copyTracedFiles.test.ts
@@ -13,9 +13,7 @@ describe("isExcluded", () => {
       ),
     ).toBe(true);
     expect(
-      isExcluded(
-        "/home/user/git/my-opennext-project/node_modules/sharp",
-      ),
+      isExcluded("/home/user/git/my-opennext-project/node_modules/sharp"),
     ).toBe(true);
   });
 
@@ -40,5 +38,5 @@ describe("isExcluded", () => {
         "/home/user/git/my-opennext-project/node_modules/.pnpm/other-package/4.1.3/node_modules/sharp-other",
       ),
     ).toBe(false);
-  });       
+  });
 });

--- a/packages/tests-unit/tests/build/copyTracedFiles.test.ts
+++ b/packages/tests-unit/tests/build/copyTracedFiles.test.ts
@@ -1,0 +1,44 @@
+import { isExcluded } from "@opennextjs/aws/build/copyTracedFiles.js";
+
+describe("isExcluded", () => {
+  test("should exclude sharp", () => {
+    expect(
+      isExcluded(
+        "/home/user/git/my-opennext-project/node_modules/sharp/lib/index.js",
+      ),
+    ).toBe(true);
+    expect(
+      isExcluded(
+        "/home/user/git/my-opennext-project/node_modules/.pnpm/sharp/4.1.3/node_modules/sharp/lib/index.js",
+      ),
+    ).toBe(true);
+    expect(
+      isExcluded(
+        "/home/user/git/my-opennext-project/node_modules/sharp",
+      ),
+    ).toBe(true);
+  });
+
+  test("should not exclude other packages", () => {
+    expect(
+      isExcluded(
+        "/home/user/git/my-opennext-project/node_modules/other-package/lib/index.js",
+      ),
+    ).toBe(false);
+    expect(
+      isExcluded(
+        "/home/user/git/my-opennext-project/node_modules/.pnpm/other-package/4.1.3/node_modules/other-package/lib/index.js",
+      ),
+    ).toBe(false);
+    expect(
+      isExcluded(
+        "/home/user/git/my-opennext-project/node_modules/.pnpm/other-package/4.1.3/node_modules/sharp-other-package/lib/index.js",
+      ),
+    ).toBe(false);
+    expect(
+      isExcluded(
+        "/home/user/git/my-opennext-project/node_modules/.pnpm/other-package/4.1.3/node_modules/sharp-other",
+      ),
+    ).toBe(false);
+  });       
+});


### PR DESCRIPTION
When you use `pnpm` there will be a symbolic link pointing to the store. Our current regex didn't exclude this as it was just looking for all the files living under a folder. This could cause `file already exists` errors when trying to install `sharp` or any of the other excluded packages on the default server function.

```bash
❯ cd node_modules
❯ file sharp
sharp: symbolic link to .pnpm/sharp@0.34.3/node_modules/sharp
```

Reference: Discord [thread](https://discord.com/channels/1283128968140161065/1353461350680101015)