### PR TITLE
replace delete with assigning to undefined

### DIFF
--- a/.changeset/rude-dodos-grab.md
+++ b/.changeset/rude-dodos-grab.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Replaces delete usage with assignment operator to undefined to avoid going into slowest mode in objects

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -108,7 +108,8 @@ export async function openNextHandler(
           overwrittenResponseHeaders[key] = value;
         }
         headers[key] = value;
-        delete headers[rawKey];
+        // @ts-expect-error Setting it to undefined is faster than deleting the attribute.
+        headers[rawKey] = undefined;
       }
 
       if (
@@ -238,7 +239,7 @@ async function processRequest(
   // @ts-ignore
   // Next.js doesn't parse body if the property exists
   // https://github.com/dougmoscrop/serverless-http/issues/227
-  delete req.body;
+  req.body = undefined;
 
   // Here we try to apply as much request metadata as possible
   // We apply every metadata from `resolve-routes` https://github.com/vercel/next.js/blob/916f105b97211de50f8580f0b39c9e7c60de4886/packages/next/src/server/lib/router-utils/resolve-routes.ts

--- a/packages/open-next/src/core/routingHandler.ts
+++ b/packages/open-next/src/core/routingHandler.ts
@@ -93,7 +93,8 @@ export default async function routingHandler(
         key.startsWith(INTERNAL_HEADER_PREFIX) ||
         key.startsWith(MIDDLEWARE_HEADER_PREFIX)
       ) {
-        delete event.headers[key];
+        // @ts-expect-error Assigning undefined is faster than deleting the attribute.
+        event.headers[key] = undefined;
       }
     }
 

--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -128,7 +128,7 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
     if (key === SET_COOKIE_HEADER) {
       this._cookies = [];
     } else {
-      delete this.headers[key];
+      this.headers[key] = undefined;
     }
     return this;
   }
@@ -187,10 +187,6 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
     this.headers[SET_COOKIE_HEADER] = this._cookies;
 
     const parsedHeaders = parseHeaders(this.headers);
-
-    // We need to remove the set-cookie header from the parsed headers because
-    // it does not handle multiple set-cookie headers properly
-    delete parsedHeaders[SET_COOKIE_HEADER];
 
     if (this.streamCreator) {
       this.responseStream = this.streamCreator?.writeHeaders({

--- a/packages/open-next/src/http/util.ts
+++ b/packages/open-next/src/http/util.ts
@@ -14,6 +14,12 @@ export const parseHeaders = (
       continue;
     }
     const keyLower = key.toLowerCase();
+    if (keyLower === "set-cookie") {
+      // We need to remove the set-cookie header from the parsed headers because
+      // it does not handle multiple set-cookie headers properly
+      continue;
+    }
+
     /**
      * Next can return an Array for the Location header when you return null from a get in the cacheHandler on a page that has a redirect()
      * We dont want to merge that into a comma-separated string
@@ -22,7 +28,7 @@ export const parseHeaders = (
      * See: https://github.com/opennextjs/opennextjs-cloudflare/issues/875#issuecomment-3258248276
      * and https://github.com/opennextjs/opennextjs-aws/pull/977#issuecomment-3261763114
      */
-    if (keyLower === "location" && Array.isArray(value)) {
+    if (Array.isArray(value) && keyLower === "location") {
       if (value[0] === value[1]) {
         result[keyLower] = value[0];
       } else {


### PR DESCRIPTION
Replacing `delete X.y` with `X.y = undefined` avoids killing any optimizations done by V8 to access the properties of an object faster.

Subset of https://github.com/opennextjs/opennextjs-aws/pull/1002