### PR TITLE
fix: ensure copied files are writable for patching

### DIFF
--- a/.changeset/fix-readonly-node-modules.md
+++ b/.changeset/fix-readonly-node-modules.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix EACCES errors when building with read-only node_modules
+
+Ensures copied files are writable after copying. This fixes build failures in environments like Bazel where node_modules files are read-only.


### PR DESCRIPTION
copyFileSync preserves source file permissions. When source files are read-only (e.g., in Bazel's node_modules managed by aspect_rules_js), the copied files remain read-only. This causes EACCES errors when codePatcher tries to write patches to these files.

This fix adds a helper function that copies files and ensures they have write permissions, preventing permission denied errors in build environments with read-only source files.

Related to https://github.com/cloudflare/workerd/pull/5993