### PR TITLE
Update npm install command to use --os flag

### DIFF
--- a/packages/open-next/src/build/createImageOptimizationBundle.ts
+++ b/packages/open-next/src/build/createImageOptimizationBundle.ts
@@ -110,7 +110,7 @@ export async function createImageOptimizationBundle(
   // Target should be same as used by Lambda, see https://github.com/sst/sst/blob/ca6f763fdfddd099ce2260202d0ce48c72e211ea/packages/sst/src/constructs/NextjsSite.ts#L114
   // For SHARP_IGNORE_GLOBAL_LIBVIPS see: https://github.com/lovell/sharp/blob/main/docs/install.md#aws-lambda
 
-  const sharpVersion = process.env.SHARP_VERSION ?? "0.32.6";
+  const sharpVersion = process.env.SHARP_VERSION ?? "0.34.4";
 
   installDependencies(
     outputPath,

--- a/packages/open-next/src/build/installDeps.ts
+++ b/packages/open-next/src/build/installDeps.ts
@@ -36,7 +36,7 @@ export function installDependencies(
       : "";
 
     const additionalArgs = installOptions.additionalArgs ?? "";
-    const installCommand = `npm install --platform=linux ${archOption} ${targetOption} ${libcOption} ${additionalArgs} ${installOptions.packages.join(" ")}`;
+    const installCommand = `npm install --os=linux ${archOption} ${targetOption} ${libcOption} ${additionalArgs} ${installOptions.packages.join(" ")}`;
     execSync(installCommand, {
       stdio: "pipe",
       cwd: tempInstallDir,

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -279,7 +279,7 @@ export interface InstallOptions {
    * @example
    * ```ts
    * install: {
-   *  packages: ["sharp@0.32"]
+   *  packages: ["sharp@0.34"]
    * }
    * ```
    */


### PR DESCRIPTION
Resolves a problem where sharp after 0.36.2 would not install correctly.

- uses `--os` instead of platform
- updates `sharp`to latest version