### PR TITLE
Update next peer dependency

### DIFF
--- a/.changeset/eight-bobcats-help.md
+++ b/.changeset/eight-bobcats-help.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Update next peer dependency

--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -64,7 +64,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "next": "< 14.2 || ^14.2 || 14.3.0-canary.0 - 14.3.0-canary.76 || ~15.0.5 || ~15.1.9 || ~15.3.6 || ~15.4.8 || ~15.5.7 || ^16.0.7"
+    "next": "< 14.2 || ^14.2 || 14.3.0-canary.0 - 14.3.0-canary.76 || ~15.0.5 || ~15.1.9 || ~15.2.6 || ~15.3.6 || ~15.4.8 || ~15.5.7 || ^16.0.7"
   },
   "bugs": {
     "url": "https://github.com/opennextjs/opennextjs-aws/issues"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,11 +10,11 @@ catalogs:
       specifier: 20.17.6
       version: 20.17.6
     '@types/react':
-      specifier: 19.0.0
-      version: 19.0.0
+      specifier: 19.0.1
+      version: 19.0.1
     '@types/react-dom':
-      specifier: 19.0.0
-      version: 19.0.0
+      specifier: 19.0.1
+      version: 19.0.1
     autoprefixer:
       specifier: 10.4.15
       version: 10.4.15
@@ -28,11 +28,11 @@ catalogs:
       specifier: 8.4.27
       version: 8.4.27
     react:
-      specifier: 19.0.0
-      version: 19.0.0
+      specifier: 19.0.1
+      version: 19.0.1
     react-dom:
-      specifier: 19.0.0
-      version: 19.0.0
+      specifier: 19.0.1
+      version: 19.0.1
     tailwindcss:
       specifier: 3.3.3
       version: 3.3.3
@@ -73,13 +73,13 @@ importers:
         version: 2.1.1
       next:
         specifier: 'catalog:'
-        version: 16.0.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 16.0.7(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
       react:
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       react-dom:
         specifier: 'catalog:'
-        version: 19.0.0(react@19.0.0)
+        version: 19.0.1(react@19.0.1)
     devDependencies:
       '@types/express-http-proxy':
         specifier: 1.6.7
@@ -89,10 +89,10 @@ importers:
         version: 20.17.6
       '@types/react':
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       '@types/react-dom':
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       autoprefixer:
         specifier: 'catalog:'
         version: 10.4.15(postcss@8.4.27)
@@ -116,13 +116,13 @@ importers:
         version: link:../shared
       next:
         specifier: 'catalog:'
-        version: 16.0.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 16.0.7(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
       react:
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       react-dom:
         specifier: 'catalog:'
-        version: 19.0.0(react@19.0.0)
+        version: 19.0.1(react@19.0.1)
     devDependencies:
       '@opennextjs/aws':
         specifier: workspace:*
@@ -132,10 +132,10 @@ importers:
         version: 20.17.6
       '@types/react':
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       '@types/react-dom':
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       autoprefixer:
         specifier: 'catalog:'
         version: 10.4.15(postcss@8.4.27)
@@ -153,13 +153,13 @@ importers:
     dependencies:
       next:
         specifier: 15.4.0-canary.14
-        version: 15.4.0-canary.14(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.4.0-canary.14(@playwright/test@1.49.1)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
       react:
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       react-dom:
         specifier: 'catalog:'
-        version: 19.0.0(react@19.0.0)
+        version: 19.0.1(react@19.0.1)
     devDependencies:
       '@opennextjs/aws':
         specifier: workspace:*
@@ -169,10 +169,10 @@ importers:
         version: 20.17.6
       '@types/react':
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       '@types/react-dom':
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -184,23 +184,23 @@ importers:
         version: link:../shared
       next:
         specifier: 'catalog:'
-        version: 16.0.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 16.0.7(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
       react:
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       react-dom:
         specifier: 'catalog:'
-        version: 19.0.0(react@19.0.0)
+        version: 19.0.1(react@19.0.1)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
         version: 20.17.6
       '@types/react':
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       '@types/react-dom':
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       autoprefixer:
         specifier: 'catalog:'
         version: 10.4.15(postcss@8.4.27)
@@ -218,17 +218,17 @@ importers:
     dependencies:
       react:
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       react-dom:
         specifier: 'catalog:'
-        version: 19.0.0(react@19.0.0)
+        version: 19.0.1(react@19.0.1)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
       '@types/react-dom':
         specifier: 'catalog:'
-        version: 19.0.0
+        version: 19.0.1
 
   examples/sst:
     devDependencies:
@@ -240,7 +240,7 @@ importers:
         version: 10.3.0
       sst:
         specifier: ^2.43.6
-        version: 2.44.0(@aws-sdk/client-sso-oidc@3.678.0(@aws-sdk/client-sts@3.678.0(aws-crt@1.23.0))(aws-crt@1.23.0))(@types/react@19.0.0)(aws-crt@1.23.0)
+        version: 2.44.0(@aws-sdk/client-sso-oidc@3.678.0(@aws-sdk/client-sts@3.678.0(aws-crt@1.23.0))(aws-crt@1.23.0))(@types/react@19.0.1)(aws-crt@1.23.0)
 
   packages/open-next:
     dependencies:
@@ -287,8 +287,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       next:
-        specifier: < 14.2 || ^14.2 || 14.3.0-canary.0 - 14.3.0-canary.76 || ~15.0.5 || ~15.1.9 || ~15.3.6 || ~15.4.8 || ~15.5.7 || ^16.0.7
-        version: 16.0.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: < 14.2 || ^14.2 || 14.3.0-canary.0 - 14.3.0-canary.76 || ~15.0.5 || ~15.1.9 || ~15.2.6 || ~15.3.6 || ~15.4.8 || ~15.5.7 || ^16.0.7
+        version: 16.0.7(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
       path-to-regexp:
         specifier: ^6.3.0
         version: 6.3.0
@@ -2798,11 +2798,11 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
-  '@types/react-dom@19.0.0':
-    resolution: {integrity: sha512-1KfiQKsH1o00p9m5ag12axHQSb3FOU9H20UTrujVSkNhuCrRHiQWFqgEnTNK5ZNfnzZv8UWrnXVqCmCF9fgY3w==}
+  '@types/react-dom@19.0.1':
+    resolution: {integrity: sha512-hljHij7MpWPKF6u5vojuyfV0YA4YURsQG7KT6SzV0Zs2BXAtgdTxG6A229Ub/xiWV4w/7JL8fi6aAyjshH4meA==}
 
-  '@types/react@19.0.0':
-    resolution: {integrity: sha512-MY3oPudxvMYyesqs/kW1Bh8y9VqSmf+tzqw3ae8a9DZW68pUe3zAdHeI1jc6iAysuRdACnVknHP8AhwD4/dxtg==}
+  '@types/react@19.0.1':
+    resolution: {integrity: sha512-YW6614BDhqbpR5KtUYzTA+zlA7nayzJRA9ljz9CQoxthR0sDisYZLuvSMsil36t4EH/uAt8T52Xb4sVw17G+SQ==}
 
   '@types/readable-stream@4.0.16':
     resolution: {integrity: sha512-Fvp+8OcU8PyV90KTk5tR/rI8OjD3MP5NUow5rjOsZo+9zxf4p4soJtK9j4V6yeG30TH6rZxqRaP4JLa8lNNTNQ==}
@@ -4997,10 +4997,10 @@ packages:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
-  react-dom@19.0.0:
-    resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
+  react-dom@19.0.1:
+    resolution: {integrity: sha512-3TJg51HSbJiLVYCS6vWwWsyqoS36aGEOCmtLLHxROlSZZ5Bk10xpxHFbrCu4DdqgR85DDc9Vucxqhai3g2xjtA==}
     peerDependencies:
-      react: ^19.0.0
+      react: ^19.0.1
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -5015,8 +5015,8 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.0.0:
-    resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
+  react@19.0.1:
+    resolution: {integrity: sha512-nVRaZCuEyvu69sWrkdwjP6QY57C+lY+uMNNMyWUFJb9Z/JlaBOQus7mSMfGYsblv7R691u6SSJA/dX9IRnyyLQ==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -9554,11 +9554,11 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
-  '@types/react-dom@19.0.0':
+  '@types/react-dom@19.0.1':
     dependencies:
-      '@types/react': 19.0.0
+      '@types/react': 19.0.1
 
-  '@types/react@19.0.0':
+  '@types/react@19.0.1':
     dependencies:
       csstype: 3.1.3
 
@@ -11027,13 +11027,13 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ink-spinner@5.0.0(ink@4.4.1(@types/react@19.0.0)(react@18.3.1))(react@18.3.1):
+  ink-spinner@5.0.0(ink@4.4.1(@types/react@19.0.1)(react@18.3.1))(react@18.3.1):
     dependencies:
       cli-spinners: 2.9.2
-      ink: 4.4.1(@types/react@19.0.0)(react@18.3.1)
+      ink: 4.4.1(@types/react@19.0.1)(react@18.3.1)
       react: 18.3.1
 
-  ink@4.4.1(@types/react@19.0.0)(react@18.3.1):
+  ink@4.4.1(@types/react@19.0.1)(react@18.3.1):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.1.3
       ansi-escapes: 6.2.1
@@ -11062,7 +11062,7 @@ snapshots:
       ws: 8.18.0
       yoga-wasm-web: 0.3.3
     optionalDependencies:
-      '@types/react': 19.0.0
+      '@types/react': 19.0.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11561,16 +11561,16 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@15.4.0-canary.14(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.4.0-canary.14(@playwright/test@1.49.1)(react-dom@19.0.1(react@19.0.1))(react@19.0.1):
     dependencies:
       '@next/env': 15.4.0-canary.14
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001669
       postcss: 8.4.31
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      styled-jsx: 5.1.6(react@19.0.0)
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+      styled-jsx: 5.1.6(react@19.0.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.4.0-canary.14
       '@next/swc-darwin-x64': 15.4.0-canary.14
@@ -11586,15 +11586,15 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.0.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@16.0.7(react-dom@19.0.1(react@19.0.1))(react@19.0.1):
     dependencies:
       '@next/env': 16.0.7
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001669
       postcss: 8.4.31
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      styled-jsx: 5.1.6(react@19.0.0)
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+      styled-jsx: 5.1.6(react@19.0.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.0.7
       '@next/swc-darwin-x64': 16.0.7
@@ -11936,9 +11936,9 @@ snapshots:
       iconv-lite: 0.6.3
       unpipe: 1.0.0
 
-  react-dom@19.0.0(react@19.0.0):
+  react-dom@19.0.1(react@19.0.1):
     dependencies:
-      react: 19.0.0
+      react: 19.0.1
       scheduler: 0.25.0
 
   react-is@18.3.1: {}
@@ -11953,7 +11953,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  react@19.0.0: {}
+  react@19.0.1: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -12363,7 +12363,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  sst@2.44.0(@aws-sdk/client-sso-oidc@3.678.0(@aws-sdk/client-sts@3.678.0(aws-crt@1.23.0))(aws-crt@1.23.0))(@types/react@19.0.0)(aws-crt@1.23.0):
+  sst@2.44.0(@aws-sdk/client-sso-oidc@3.678.0(@aws-sdk/client-sts@3.678.0(aws-crt@1.23.0))(aws-crt@1.23.0))(@types/react@19.0.1)(aws-crt@1.23.0):
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.161.1-alpha.0(aws-cdk-lib@2.161.1(constructs@10.3.0))(constructs@10.3.0)
       '@aws-cdk/cloud-assembly-schema': 38.0.1
@@ -12415,8 +12415,8 @@ snapshots:
       graphql: 16.9.0
       graphql-yoga: 3.9.1(graphql@16.9.0)
       immer: 9.0.21
-      ink: 4.4.1(@types/react@19.0.0)(react@18.3.1)
-      ink-spinner: 5.0.0(ink@4.4.1(@types/react@19.0.0)(react@18.3.1))(react@18.3.1)
+      ink: 4.4.1(@types/react@19.0.1)(react@18.3.1)
+      ink-spinner: 5.0.0(ink@4.4.1(@types/react@19.0.1)(react@18.3.1))(react@18.3.1)
       kysely: 0.25.0
       kysely-codegen: 0.10.1(kysely@0.25.0)
       kysely-data-api: 0.2.1(@aws-sdk/client-rds-data@3.678.0(aws-crt@1.23.0))(kysely@0.25.0)
@@ -12516,10 +12516,10 @@ snapshots:
 
   strnum@1.0.5: {}
 
-  styled-jsx@5.1.6(react@19.0.0):
+  styled-jsx@5.1.6(react@19.0.1):
     dependencies:
       client-only: 0.0.1
-      react: 19.0.0
+      react: 19.0.1
 
   sucrase@3.35.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,11 +4,11 @@ packages:
 
 catalog:
   next: 16.0.7
-  react: 19.0.0
-  react-dom: 19.0.0
+  react: 19.0.1
+  react-dom: 19.0.1
   "@types/node": 20.17.6
-  "@types/react": 19.0.0
-  "@types/react-dom": 19.0.0
+  "@types/react": 19.0.1
+  "@types/react-dom": 19.0.1
   autoprefixer: 10.4.15
   postcss: 8.4.27
   tailwindcss: 3.3.3


### PR DESCRIPTION
15.2 was originally missing from https://vercel.com/changelog/cve-2025-55182
...and I forgot to bump react
