### PR TITLE
fix(cache): add null check for globalThis.openNextConfig

### DIFF
--- a/.changeset/fix-opennextconfig-null-check.md
+++ b/.changeset/fix-opennextconfig-null-check.md
@@ -1,0 +1,10 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: add null check for globalThis.openNextConfig in cache handler
+
+Adds optional chaining when accessing globalThis.openNextConfig to prevent
+TypeError during Next.js 16 build phase when using the Adapters API. The cache
+handler can be instantiated during SSG/prerendering before openNextConfig is
+initialized by the runtime handlers.

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -45,7 +45,7 @@ export default class Cache {
           kind?: "FETCH";
         },
   ) {
-    if (globalThis.openNextConfig.dangerous?.disableIncrementalCache) {
+    if (globalThis.openNextConfig?.dangerous?.disableIncrementalCache) {
       return null;
     }
 
@@ -204,7 +204,7 @@ export default class Cache {
     data?: IncrementalCacheValue,
     ctx?: IncrementalCacheContext,
   ): Promise<void> {
-    if (globalThis.openNextConfig.dangerous?.disableIncrementalCache) {
+    if (globalThis.openNextConfig?.dangerous?.disableIncrementalCache) {
       return;
     }
     // This one might not even be necessary anymore
@@ -322,7 +322,7 @@ export default class Cache {
   }
 
   public async revalidateTag(tags: string | string[]) {
-    const config = globalThis.openNextConfig.dangerous;
+    const config = globalThis.openNextConfig?.dangerous;
     if (config?.disableTagCache || config?.disableIncrementalCache) {
       return;
     }
@@ -430,7 +430,7 @@ export default class Cache {
     ctx?: IncrementalCacheContext,
   ) {
     if (
-      globalThis.openNextConfig.dangerous?.disableTagCache ||
+      globalThis.openNextConfig?.dangerous?.disableTagCache ||
       globalThis.tagCache.mode === "nextMode" ||
       // Here it means it's a delete
       !data

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -85,6 +85,34 @@ describe("CacheHandler", () => {
       expect(result).toBeNull();
     });
 
+    describe("undefined openNextConfig", () => {
+      it("Should not throw when globalThis.openNextConfig is undefined", async () => {
+        // @ts-expect-error - Testing undefined config scenario
+        globalThis.openNextConfig = undefined;
+
+        // Should not throw TypeError: Cannot read properties of undefined (reading 'dangerous')
+        const result = await cache.get("key");
+
+        expect(result).not.toBeUndefined();
+      });
+
+      it("Should not throw on set when globalThis.openNextConfig is undefined", async () => {
+        // @ts-expect-error - Testing undefined config scenario
+        globalThis.openNextConfig = undefined;
+
+        await expect(
+          cache.set("key", { kind: "REDIRECT", props: {} }),
+        ).resolves.not.toThrow();
+      });
+
+      it("Should not throw on revalidateTag when globalThis.openNextConfig is undefined", async () => {
+        // @ts-expect-error - Testing undefined config scenario
+        globalThis.openNextConfig = undefined;
+
+        await expect(cache.revalidateTag("tag")).resolves.not.toThrow();
+      });
+    });
+
     describe("disableIncrementalCache", () => {
       beforeEach(() => {
         globalThis.openNextConfig.dangerous.disableIncrementalCache = true;


### PR DESCRIPTION
## What?
Adds null checks for `globalThis.openNextConfig` in the cache handler to prevent TypeError during Next.js 16 build phase.

## Why?
When using the Next.js 16 Adapters API, the cache handler class is instantiated during SSG/prerendering **before** `globalThis.openNextConfig` is initialized by the runtime handlers. This causes:

```
TypeError: Cannot read properties of undefined (reading 'dangerous')
```

## How?
Changed all occurrences of:
```typescript
if (globalThis.openNextConfig.dangerous?.disableIncrementalCache)
```
To:
```typescript
if (globalThis.openNextConfig?.dangerous?.disableIncrementalCache)
```

Fixed 4 locations in `packages/open-next/src/adapters/cache.ts`:
- `get()` method (line 48)
- `set()` method (line 207)
- `revalidateTag()` method (line 325)
- `updateTagsOnSet()` method (line 433)

## Testing
- Added 3 test cases that verify cache operations work when `globalThis.openNextConfig` is undefined
- All 50 existing cache tests continue to pass

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
This is a blocker for the Adapters API work in opennextjs-cloudflare.