### PR TITLE
ci: update deployment workflow to use npm trusted publishers

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,6 +17,13 @@ runs:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
 
+    # Ensure npm 11.5.1 or later is installed
+    # See https://docs.npmjs.com/trusted-publishers
+    # Note that pnpm publish runs npm publish
+    - name: Update npm
+      shell: bash
+      run: npm install -g npm@latest
+
     # Install pnpm. https://github.com/pnpm/action-setup
     - uses: pnpm/action-setup@v4
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,8 +14,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - uses: ./.github/actions/lint
             - uses: ./.github/actions/setup
+            - uses: ./.github/actions/lint
             - uses: ./.github/actions/test
             - uses: ./.github/actions/local/build
             - uses: ./.github/actions/local/e2e

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           node-version: 22
 
-
       - name: Build package
         run: pnpm -F @opennextjs/aws build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   release:
     name: Release
@@ -19,6 +23,11 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
+        with:
+          # Ensure npm 11.5.1 or later is installed
+          # See https://docs.npmjs.com/trusted-publishers
+          node-version: 24
+
       - uses: ./.github/actions/lint
 
       - name: Create Release Pull Request or Publish to npm
@@ -31,7 +40,6 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: View outputs
         run: echo ${{join(steps.changesets.outputs.*, ' ')}}


### PR DESCRIPTION
Mirroring what @petebacondarwin did for the cloudflare adapter at https://github.com/opennextjs/opennextjs-cloudflare/pull/950