### PR TITLE
chore: github actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,18 +4,17 @@ description: Install's node, pnpm, restores cache, and then installs dependencie
 runs:
   using: 'composite'
   steps:
+    # Install nodejs. https://github.com/actions/setup-node
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18.x
+
     # Install pnpm. https://github.com/pnpm/action-setup
     - uses: pnpm/action-setup@v4
       with:
         version: 9
         # run_install: false
-
-    - name: Install Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20.19.4
-        cache: "pnpm"
-        registry-url: "https://registry.npmjs.org"
 
     # Get pnpm store path so we can cache it
     - name: Get pnpm store directory
@@ -30,7 +29,7 @@ runs:
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
-          
+
     - name: Install dependencies
       run: pnpm install
       shell: bash

--- a/.github/workflows/v2-release.yml
+++ b/.github/workflows/v2-release.yml
@@ -18,9 +18,6 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Install dependencies
-        run: pnpm install
-
       - name: Publish Pre-release to npm
         run: pnpm release-v2
         env:


### PR DESCRIPTION
- Revert Node version change to see if it helps with the release workflow
- Drop installing the deps from `.github/workflows/v2-release.yml` as it is now part of the setup.