### PR TITLE
avoid unnecessary buffer copies on opennext.js response

### DIFF
--- a/.changeset/nasty-houses-relate.md
+++ b/.changeset/nasty-houses-relate.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Cache opennext response body to avoid unnecessary copies


### PR DESCRIPTION
Several optimizations but I think the most impactful one is to avoid having an unnecessary copy everytime getBody() is called.