### PR TITLE
avoid creating unnecessary headers instance

### DIFF
--- a/.changeset/red-kiwis-press.md
+++ b/.changeset/red-kiwis-press.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Avoid creating unnecessary headers instance on every request


### PR DESCRIPTION
Let's make sure that we don't copy all of the headers, just to mutate it.

Part of https://github.com/opennextjs/opennextjs-aws/pull/1002