### PR TITLE
fix: bypass next tag cache when there are no tags to check

### DIFF
--- a/.changeset/rude-trains-know.md
+++ b/.changeset/rude-trains-know.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: bypass next tag cache when there are no tags to check

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -23,7 +23,9 @@ export async function hasBeenRevalidated(
   }
   const lastModified = cacheEntry.lastModified ?? Date.now();
   if (globalThis.tagCache.mode === "nextMode") {
-    return await globalThis.tagCache.hasBeenRevalidated(tags, lastModified);
+    return tags.length === 0
+      ? false
+      : await globalThis.tagCache.hasBeenRevalidated(tags, lastModified);
   }
   // TODO: refactor this, we should introduce a new method in the tagCache interface so that both implementations use hasBeenRevalidated
   const _lastModified = await globalThis.tagCache.getLastModified(


### PR DESCRIPTION
Before this PR `hasBeenRevalidated` might be called with an empty tag list.

However we can early return `false` in this case