### PR TITLE
improve composable-cache performance

### DIFF
--- a/packages/open-next/src/types/cache.ts
+++ b/packages/open-next/src/types/cache.ts
@@ -1,5 +1,3 @@
-import type { ReadableStream } from "node:stream/web";
-
 interface CachedFetchValue {
   kind: "FETCH";
   data: {
@@ -152,7 +150,7 @@ export interface ComposableCacheEntry {
 }
 
 export type StoredComposableCacheEntry = Omit<ComposableCacheEntry, "value"> & {
-  value: string;
+  value: Blob;
 };
 
 export interface ComposableCacheHandler {

--- a/packages/open-next/src/utils/stream.ts
+++ b/packages/open-next/src/utils/stream.ts
@@ -20,9 +20,13 @@ export async function fromReadableStream(
     return Buffer.from(chunks[0]).toString(base64 ? "base64" : "utf8");
   }
 
-  // Use Buffer.concat which is more efficient than manual allocation and copy
-  // It handles the allocation and copy in optimized native code
-  const buffer = Buffer.concat(chunks, totalLength);
+  // Pre-allocate buffer with exact size to avoid reallocation
+  const buffer = Buffer.alloc(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.length;
+  }
 
   return buffer.toString(base64 ? "base64" : "utf8");
 }


### PR DESCRIPTION
We saw that under high concurrency, Nth request was taking a lot more time than others. This was caused by the composable cache. Prior to this pull-request, cache was consuming all data stream (the response of the page), just to access it and later convert it to a stream (and discard the data cached). This created a lot of GC pressure and caused a lot of unnecessary memory usage.

Subset of https://github.com/opennextjs/opennextjs-aws/pull/1002