### PR TITLE
fix the detection of the runtime (webpack vs turbopack)

### DIFF
--- a/.changeset/yellow-icons-shop.md
+++ b/.changeset/yellow-icons-shop.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix the detection of the runtime (webpack vs turbopack)

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -461,13 +461,16 @@ export function getPackagePath(options: BuildOptions) {
 export function getBundlerRuntime(
   options: BuildOptions,
 ): "webpack" | "turbopack" {
-  const dotNextPath = path.join(options.appPath, ".next");
-  if (fs.existsSync(path.join(dotNextPath, "server/webpack-runtime.js"))) {
+  const dotNextServerPath = path.join(options.appPath, ".next/server");
+  if (fs.existsSync(path.join(dotNextServerPath, "webpack-runtime.js"))) {
     return "webpack";
   }
   if (
     fs.existsSync(
-      path.join(dotNextPath, "server/chunks/[turbopack]_runtime.js"),
+      path.join(dotNextServerPath, "chunks/[turbopack]_runtime.js"),
+    ) ||
+    fs.existsSync(
+      path.join(dotNextServerPath, "chunks/ssr/[turbopack]_runtime.js"),
     )
   ) {
     return "turbopack";


### PR DESCRIPTION
The path to the runtime is different for SSR apps.

Validated that:
- it works for a SSR app
- webpack runtime is still at the same location for SSR apps