### PR TITLE
fix a typo in the e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           version: 9
 
-      - name: Set up NodeJS v18
+      - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
           cache: pnpm # cache pnpm store


### PR DESCRIPTION
"v18" is no more valid, removing this altogether as the version can be found in the details

<img width="372" height="160" alt="image" src="https://github.com/user-attachments/assets/f83c1440-502b-47a0-aef1-e6cb4daa3a4c" />
