### PR TITLE
Replace styled logger with warn from adapters/logger

### DIFF
--- a/packages/open-next/src/http/util.ts
+++ b/packages/open-next/src/http/util.ts
@@ -1,5 +1,5 @@
 import type http from "node:http";
-import logger from "../logger";
+import { warn } from "../adapters/logger";
 
 export const parseHeaders = (
   headers?: http.OutgoingHttpHeader[] | http.OutgoingHttpHeaders,
@@ -26,7 +26,7 @@ export const parseHeaders = (
       if (value.length === 1 || value[0] === value[1]) {
         result[keyLower] = value[0];
       } else {
-        logger.warn(
+        warn(
           "Multiple different values for Location header found. Using the last one",
         );
         result[keyLower] = value[value.length - 1];


### PR DESCRIPTION
This saves bringing in the `chalk` dependency and saves 18kb in a bundled OpenNext Cloudflare script.