### PR TITLE
refactor: lazily compile Next config

### DIFF
--- a/packages/open-next/src/build/patch/patches/patchNextConfig.ts
+++ b/packages/open-next/src/build/patch/patches/patchNextConfig.ts
@@ -2,8 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { build } from "esbuild";
 import { inlineRequireResolvePlugin } from "../../../plugins/inline-require-resolve.js";
+import type { BuildOptions } from "../../helper.js";
 import type { CodePatcher } from "../codePatcher.js";
 
+/**
+ * Next 16.1+ removes `skipTrailingSlashRedirect` from the config in `required-server-files.json`.
+ * This patch adds it back in by compiling and importing the user's `next.config.js` file.
+ */
 export const patchNextConfig: CodePatcher = {
   name: "patch-next-config",
   patches: [
@@ -11,55 +16,62 @@ export const patchNextConfig: CodePatcher = {
       pathFilter: /required\-server\-files\.json$/,
       versions: ">=16.1.0",
       patchCode: async ({ code, buildOptions }) => {
-        // Find the next.config file with any supported extension
-        const tsExtensions = [".ts", ".mts", ".cts"];
-        const possibleExtensions = [...tsExtensions, ".mjs", ".js", ".cjs"];
-        let configPath: string | undefined;
-        let configExtension: string | undefined;
+        const manifest = JSON.parse(code);
+        if (manifest.config.skipTrailingSlashRedirect === undefined) {
+          const { skipTrailingSlashRedirect } =
+            await importNextConfigFromSource(buildOptions);
 
-        for (const ext of possibleExtensions) {
-          const testPath = path.join(buildOptions.appPath, `next.config${ext}`);
-          if (fs.existsSync(testPath)) {
-            configPath = testPath;
-            configExtension = ext;
-            break;
-          }
+          manifest.config.skipTrailingSlashRedirect =
+            skipTrailingSlashRedirect ?? false;
         }
-
-        if (!configPath || !configExtension) {
-          throw new Error("Could not find next.config file");
-        }
-
-        let configToImport: string;
-
-        // Only compile if the extension is a TypeScript extension
-        if (tsExtensions.includes(configExtension)) {
-          await build({
-            entryPoints: [configPath],
-            outfile: path.join(buildOptions.tempBuildDir, "next.config.mjs"),
-            bundle: true,
-            format: "esm",
-            platform: "node",
-            plugins: [inlineRequireResolvePlugin],
-          });
-          configToImport = path.join(
-            buildOptions.tempBuildDir,
-            "next.config.mjs",
-          );
-        } else {
-          // For .js, .mjs, .cjs, use the file directly
-          configToImport = configPath;
-        }
-
-        // In next 16.1+ we need to add `skipTrailingSlashRedirect` manually because next removes it from the config
-        const originalConfig = (await import(configToImport)).default;
-        const config = JSON.parse(code);
-        if (config.config.skipTrailingSlashRedirect === undefined) {
-          config.config.skipTrailingSlashRedirect =
-            originalConfig.skipTrailingSlashRedirect ?? false;
-        }
-        return JSON.stringify(config, null, 2);
+        return JSON.stringify(manifest, null, 2);
       },
     },
   ],
 };
+
+/**
+ * Compile and import the user's `next.config` file
+ *
+ * @returns
+ */
+async function importNextConfigFromSource(buildOptions: BuildOptions) {
+  // Find the `next.config file with any supported extension
+  const tsExtensions = [".ts", ".mts", ".cts"];
+  const possibleExtensions = [...tsExtensions, ".mjs", ".js", ".cjs"];
+  let configPath: string | undefined;
+  let configExtension: string | undefined;
+
+  for (const ext of possibleExtensions) {
+    const testPath = path.join(buildOptions.appPath, `next.config${ext}`);
+    if (fs.existsSync(testPath)) {
+      configPath = testPath;
+      configExtension = ext;
+      break;
+    }
+  }
+
+  if (!configPath || !configExtension) {
+    throw new Error("Could not find next.config file");
+  }
+
+  let configToImport: string;
+
+  // Only compile if the extension is a TypeScript extension
+  if (tsExtensions.includes(configExtension)) {
+    await build({
+      entryPoints: [configPath],
+      outfile: path.join(buildOptions.tempBuildDir, "next.config.mjs"),
+      bundle: true,
+      format: "esm",
+      platform: "node",
+      plugins: [inlineRequireResolvePlugin],
+    });
+    configToImport = path.join(buildOptions.tempBuildDir, "next.config.mjs");
+  } else {
+    // For .js, .mjs, .cjs, use the file directly
+    configToImport = configPath;
+  }
+
+  return (await import(configToImport)).default;
+}


### PR DESCRIPTION
The current code pro-actively compiles the Next Config.

The PR only compiles it when needed - that is when `skipTrailingSlashRedirect` is not present in the manifest.

Note that the behavior should be the same as of today because the patch is only executed for Next >= 16.1 where `skipTrailingSlashRedirect` is always missing. But hopefully it can be added back at some point.

/cc @ijjk

