### PR TITLE
fix(build): add empty loader for .node files in esbuild

### DIFF
--- a/.changeset/esbuild-node-loader.md
+++ b/.changeset/esbuild-node-loader.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(build): add empty loader for .node files in esbuild to prevent build crashes

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -124,6 +124,7 @@ export function esbuildSync(
     sourcemap: debug ? "inline" : false,
     sourcesContent: false,
     ...esbuildOptions,
+    loader: { ".node": "empty", ...esbuildOptions.loader },
     external: ["./open-next.config.mjs", ...(esbuildOptions.external ?? [])],
     banner: {
       ...esbuildOptions.banner,
@@ -163,6 +164,7 @@ export async function esbuildAsync(
     sourcemap: debug ? "inline" : false,
     sourcesContent: false,
     ...esbuildOptions,
+    loader: { ".node": "empty", ...esbuildOptions.loader },
     external: [
       ...(esbuildOptions.external ?? []),
       "next",


### PR DESCRIPTION
## Motivation

When a project has native binary dependencies (e.g. `@swc/core`, Prisma), esbuild can encounter `.node` files during bundling and crash with:

```
No loader is configured for ".node" files
```

This was split from #1117 per review feedback.

The root cause is that esbuild resolves package imports (e.g. `@swc/core-darwin-arm64`) through `package.json` main fields, which can point to `.node` native binaries. Since esbuild has no built-in handler for this format, it fails.

## Changes

Added `loader: { ".node": "empty" }` to both `esbuildSync` and `esbuildAsync` in `helper.ts`, so esbuild produces an empty module instead of crashing.

### Related issues
- [next-intl#2255](https://github.com/amannn/next-intl/issues/2255)
- #1115
- #1117