### PR TITLE
fix: find the correct output for the standalone output

### DIFF
--- a/.changeset/forty-pets-sell.md
+++ b/.changeset/forty-pets-sell.md
@@ -1,0 +1,19 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: find the correct output for the standalone output
+
+Open Next assumes that standalone is based on the root of a monorepo, while Next uses `outputFileTracingRoot` to determine the root and path of .next/standalone. For example, take a monorepo like this:
+
+```
+apps/
+  marketing/
+    landing-pages/
+      // next app
+
+```
+
+If you set `outputFileTracingRoot` in landing pages to ../, then the standalone output would be `.next/standalone/landing-pages`, but open-next will assume that the output is `.next/standalone/apps/marketing/landing-pages`.
+
+This PR fixes that by actually looking at the standalone output and determining its structure by looking for `.next/standalone/dir/.next` and returning `.next/standalone/dir`.


### PR DESCRIPTION
There is a mismatch between next's output, and open-next's assumption.

Open Next assumes that standalone is based on the root of a monorepo, while Next uses `outputFileTracingRoot` to determine the root and path of .next/standalone. For example, take a monorepo like this:

```
apps/
  marketing/
    landing-pages/
      // next app

```

If you set `outputFileTracingRoot` in landing pages to ../, then the standalone output would be `.next/standalone/landing-pages`, but open-next will assume that the output is `.next/standalone/apps/marketing/landing-pages`.

This PR fixes that by actually looking at the standalone output and determining its structure by looking for `.next/standalone/dir/.next` and returning `.next/standalone/dir`.

I tried using the `outputFileTracingRoot` directly, but this proved to be more unstable because it was still tied to the relative path of the mono-repo, so in some cases it would generate wrong paths.

I also tried to set the `outputFileTracingRoot` in my next config to line up with what open-next assumed, and while the build was working, it bloated the assets to deploy (this mono-repo has grown a lot), which made it impossible to deploy.