### PR TITLE
feat(config): add `esbuild.external` option to `DefaultFunctionOptions`

### DIFF
--- a/.changeset/custom-esbuild-externals.md
+++ b/.changeset/custom-esbuild-externals.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": minor
+---
+
+Add `esbuild.external` option to function config for custom esbuild externals

--- a/packages/open-next/src/build/createImageOptimizationBundle.ts
+++ b/packages/open-next/src/build/createImageOptimizationBundle.ts
@@ -66,7 +66,11 @@ export async function createImageOptimizationBundle(
           "image-optimization-adapter.js",
         ),
       ],
-      external: ["sharp", "next"],
+      external: [
+        "sharp",
+        "next",
+        ...(config.imageOptimization?.esbuild?.external ?? []),
+      ],
       outfile: path.join(outputPath, "index.mjs"),
       plugins,
     },
@@ -81,7 +85,11 @@ export async function createImageOptimizationBundle(
   buildHelper.esbuildSync(
     {
       entryPoints: [path.join(outputPath, "index.mjs")],
-      external: ["sharp", "@opentelemetry/api"],
+      external: [
+        "sharp",
+        "@opentelemetry/api",
+        ...(config.imageOptimization?.esbuild?.external ?? []),
+      ],
       allowOverwrite: true,
       outfile: path.join(outputPath, "index.mjs"),
       banner: {

--- a/packages/open-next/src/build/createRevalidationBundle.ts
+++ b/packages/open-next/src/build/createRevalidationBundle.ts
@@ -23,7 +23,12 @@ export async function createRevalidationBundle(
   // Build Lambda code
   await buildHelper.esbuildAsync(
     {
-      external: ["next", "styled-jsx", "react"],
+      external: [
+        "next",
+        "styled-jsx",
+        "react",
+        ...(config.revalidate?.esbuild?.external ?? []),
+      ],
       entryPoints: [
         path.join(options.openNextDistDir, "adapters", "revalidate.js"),
       ],

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -298,7 +298,12 @@ async function generateBundle(
       entryPoints: [
         path.join(options.openNextDistDir, "adapters", "server-adapter.js"),
       ],
-      external: ["next", "./middleware.mjs", "./next-server.runtime.prod.js"],
+      external: [
+        "next",
+        "./middleware.mjs",
+        "./next-server.runtime.prod.js",
+        ...(fnOptions.esbuild?.external ?? []),
+      ],
       outfile: path.join(outputPath, packagePath, `index.${outfileExt}`),
       banner: {
         js: [

--- a/packages/open-next/src/build/createWarmerBundle.ts
+++ b/packages/open-next/src/build/createWarmerBundle.ts
@@ -27,7 +27,7 @@ export async function createWarmerBundle(options: buildHelper.BuildOptions) {
       entryPoints: [
         path.join(options.openNextDistDir, "adapters", "warmer-function.js"),
       ],
-      external: ["next"],
+      external: ["next", ...(config.warmer?.esbuild?.external ?? [])],
       outfile: path.join(outputPath, "index.mjs"),
       plugins: [
         openNextResolvePlugin({

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -338,6 +338,26 @@ export interface DefaultFunctionOptions<
    * @default undefined
    */
   install?: InstallOptions;
+
+  /**
+   * Custom esbuild options for the function bundling.
+   * @default undefined
+   */
+  esbuild?: {
+    /**
+     * Additional packages to exclude from the esbuild bundle.
+     * Useful when a dependency includes native binaries (.node files)
+     * that esbuild cannot handle.
+     * @example
+     * ```ts
+     * esbuild: {
+     *   external: ["@swc/core", "@swc/wasm"]
+     * }
+     * ```
+     * @default []
+     */
+    external?: string[];
+  };
 }
 
 export interface FunctionOptions extends DefaultFunctionOptions {


### PR DESCRIPTION
## Summary

Closes #1115

When a Next.js plugin (e.g. `next-intl`) has a transitive dependency on packages with native `.node` binaries (e.g. `@swc/core`), the server function esbuild step fails with "No loader is configured for .node files".

The esbuild externals are currently hardcoded with no way to add custom entries via config.

This PR adds an `esbuild.external` option to `DefaultFunctionOptions`, allowing users to specify additional esbuild externals through `open-next.config.ts`.

### Changes
- Add `esbuild.external` option to `DefaultFunctionOptions` interface (`packages/open-next/src/types/open-next.ts`)
- Spread user-configured externals into esbuild calls across all bundle creation functions:
  - `createServerBundle.ts` — server function
  - `createImageOptimizationBundle.ts` — image optimization function (both async and sync passes)
  - `createRevalidationBundle.ts` — revalidation function
  - `createWarmerBundle.ts` — warmer function

### Usage

```ts
// open-next.config.ts
const config = {
  default: {
    esbuild: {
      external: ["@swc/core", "@swc/wasm"],
    },
  },
};
export default config;
```

Per-function configuration is also supported:

```ts
const config = {
  default: { /* ... */ },
  functions: {
    api: {
      routes: ["app/api/route"],
      patterns: ["/api/*"],
      esbuild: {
        external: ["@swc/core"],
      },
    },
  },
};
```
