### PR TITLE
Next 16 takes an array of tags in ComposableCacheHandler#getExpiration

### DIFF
--- a/.changeset/young-parents-take.md
+++ b/.changeset/young-parents-take.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Next 16 takes an array of tags in ComposableCacheHandler#getExpiration

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -99,14 +99,25 @@ export default {
     // We don't do anything for now, do we want to do something here ???
     return;
   },
-  async getExpiration(...tags: string[]) {
+
+  /**
+   * The signature has changed in Next.js 16
+   * - Before Next.js 16, the method takes `...tags: string[]`
+   * - From Next.js 16, the method takes `tags: string[]`
+   */
+  async getExpiration(...tags: string[] | string[][]) {
     if (globalThis.tagCache.mode === "nextMode") {
-      return globalThis.tagCache.getLastRevalidated(tags);
+      // Use `.flat()` to accommodate both signatures
+      return globalThis.tagCache.getLastRevalidated(tags.flat());
     }
     // We always return 0 here, original tag cache are handled directly in the get part
     // TODO: We need to test this more, i'm not entirely sure that this is working as expected
     return 0;
   },
+
+  /**
+   * This method is only used before Next.js 16
+   */
   async expireTags(...tags: string[]) {
     if (globalThis.tagCache.mode === "nextMode") {
       return writeTags(tags);

--- a/packages/open-next/src/types/cache.ts
+++ b/packages/open-next/src/types/cache.ts
@@ -162,7 +162,13 @@ export interface ComposableCacheHandler {
     pendingEntry: Promise<ComposableCacheEntry>,
   ): Promise<void>;
   refreshTags(): Promise<void>;
-  getExpiration(...tags: string[]): Promise<number>;
+  /**
+   * Next 16 takes an array of tags instead of variadic arguments
+   */
+  getExpiration(...tags: string[] | string[][]): Promise<number>;
+  /**
+   * Removed from Next.js 16
+   */
   expireTags(...tags: string[]): Promise<void>;
   /**
    * This function is only there for older versions and do nothing

--- a/packages/tests-unit/tests/adapters/composable-cache.test.ts
+++ b/packages/tests-unit/tests/adapters/composable-cache.test.ts
@@ -326,7 +326,7 @@ describe("Composable cache handler", () => {
     });
   });
 
-  describe("getExpiration", () => {
+  describe("getExpiration (Next 15)", () => {
     it("should return last revalidated time in nextMode", async () => {
       tagCache.mode = "nextMode";
       tagCache.getLastRevalidated.mockResolvedValueOnce(123456);
@@ -352,6 +352,37 @@ describe("Composable cache handler", () => {
       tagCache.mode = undefined;
 
       const result = await ComposableCache.getExpiration("tag1", "tag2");
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("getExpiration (Next 16)", () => {
+    it("should return last revalidated time in nextMode", async () => {
+      tagCache.mode = "nextMode";
+      tagCache.getLastRevalidated.mockResolvedValueOnce(123456);
+
+      const result = await ComposableCache.getExpiration(["tag1", "tag2"]);
+
+      expect(tagCache.getLastRevalidated).toHaveBeenCalledWith([
+        "tag1",
+        "tag2",
+      ]);
+      expect(result).toBe(123456);
+    });
+
+    it("should return 0 in original mode", async () => {
+      tagCache.mode = "original";
+
+      const result = await ComposableCache.getExpiration(["tag1", "tag2"]);
+
+      expect(result).toBe(0);
+    });
+
+    it("should return 0 when mode is undefined", async () => {
+      tagCache.mode = undefined;
+
+      const result = await ComposableCache.getExpiration(["tag1", "tag2"]);
 
       expect(result).toBe(0);
     });


### PR DESCRIPTION
`...tags` in 15
https://github.com/vercel/next.js/blob/c5de33e93ccccaf3bee60cf50603e2152f9886e1/packages/next/src/server/lib/cache-handlers/types.ts#L109

`tags` in 16
https://github.com/vercel/next.js/blob/92f72373644fae3a2822386480e9e2b6fcf3df68/packages/next/src/server/lib/cache-handlers/types.ts#L73

Validated with the cloudflare adapter