### PR TITLE
fix(build): auto-filter non-Linux platform-specific native binaries

### DIFF
--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -73,7 +73,7 @@ export function isExcluded(srcPath: string): boolean {
   );
 }
 
-const NON_LINUX_PLATFORMS = ["darwin", "win32", "freebsd", "android"];
+const NON_LINUX_PLATFORMS = ["darwin", "win32", "freebsd"];
 
 const platformPattern = NON_LINUX_PLATFORMS.join("|");
 const nonLinuxPlatformRegex = getCrossPlatformPathRegex(
@@ -297,7 +297,11 @@ File ${serverPath} does not exist
       return;
     }
     // Skip non-Linux platform-specific native binaries (e.g. @swc/core-darwin-arm64)
-    if (isNonLinuxPlatformPackage(from)) {
+    // Set OPEN_NEXT_SKIP_PLATFORM_FILTER=true to bypass this check
+    if (
+      !process.env.OPEN_NEXT_SKIP_PLATFORM_FILTER &&
+      isNonLinuxPlatformPackage(from)
+    ) {
       const match = from.match(
         /node_modules\/(?:\.pnpm\/.*\/node_modules\/)?((?:@[^/]+\/)?[^/]+)/,
       );

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -124,8 +124,6 @@ export function esbuildSync(
     sourcemap: debug ? "inline" : false,
     sourcesContent: false,
     ...esbuildOptions,
-    // Native .node binaries cannot be bundled by esbuild
-    loader: { ".node": "empty", ...esbuildOptions.loader },
     external: ["./open-next.config.mjs", ...(esbuildOptions.external ?? [])],
     banner: {
       ...esbuildOptions.banner,
@@ -165,8 +163,6 @@ export async function esbuildAsync(
     sourcemap: debug ? "inline" : false,
     sourcesContent: false,
     ...esbuildOptions,
-    // Native .node binaries cannot be bundled by esbuild
-    loader: { ".node": "empty", ...esbuildOptions.loader },
     external: [
       ...(esbuildOptions.external ?? []),
       "next",

--- a/packages/tests-unit/tests/build/copyTracedFiles.test.ts
+++ b/packages/tests-unit/tests/build/copyTracedFiles.test.ts
@@ -66,15 +66,10 @@ describe("isNonLinuxPlatformPackage", () => {
     ).toBe(true);
   });
 
-  test("should exclude freebsd and android packages", () => {
+  test("should exclude freebsd packages", () => {
     expect(
       isNonLinuxPlatformPackage(
         "/project/node_modules/@rollup/rollup-freebsd-x64/rollup.freebsd-x64.node",
-      ),
-    ).toBe(true);
-    expect(
-      isNonLinuxPlatformPackage(
-        "/project/node_modules/@rollup/rollup-android-arm64/rollup.android-arm64.node",
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
## Motivation

When building on macOS, npm/pnpm installs platform-matching native binaries (e.g. `@swc/core-darwin-arm64`, `@esbuild/darwin-arm64`) via `optionalDependencies`. Next.js output file tracing picks these up because they exist on disk, causing two problems:

1. **esbuild build crash** — esbuild has no loader for `.node` files and fails with "No loader is configured for .node files" ([next-intl#2255](https://github.com/amannn/next-intl/issues/2255))
2. **Bundle bloat** — `copyTracedFiles` copies darwin/win32 binaries into the Lambda bundle where they can never work (~65MB in a production app)

The current user-side workaround is `outputFileTracingExcludes` in `next.config.ts`, but this requires manually listing every platform-specific package.

This mainly affects local macOS/Windows builds — CI environments on Linux wouldn't install these binaries in the first place.

**Local development is not affected** — these changes only run during the OpenNext build step. `next dev`, `next build`, and the local OpenNext server (`openbuild:local:start`) all work normally on macOS.

## Changes

### 1. `helper.ts` — Prevent esbuild crash on `.node` files
Added `loader: { ".node": "empty" }` to both `esbuildSync` and `esbuildAsync`, so esbuild skips native binaries instead of crashing.

### 2. `copyTracedFiles.ts` — Filter non-Linux platform binaries
Added `isNonLinuxPlatformPackage()` that auto-detects and excludes `darwin`/`win32`/`freebsd`/`android` packages matching the `{pkg}-{platform}-{arch}` naming convention. Operates independently from existing `EXCLUDED_PACKAGES`.

Both `linux-arm64` and `linux-x64` packages are kept since the target architecture is unknown at build time.

This filter complements the existing `install` feature (`InstallOptions` with `--os`/`--arch`): `install` provides the correct platform binaries for runtime dependencies, while this filter removes the wrong ones that came from the host machine.

### Related issues
- #166 (bundled node_modules bloat)
- #1115 (esbuild externals)
- [next-intl#2255](https://github.com/amannn/next-intl/issues/2255) (esbuild .node crash)

## Verification
Tested on a production Next.js app (next-intl + Prisma + esbuild) by **completely removing `outputFileTracingExcludes`** — both Next.js and OpenNext builds succeed, and no darwin binaries end up in the Lambda bundle.