### PR TITLE
fix: add lambda:InvokeFunction permission for function URLs

### DIFF
--- a/examples/sst/stacks/OpenNextReferenceImplementation.ts
+++ b/examples/sst/stacks/OpenNextReferenceImplementation.ts
@@ -24,7 +24,7 @@ import {
   TableV2 as Table,
 } from "aws-cdk-lib/aws-dynamodb";
 import type { IGrantable } from "aws-cdk-lib/aws-iam";
-import { Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { AnyPrincipal, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import {
   Architecture,
   Function as CdkFunction,
@@ -343,6 +343,17 @@ export class OpenNextCdkReferenceImplementation extends Construct {
         ? InvokeMode.RESPONSE_STREAM
         : InvokeMode.BUFFERED,
     });
+
+    fn.addPermission(`${key}FunctionUrlPermission`, {
+      principal: new AnyPrincipal(),
+      action: "lambda:InvokeFunctionUrl",
+      functionUrlAuthType: FunctionUrlAuthType.NONE,
+    });
+    fn.addPermission(`${key}FunctionInvokePermission`, {
+      principal: new AnyPrincipal(),
+      action: "lambda:InvokeFunction",
+    });
+
     this.grantPermissions(fn);
     return new HttpOrigin(Fn.parseDomainName(fnUrl.url));
   }


### PR DESCRIPTION
## Summary

Hello! While running the SST example, I encountered a 403 Forbidden error when accessing the deployed CloudFront URL.

After investigation, I found that starting **October 2025**, AWS Lambda function URLs require **both** `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` permissions in the resource-based policy.

The current implementation only grants `lambda:InvokeFunctionUrl`, which causes `AccessDeniedException` when invoking the function URL.

## Changes

- Added `lambda:InvokeFunction` permission alongside the existing `lambda:InvokeFunctionUrl` permission
- Added `AnyPrincipal` to the existing IAM imports for cleaner code

## Reference

- [AWS Documentation: Control access to Lambda function URLs](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html)

> Starting in October 2025, new function URLs will require both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` permissions.

## Test

- Deployed the example using `npx sst deploy`
- Verified the CloudFront URL returns 200 OK instead of 403 Forbidden