### PR TITLE
Check for supported Next version

### DIFF
--- a/.changeset/small-shrimps-roll.md
+++ b/.changeset/small-shrimps-roll.md
@@ -1,0 +1,8 @@
+---
+"@opennextjs/aws": patch
+---
+
+Check for supported Next version
+
+The build will now error for unsupported Next version which may contain unpatched security vulnerabilities.
+You can bypass the check using the `--dangerously-use-unsupported-next-version` flag.

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -27,6 +27,7 @@ export type PublicFiles = {
 export async function build(
   openNextConfigPath?: string,
   nodeExternals?: string,
+  allowUnsupportedNextVersion?: boolean,
 ) {
   showWarningOnWindows();
 
@@ -50,6 +51,12 @@ export async function build(
   buildHelper.checkRunningInsideNextjsApp(options);
   buildHelper.printNextjsVersion(options);
   buildHelper.printOpenNextVersion(options);
+
+  // Check Next.js version support
+  buildHelper.checkNextVersionSupport(
+    options.nextVersion,
+    allowUnsupportedNextVersion ?? false,
+  );
 
   // Build Next.js app
   printHeader("Building Next.js app");

--- a/packages/open-next/src/index.ts
+++ b/packages/open-next/src/index.ts
@@ -8,7 +8,11 @@ if (command !== "build") printHelp();
 const args = parseArgs();
 if (Object.keys(args).includes("--help")) printHelp();
 
-await build(args["--config-path"], args["--node-externals"]);
+await build(
+  args["--config-path"],
+  args["--node-externals"],
+  args["--dangerously-use-unsupported-next-version"] !== undefined,
+);
 
 function parseArgs() {
   return process.argv.slice(2).reduce(
@@ -30,19 +34,15 @@ function parseArgs() {
 }
 
 function printHelp() {
-  console.log("Unknown command");
-  console.log("");
-  console.log("Usage:");
-  console.log("  npx open-next build");
-  console.log("You can use a custom config path here");
-  console.log(
-    "  npx open-next build --config-path ./path/to/open-next.config.ts",
-  );
-  console.log(
-    "You can configure externals for the esbuild compilation of the open-next.config.ts file",
-  );
-  console.log("  npx open-next build --node-externals aws-sdk,sharp,sqlite3");
-  console.log("");
+  console.log(`Unknown command
+
+Usage:
+  npx open-next build
+You can use a custom config path here
+  npx open-next build --config-path ./path/to/open-next.config.ts
+You can configure externals for the esbuild compilation of the open-next.config.ts file
+  npx open-next build --node-externals aws-sdk,sharp,sqlite3
+`);
 
   process.exit(1);
 }

--- a/packages/tests-unit/tests/build/helper.test.ts
+++ b/packages/tests-unit/tests/build/helper.test.ts
@@ -1,4 +1,8 @@
-import { compareSemver } from "@opennextjs/aws/build/helper.js";
+import {
+  compareSemver,
+  isNextVersionSupported,
+} from "@opennextjs/aws/build/helper.js";
+import { afterEach, vi } from "vitest";
 
 // We don't need to test canary versions, they are stripped out
 describe("compareSemver", () => {
@@ -63,5 +67,58 @@ describe("compareSemver", () => {
   test("throw if the operator is not supported", () => {
     expect(() => compareSemver("14.0.0", "==" as any, "14.0.0")).toThrow();
     expect(() => compareSemver("14.0.0", "!=" as any, "14.0.0")).toThrow();
+  });
+});
+
+describe("isNextVersionSupported", () => {
+  const mockDate = (dateStr: string) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(dateStr));
+  };
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("returns true for version released less than 2 years ago", () => {
+    mockDate("2026-01-26");
+
+    expect(isNextVersionSupported("16.0.0")).toBe(true);
+    expect(isNextVersionSupported("16.1.5")).toBe(true);
+
+    expect(isNextVersionSupported("15.0.0")).toBe(true);
+    expect(isNextVersionSupported("15.5.9")).toBe(true);
+  });
+
+  test("returns false for version released more than 2 years ago", () => {
+    mockDate("2026-01-26");
+
+    expect(isNextVersionSupported("14.0.0")).toBe(false);
+    expect(isNextVersionSupported("14.2.3")).toBe(false);
+    expect(isNextVersionSupported("13.0.0")).toBe(false);
+    expect(isNextVersionSupported("13.5.6")).toBe(false);
+  });
+
+  test("handles boundary case - exactly 2 years", () => {
+    mockDate("2026-10-21");
+    expect(isNextVersionSupported("15.0.0")).toBe(true);
+
+    mockDate("2026-10-22");
+    expect(isNextVersionSupported("15.0.0")).toBe(false);
+  });
+
+  test("returns false for unknown major versions", () => {
+    mockDate("2026-01-26");
+    expect(isNextVersionSupported("999.0.0")).toBe(false);
+    expect(isNextVersionSupported("0.1.0")).toBe(false);
+    expect(isNextVersionSupported("17.0.0")).toBe(false); // Not released yet
+  });
+
+  test("handles older versions correctly", () => {
+    mockDate("2026-01-26");
+    expect(isNextVersionSupported("12.0.0")).toBe(false);
+    expect(isNextVersionSupported("11.0.0")).toBe(false);
+    expect(isNextVersionSupported("10.0.0")).toBe(false);
+    expect(isNextVersionSupported("9.0.0")).toBe(false);
   });
 });


### PR DESCRIPTION
Note that this will error on unkown Next version.

I think it is a feature for when Next 17 is released (we have to explicitly marked is as supported)

Some of the code was generated by Claude/Opus