### PR TITLE
fix: allow bypassing the Tag Cache in the interceptor

### DIFF
--- a/.changeset/gold-penguins-walk.md
+++ b/.changeset/gold-penguins-walk.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": minor
+---
+
+fix: allow bypassing the Tag Cache in the interceptor

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -233,11 +233,11 @@ export async function cacheInterceptor(
         cachedData.value?.type === "route"
       ) {
         const tags = getTagsFromValue(cachedData.value);
-        const _hasBeenRevalidated = await hasBeenRevalidated(
-          localizedPath,
-          tags,
-          cachedData,
-        );
+
+        const _hasBeenRevalidated = cachedData.shouldBypassTagCache
+          ? false
+          : await hasBeenRevalidated(localizedPath, tags, cachedData);
+
         if (_hasBeenRevalidated) {
           return event;
         }

--- a/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
+++ b/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
@@ -170,6 +170,23 @@ describe("cacheInterceptor", () => {
     expect(result).toEqual(event);
   });
 
+  it("should bypass the tag cache when shouldBypassTagCache is true", async () => {
+    const event = createEvent({
+      url: "/albums",
+    });
+    incrementalCache.get.mockResolvedValueOnce({
+      value: {
+        type: "app",
+        html: "Hello, world!",
+      },
+      shouldBypassTagCache: true,
+    });
+
+    await cacheInterceptor(event);
+
+    expect(tagCache.getLastModified).not.toHaveBeenCalled();
+  });
+
   it("should take no action when tagCache lasModified is -1 for route type", async () => {
     const event = createEvent({
       url: "/albums",


### PR DESCRIPTION
`shouldBypassTagCache` was implemented in https://github.com/opennextjs/opennextjs-aws/pull/944.

It is useful to bypass the Tag Cache when we know that an entry has not been revalidated.

The original PR missed an updated in the cache interceptor resulting in the Tag Cache never being bypassed when it is in use.

/cc @dario-piotrowicz 