### PR TITLE
perf(OriginResolver): cache expensive compute

### DIFF
--- a/.changeset/chilly-pens-tease.md
+++ b/.changeset/chilly-pens-tease.md
@@ -2,4 +2,4 @@
 "@opennextjs/aws": patch
 ---
 
-Improve withCloudflare() execution cost by caching internals
+perf(OriginResolver): cache expensive compute


### PR DESCRIPTION
Let's cache certain internals to avoid calling them on every re-render.

Part of https://github.com/opennextjs/opennextjs-aws/pull/1002