### PR TITLE
feat: add option to align header priorization execution order

### DIFF
--- a/.changeset/shiny-plants-remember.md
+++ b/.changeset/shiny-plants-remember.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": minor
+---
+
+feat: Add option to align with Next.js execution order for headers in middleware and next.config.js

--- a/examples/app-router/app/headers/execution-order/page.tsx
+++ b/examples/app-router/app/headers/execution-order/page.tsx
@@ -1,0 +1,9 @@
+export default async function HeadersExecutionOrder() {
+  return (
+    <div>
+      <h1>
+        Used to check execution order of middleware vs next.config headers.
+      </h1>
+    </div>
+  );
+}

--- a/examples/app-router/app/headers/execution-order/page.tsx
+++ b/examples/app-router/app/headers/execution-order/page.tsx
@@ -1,9 +1,0 @@
-export default async function HeadersExecutionOrder() {
-  return (
-    <div>
-      <h1>
-        Used to check execution order of middleware vs next.config headers.
-      </h1>
-    </div>
-  );
-}

--- a/examples/app-router/middleware.ts
+++ b/examples/app-router/middleware.ts
@@ -51,8 +51,9 @@ export function middleware(request: NextRequest) {
   responseHeaders.set("response-header", "response-header");
 
   // For dangerous.middlewareHeadersOverrideNextConfigHeaders we need to verify that middleware headers override next.config.js headers.
-  if (path === "/headers/execution-order") {
+  if (path === "/headers/override-from-middleware") {
     responseHeaders.set("e2e-headers", "middleware");
+    return NextResponse.json({}, { headers: responseHeaders });
   }
 
   // Set the cache control header with custom swr

--- a/examples/app-router/middleware.ts
+++ b/examples/app-router/middleware.ts
@@ -50,6 +50,11 @@ export function middleware(request: NextRequest) {
   // Response headers should show up in the client's response headers
   responseHeaders.set("response-header", "response-header");
 
+  // For dangerous.middlewareHeadersOverrideNextConfigHeaders we need to verify that middleware headers override next.config.js headers.
+  if (path === "/headers/execution-order") {
+    responseHeaders.set("e2e-headers", "middleware");
+  }
+
   // Set the cache control header with custom swr
   // For: isr.test.ts
   if (path === "/isr" && !request.headers.get("x-prerender-revalidate")) {

--- a/examples/app-router/open-next.config.local.ts
+++ b/examples/app-router/open-next.config.local.ts
@@ -11,6 +11,11 @@ export default {
     },
   },
 
+
+  dangerous: {
+    middlewareHeadersOverrideNextConfigHeaders: true,
+  },
+
   imageOptimization: {
     override: {
       wrapper: "dummy",

--- a/examples/app-router/open-next.config.local.ts
+++ b/examples/app-router/open-next.config.local.ts
@@ -11,7 +11,6 @@ export default {
     },
   },
 
-
   dangerous: {
     middlewareHeadersOverrideNextConfigHeaders: true,
   },

--- a/examples/app-router/open-next.config.ts
+++ b/examples/app-router/open-next.config.ts
@@ -8,6 +8,9 @@ const config = {
     },
   },
   functions: {},
+  dangerous: {
+    middlewareHeadersOverrideNextConfigHeaders: true,
+  },
   buildCommand: "npx turbo build",
 };
 

--- a/packages/open-next/src/core/routingHandler.ts
+++ b/packages/open-next/src/core/routingHandler.ts
@@ -129,10 +129,22 @@ export default async function routingHandler(
       return middlewareEventOrResult;
     }
 
-    headers = {
-      ...middlewareEventOrResult.responseHeaders,
-      ...headers,
-    };
+    const middlewareHeadersPrioritized =
+      globalThis.openNextConfig.dangerous
+        ?.middlewareHeadersOverrideNextConfigHeaders ?? false;
+
+    if (middlewareHeadersPrioritized) {
+      headers = {
+        ...headers,
+        ...middlewareEventOrResult.responseHeaders,
+      };
+    } else {
+      headers = {
+        ...middlewareEventOrResult.responseHeaders,
+        ...headers,
+      };
+    }
+
     let isExternalRewrite = middlewareEventOrResult.isExternalRewrite ?? false;
     eventOrResult = middlewareEventOrResult;
 

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -83,7 +83,8 @@ export interface DangerousOptions {
 
   /**
    * Configuration option to prioritize headers set via middleware over headers set via the option in the Next config.
-   * This brings OpenNext behavior inline with the documented execution order.
+   *
+   * The default will change to 'true' in v4.
    *
    * See also {@link https://nextjs.org/docs/app/api-reference/file-conventions/middleware#execution-order}
    *

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -80,6 +80,16 @@ export interface DangerousOptions {
   headersAndCookiesPriority?: (
     event: InternalEvent,
   ) => "middleware" | "handler";
+
+  /**
+   * Configuration option to prioritize headers set via middleware over headers set via the option in the Next config.
+   * This brings OpenNext behavior inline with the documented execution order.
+   *
+   * See also {@link https://nextjs.org/docs/app/api-reference/file-conventions/middleware#execution-order}
+   *
+   * @default false
+   */
+  middlewareHeadersOverrideNextConfigHeaders?: boolean;
 }
 
 export type BaseOverride = {

--- a/packages/tests-e2e/tests/appRouter/headers.test.ts
+++ b/packages/tests-e2e/tests/appRouter/headers.test.ts
@@ -36,7 +36,7 @@ test("Headers execution order", async ({ page }) => {
   const responsePromise = page.waitForResponse((response) => {
     return response.status() === 200;
   });
-  await page.goto("/headers/execution-order");
+  await page.goto("/headers/override-from-middleware");
 
   const response = await responsePromise;
   // Response header should be set

--- a/packages/tests-e2e/tests/appRouter/headers.test.ts
+++ b/packages/tests-e2e/tests/appRouter/headers.test.ts
@@ -28,3 +28,20 @@ test("Headers", async ({ page }) => {
   // Request ID header should be set
   expect(headers["x-opennext-requestid"]).not.toBeFalsy();
 });
+
+/**
+ * Tests that the middleware headers are applied after next.config.js headers.
+ */
+test("Headers execution order", async ({ page }) => {
+  const responsePromise = page.waitForResponse((response) => {
+    return response.status() === 200;
+  });
+  await page.goto("/headers/execution-order");
+
+  const response = await responsePromise;
+  // Response header should be set
+  const headers = response.headers();
+
+  // The next.config.js headers is overwritten by the middleware
+  expect(headers["e2e-headers"]).toEqual("middleware");
+});

--- a/packages/tests-e2e/tests/appRouter/headers.test.ts
+++ b/packages/tests-e2e/tests/appRouter/headers.test.ts
@@ -30,9 +30,9 @@ test("Headers", async ({ page }) => {
 });
 
 /**
- * Tests that the middleware headers are applied after next.config.js headers.
+ * Tests that the middleware headers are applied after next.config.js headers. Requires 'dangerous.middlewareHeadersOverrideNextConfigHeaders' to be set.
  */
-test("Headers execution order", async ({ page }) => {
+test("Middleware headers override next.config.js headers", async ({ page }) => {
   const responsePromise = page.waitForResponse((response) => {
     return response.status() === 200;
   });


### PR DESCRIPTION
Fixes opennextjs/opennextjs-aws#973

I'm not sure if the added configuration option should be under `dangerous`, but just put it there since it changes some behavior. Also alternative names are welcome :) 

Should I also create a PR to the docs repo, or is that auto-synced based on types / comment extraction?