### PR TITLE
Add support for swr with revalidateTag

### DIFF
--- a/.changeset/slick-crabs-hear.md
+++ b/.changeset/slick-crabs-hear.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/aws": minor
+---
+
+Add support for stale-while-revalidate in revalidateTag
+
+Introduces a new methods in the tag cache (hasBeenStale, optional), both for the original and the next mode tag cache, mandatory to make swr work.
+
+It also introduces a RequestCache utils that can be used to cache things scoped to a request (stored in the OpenNext internal AsyncLocalStorage context)

--- a/.changeset/slick-crabs-hear.md
+++ b/.changeset/slick-crabs-hear.md
@@ -7,3 +7,7 @@ Add support for stale-while-revalidate in revalidateTag
 Introduces a new methods in the tag cache (hasBeenStale, optional), both for the original and the next mode tag cache, mandatory to make swr work.
 
 It also introduces a RequestCache utils that can be used to cache things scoped to a request (stored in the OpenNext internal AsyncLocalStorage context)
+
+### BREAKING CHANGE
+
+`writeTags` for the tag cache signature has changed to `writeTags(tags: NextModeTagCacheWriteInput[]): Promise<void>;` for Next mode, and `writeTags(tags: OriginalTagCacheWriteInput[]): Promise<void>;` for the original mode.

--- a/.changeset/slick-crabs-hear.md
+++ b/.changeset/slick-crabs-hear.md
@@ -4,11 +4,13 @@
 
 Add support for SWR (stale-while-revalidate) in `revalidateTag`
 
-Introduces a new methods in the tag cache (hasBeenStale, optional), both for the original and the next mode tag cache, mandatory for SWR.
+Introduces a new optional method `isStale` in the tag cache for both the original and the next modes. The implementation is mandatory for SWR to work.
 
-It also introduces a RequestCache utils that can be used to cache things scoped to a request (stored in the OpenNext internal AsyncLocalStorage context)
+It also introduces a `RequestCache` utility that can be used to cache things scoped to a request (stored in the OpenNext internal AsyncLocalStorage context)
 
 ### BREAKING CHANGE
 
 `writeTags` for the tag cache signature has changed to `writeTags(tags: NextModeTagCacheWriteInput[]): Promise<void>` for Next mode, and `writeTags(tags: OriginalTagCacheWriteInput[]): Promise<void>` for the original mode.
 This is breaking only for custom tag cache implementations, if you are using the default one provided by OpenNext, you don't need to do anything.
+
+`globalThis.isNextAfter15` is no longer available in the cache.

--- a/.changeset/slick-crabs-hear.md
+++ b/.changeset/slick-crabs-hear.md
@@ -2,12 +2,13 @@
 "@opennextjs/aws": minor
 ---
 
-Add support for stale-while-revalidate in revalidateTag
+Add support for SWR (stale-while-revalidate) in `revalidateTag`
 
-Introduces a new methods in the tag cache (hasBeenStale, optional), both for the original and the next mode tag cache, mandatory to make swr work.
+Introduces a new methods in the tag cache (hasBeenStale, optional), both for the original and the next mode tag cache, mandatory for SWR.
 
 It also introduces a RequestCache utils that can be used to cache things scoped to a request (stored in the OpenNext internal AsyncLocalStorage context)
 
 ### BREAKING CHANGE
 
-`writeTags` for the tag cache signature has changed to `writeTags(tags: NextModeTagCacheWriteInput[]): Promise<void>;` for Next mode, and `writeTags(tags: OriginalTagCacheWriteInput[]): Promise<void>;` for the original mode.
+`writeTags` for the tag cache signature has changed to `writeTags(tags: NextModeTagCacheWriteInput[]): Promise<void>` for Next mode, and `writeTags(tags: OriginalTagCacheWriteInput[]): Promise<void>` for the original mode.
+This is breaking only for custom tag cache implementations, if you are using the default one provided by OpenNext, you don't need to do anything.

--- a/examples/app-router/app/api/revalidate-tag-stale/route.ts
+++ b/examples/app-router/app/api/revalidate-tag-stale/route.ts
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET() {
   // Revalidate with expire:10 to mark the tag as stale immediately and set expiry to 10 seconds later
-  revalidateTag("revalidate-stale", { expire: 10});
+  revalidateTag("revalidate-stale", { expire: 10 });
 
   return new Response("ok");
 }

--- a/examples/app-router/app/api/revalidate-tag-stale/route.ts
+++ b/examples/app-router/app/api/revalidate-tag-stale/route.ts
@@ -1,0 +1,10 @@
+import { revalidateTag } from "next/cache";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  // Revalidate with expire:10 to mark the tag as stale immediately and set expiry to 10 seconds later
+  revalidateTag("revalidate-stale", { expire: 10});
+
+  return new Response("ok");
+}

--- a/examples/app-router/app/revalidate-tag/stale/page.tsx
+++ b/examples/app-router/app/revalidate-tag/stale/page.tsx
@@ -1,0 +1,20 @@
+import { unstable_cache } from "next/cache";
+
+const getCachedTime = unstable_cache(
+  async () => new Date().toISOString(),
+  ["stale-revalidate-time"],
+  {
+    tags: ["revalidate-stale"],
+    // Long revalidate time so the cache only expires via revalidateTag
+    revalidate: 3600,
+  },
+);
+
+export default async function StaleRevalidateTag() {
+  const cachedTime = await getCachedTime();
+  return (
+    <div>
+      <p data-testid="cached-time">Cached time: {cachedTime}</p>
+    </div>
+  );
+}

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -466,8 +466,6 @@ export default class Cache {
           }
         }
 
-        console.log("Tags to revalidate", toInsert);
-
         // Update all keys with the given tag with revalidatedAt set to now
         await writeTags(toInsert);
 

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -6,7 +6,7 @@ import type {
 import {
   getTagsFromValue,
   hasBeenRevalidated,
-  hasBeenStale,
+  isStale as isStale,
   writeTags,
 } from "utils/cache";
 import { isBinaryContentType } from "../utils/binary";
@@ -103,7 +103,7 @@ export default class Cache {
 
       const _isStale = cachedEntry.shouldBypassTagCache
         ? false
-        : await hasBeenStale(key, _tags, _lastModified);
+        : await isStale(key, _tags, _lastModified);
 
       return {
         lastModified: _isStale ? 1 : _lastModified,
@@ -136,7 +136,7 @@ export default class Cache {
 
       const _isStale = cachedEntry.shouldBypassTagCache
         ? false
-        : await hasBeenStale(key, tags, _lastModified);
+        : await isStale(key, tags, _lastModified);
 
       const store = globalThis.__openNextAls.getStore();
       if (store) {

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -333,7 +333,10 @@ export default class Cache {
     }
   }
 
-  public async revalidateTag(tags: string | string[]) {
+  public async revalidateTag(
+    tags: string | string[],
+    durations?: { expire?: number }
+  ) {
     const config = globalThis.openNextConfig.dangerous;
     if (config?.disableTagCache || config?.disableIncrementalCache) {
       return;
@@ -347,7 +350,25 @@ export default class Cache {
       if (globalThis.tagCache.mode === "nextMode") {
         const paths = (await globalThis.tagCache.getPathsByTags?.(_tags)) ?? [];
 
-        await writeTags(_tags);
+        const now = Date.now();
+        const tagsToWrite = _tags.map((tag) => {
+          if (durations) {
+            // Use provided durations
+            return {
+              tag,
+              stale: now,
+              expiry: durations.expire !== undefined ? now + durations.expire * 1000 : undefined,
+            };
+          } else {
+            // Default behavior: immediate expiration
+            return {
+              tag,
+              expiry: now,
+            };
+          }
+        });
+        
+        await writeTags(tagsToWrite);
         if (paths.length > 0) {
           // TODO: we should introduce a new method in cdnInvalidationHandler to invalidate paths by tags for cdn that supports it
           // It also means that we'll need to provide the tags used in every request to the wrapper or converter.
@@ -373,10 +394,24 @@ export default class Cache {
         // Find all keys with the given tag
         const paths = await globalThis.tagCache.getByTag(tag);
         debug("Items", paths);
-        const toInsert = paths.map((path) => ({
-          path,
-          tag,
-        }));
+        const now = Date.now();
+        const toInsert = paths.map((path) => {
+          const baseEntry = { path, tag };
+          if (durations) {
+            // Use provided durations
+            return {
+              ...baseEntry,
+              stale: now,
+              expiry: durations.expire !== undefined ? now + durations.expire * 1000 : undefined,
+            };
+          } else {
+            // Default behavior: immediate expiration
+            return {
+              ...baseEntry,
+              expiry: now,
+            };
+          }
+        });
 
         // If the tag is a soft tag, we should also revalidate the hard tags
         if (tag.startsWith(SOFT_TAG_PREFIX)) {
@@ -391,10 +426,21 @@ export default class Cache {
               const _paths = await globalThis.tagCache.getByTag(hardTag);
               debug({ hardTag, _paths });
               toInsert.push(
-                ..._paths.map((path) => ({
-                  path,
-                  tag: hardTag,
-                })),
+                ..._paths.map((path) => {
+                  const baseEntry = { path, tag: hardTag };
+                  if (durations) {
+                    return {
+                      ...baseEntry,
+                      stale: now,
+                      expiry: durations.expire !== undefined ? now + durations.expire * 1000 : undefined,
+                    };
+                  } else {
+                    return {
+                      ...baseEntry,
+                      expiry: now,
+                    };
+                  }
+                }),
               );
             }
           }

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -377,7 +377,7 @@ export default class Cache {
                   : undefined,
             };
           }
-          // Default behavior: immediate expiration
+          // Immediate expiration, default behavior before next 16, now only with {expire: 0}
           return {
             tag,
             expiry: now,

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -371,7 +371,7 @@ export default class Cache {
             return {
               tag,
               stale: now,
-              expiry:
+              expire:
                 durations.expire !== undefined
                   ? now + durations.expire * 1000
                   : undefined,
@@ -380,7 +380,7 @@ export default class Cache {
           // Immediate expiration, default behavior before next 16, now only with {expire: 0}
           return {
             tag,
-            expiry: now,
+            expire: now,
           };
         });
 
@@ -418,7 +418,7 @@ export default class Cache {
             return {
               ...baseEntry,
               stale: now,
-              expiry:
+              expire:
                 durations.expire !== undefined
                   ? now + durations.expire * 1000
                   : undefined,
@@ -427,7 +427,7 @@ export default class Cache {
           // Default behavior: immediate expiration
           return {
             ...baseEntry,
-            expiry: now,
+            expire: now,
           };
         });
 
@@ -450,7 +450,7 @@ export default class Cache {
                     return {
                       ...baseEntry,
                       stale: now,
-                      expiry:
+                      expire:
                         durations.expire !== undefined
                           ? now + durations.expire * 1000
                           : undefined,
@@ -458,7 +458,7 @@ export default class Cache {
                   }
                   return {
                     ...baseEntry,
-                    expiry: now,
+                    expire: now,
                   };
                 }),
               );

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -372,13 +372,12 @@ export default class Cache {
                   ? now + durations.expire * 1000
                   : undefined,
             };
-          } else {
-            // Default behavior: immediate expiration
-            return {
-              tag,
-              expiry: now,
-            };
           }
+          // Default behavior: immediate expiration
+          return {
+            tag,
+            expiry: now,
+          };
         });
 
         await writeTags(tagsToWrite);
@@ -420,13 +419,12 @@ export default class Cache {
                   ? now + durations.expire * 1000
                   : undefined,
             };
-          } else {
-            // Default behavior: immediate expiration
-            return {
-              ...baseEntry,
-              expiry: now,
-            };
           }
+          // Default behavior: immediate expiration
+          return {
+            ...baseEntry,
+            expiry: now,
+          };
         });
 
         // If the tag is a soft tag, we should also revalidate the hard tags
@@ -453,12 +451,11 @@ export default class Cache {
                           ? now + durations.expire * 1000
                           : undefined,
                     };
-                  } else {
-                    return {
-                      ...baseEntry,
-                      expiry: now,
-                    };
                   }
+                  return {
+                    ...baseEntry,
+                    expiry: now,
+                  };
                 }),
               );
             }

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -335,7 +335,7 @@ export default class Cache {
 
   public async revalidateTag(
     tags: string | string[],
-    durations?: { expire?: number }
+    durations?: { expire?: number },
   ) {
     const config = globalThis.openNextConfig.dangerous;
     if (config?.disableTagCache || config?.disableIncrementalCache) {
@@ -357,7 +357,10 @@ export default class Cache {
             return {
               tag,
               stale: now,
-              expiry: durations.expire !== undefined ? now + durations.expire * 1000 : undefined,
+              expiry:
+                durations.expire !== undefined
+                  ? now + durations.expire * 1000
+                  : undefined,
             };
           } else {
             // Default behavior: immediate expiration
@@ -367,7 +370,7 @@ export default class Cache {
             };
           }
         });
-        
+
         await writeTags(tagsToWrite);
         if (paths.length > 0) {
           // TODO: we should introduce a new method in cdnInvalidationHandler to invalidate paths by tags for cdn that supports it
@@ -402,7 +405,10 @@ export default class Cache {
             return {
               ...baseEntry,
               stale: now,
-              expiry: durations.expire !== undefined ? now + durations.expire * 1000 : undefined,
+              expiry:
+                durations.expire !== undefined
+                  ? now + durations.expire * 1000
+                  : undefined,
             };
           } else {
             // Default behavior: immediate expiration
@@ -432,7 +438,10 @@ export default class Cache {
                     return {
                       ...baseEntry,
                       stale: now,
-                      expiry: durations.expire !== undefined ? now + durations.expire * 1000 : undefined,
+                      expiry:
+                        durations.expire !== undefined
+                          ? now + durations.expire * 1000
+                          : undefined,
                     };
                   } else {
                     return {

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -3,7 +3,12 @@ import type {
   IncrementalCacheContext,
   IncrementalCacheValue,
 } from "types/cache";
-import { getTagsFromValue, hasBeenRevalidated, hasBeenStale, writeTags } from "utils/cache";
+import {
+  getTagsFromValue,
+  hasBeenRevalidated,
+  hasBeenStale,
+  writeTags,
+} from "utils/cache";
 import { isBinaryContentType } from "../utils/binary";
 import { debug, error, warn } from "./logger";
 

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -98,7 +98,8 @@ export default class Cache {
 
       const _isStale = cachedEntry.shouldBypassTagCache
         ? false
-        : ((await globalThis.tagCache.hasBeenStale?.(_tags, _lastModified)) ?? false);
+        : ((await globalThis.tagCache.hasBeenStale?.(_tags, _lastModified)) ??
+          false);
 
       return {
         lastModified: _isStale ? 1 : _lastModified,
@@ -131,7 +132,8 @@ export default class Cache {
 
       const _isStale = cachedEntry.shouldBypassTagCache
         ? false
-        : ((await globalThis.tagCache.hasBeenStale?.(tags, _lastModified)) ?? false);
+        : ((await globalThis.tagCache.hasBeenStale?.(tags, _lastModified)) ??
+          false);
 
       const store = globalThis.__openNextAls.getStore();
       if (store) {

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -6,7 +6,7 @@ import type {
 import {
   getTagsFromValue,
   hasBeenRevalidated,
-  isStale as isStale,
+  isStale,
   writeTags,
 } from "utils/cache";
 import { isBinaryContentType } from "../utils/binary";
@@ -149,7 +149,9 @@ export default class Cache {
         return {
           lastModified: _lastModified,
           value: {
-            kind: compareSemver(globalThis.nextVersion, ">=", "15.0.0") ? "APP_ROUTE" : "ROUTE",
+            kind: compareSemver(globalThis.nextVersion, ">=", "15.0.0")
+              ? "APP_ROUTE"
+              : "ROUTE",
             body: Buffer.from(
               cacheData.body ?? Buffer.alloc(0),
               isBinaryContentType(String(meta?.headers?.["content-type"]))
@@ -162,7 +164,10 @@ export default class Cache {
         } as CacheHandlerValue;
       }
       if (cacheData?.type === "page" || cacheData?.type === "app") {
-        if (compareSemver(globalThis.nextVersion, ">=", "15.0.0") && cacheData?.type === "app") {
+        if (
+          compareSemver(globalThis.nextVersion, ">=", "15.0.0") &&
+          cacheData?.type === "app"
+        ) {
           const segmentData = new Map<string, Buffer>();
           if (cacheData.segmentData) {
             for (const [segmentPath, segmentContent] of Object.entries(
@@ -187,7 +192,9 @@ export default class Cache {
         return {
           lastModified: _lastModified,
           value: {
-            kind: compareSemver(globalThis.nextVersion, ">=", "15.0.0") ? "PAGES" : "PAGE",
+            kind: compareSemver(globalThis.nextVersion, ">=", "15.0.0")
+              ? "PAGES"
+              : "PAGE",
             html: cacheData.html,
             pageData:
               cacheData.type === "page" ? cacheData.json : cacheData.rsc,

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -3,7 +3,7 @@ import type {
   IncrementalCacheContext,
   IncrementalCacheValue,
 } from "types/cache";
-import { getTagsFromValue, hasBeenRevalidated, writeTags } from "utils/cache";
+import { getTagsFromValue, hasBeenRevalidated, hasBeenStale, writeTags } from "utils/cache";
 import { isBinaryContentType } from "../utils/binary";
 import { debug, error, warn } from "./logger";
 
@@ -98,8 +98,7 @@ export default class Cache {
 
       const _isStale = cachedEntry.shouldBypassTagCache
         ? false
-        : ((await globalThis.tagCache.hasBeenStale?.(_tags, _lastModified)) ??
-          false);
+        : await hasBeenStale(key, _tags, _lastModified);
 
       return {
         lastModified: _isStale ? 1 : _lastModified,
@@ -124,7 +123,7 @@ export default class Cache {
 
       const meta = cacheData.meta;
       const tags = getTagsFromValue(cacheData);
-      const _lastModified = cachedEntry.lastModified ?? Date.now();
+      let _lastModified = cachedEntry.lastModified ?? Date.now();
       const _hasBeenRevalidated = cachedEntry.shouldBypassTagCache
         ? false
         : await hasBeenRevalidated(key, tags, cachedEntry);
@@ -132,12 +131,12 @@ export default class Cache {
 
       const _isStale = cachedEntry.shouldBypassTagCache
         ? false
-        : ((await globalThis.tagCache.hasBeenStale?.(tags, _lastModified)) ??
-          false);
+        : await hasBeenStale(key, tags, _lastModified);
 
       const store = globalThis.__openNextAls.getStore();
       if (store) {
         store.lastModified = _isStale ? 1 : _lastModified;
+        _lastModified = store.lastModified;
       }
 
       if (cacheData?.type === "route") {
@@ -461,6 +460,8 @@ export default class Cache {
             }
           }
         }
+
+        console.log("Tags to revalidate", toInsert);
 
         // Update all keys with the given tag with revalidatedAt set to now
         await writeTags(toInsert);

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -10,6 +10,7 @@ import {
   writeTags,
 } from "utils/cache";
 import { isBinaryContentType } from "../utils/binary";
+import { compareSemver } from "../utils/semver";
 import { debug, error, warn } from "./logger";
 
 export const SOFT_TAG_PREFIX = "_N_T_/";
@@ -148,7 +149,7 @@ export default class Cache {
         return {
           lastModified: _lastModified,
           value: {
-            kind: globalThis.isNextAfter15 ? "APP_ROUTE" : "ROUTE",
+            kind: compareSemver(globalThis.nextVersion, ">=", "15.0.0") ? "APP_ROUTE" : "ROUTE",
             body: Buffer.from(
               cacheData.body ?? Buffer.alloc(0),
               isBinaryContentType(String(meta?.headers?.["content-type"]))
@@ -161,7 +162,7 @@ export default class Cache {
         } as CacheHandlerValue;
       }
       if (cacheData?.type === "page" || cacheData?.type === "app") {
-        if (globalThis.isNextAfter15 && cacheData?.type === "app") {
+        if (compareSemver(globalThis.nextVersion, ">=", "15.0.0") && cacheData?.type === "app") {
           const segmentData = new Map<string, Buffer>();
           if (cacheData.segmentData) {
             for (const [segmentPath, segmentContent] of Object.entries(
@@ -186,7 +187,7 @@ export default class Cache {
         return {
           lastModified: _lastModified,
           value: {
-            kind: globalThis.isNextAfter15 ? "PAGES" : "PAGE",
+            kind: compareSemver(globalThis.nextVersion, ">=", "15.0.0") ? "PAGES" : "PAGE",
             html: cacheData.html,
             pageData:
               cacheData.type === "page" ? cacheData.json : cacheData.rsc,

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -96,8 +96,12 @@ export default class Cache {
         }
       }
 
+      const _isStale = cachedEntry.shouldBypassTagCache
+        ? false
+        : ((await globalThis.tagCache.hasBeenStale?.(_tags, _lastModified)) ?? false);
+
       return {
-        lastModified: _lastModified,
+        lastModified: _isStale ? 1 : _lastModified,
         value: cachedEntry.value,
       } as CacheHandlerValue;
     } catch (e) {
@@ -125,9 +129,13 @@ export default class Cache {
         : await hasBeenRevalidated(key, tags, cachedEntry);
       if (_hasBeenRevalidated) return null;
 
+      const _isStale = cachedEntry.shouldBypassTagCache
+        ? false
+        : ((await globalThis.tagCache.hasBeenStale?.(tags, _lastModified)) ?? false);
+
       const store = globalThis.__openNextAls.getStore();
       if (store) {
-        store.lastModified = _lastModified;
+        store.lastModified = _isStale ? 1 : _lastModified;
       }
 
       if (cacheData?.type === "route") {

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -1,6 +1,6 @@
 import type { ComposableCacheEntry, ComposableCacheHandler } from "types/cache";
 import type { CacheValue, OriginalTagCache } from "types/overrides";
-import { hasBeenStale, writeTags } from "utils/cache";
+import { isStale, writeTags } from "utils/cache";
 import { fromReadableStream, toReadableStream } from "utils/stream";
 import { debug } from "./logger";
 
@@ -48,14 +48,14 @@ export default {
         if (hasBeenRevalidated) return undefined;
 
         // Check if tags are stale – entry is valid but needs background revalidation
-        const isStale = result.shouldBypassTagCache
+        const isCacheStale = result.shouldBypassTagCache
           ? false
-          : await hasBeenStale(
+          : await isStale(
               cacheKey,
               result.value.tags,
               result.lastModified,
             );
-        if (isStale) {
+        if (isCacheStale) {
           revalidate = -1;
         }
       } else if (
@@ -71,14 +71,14 @@ export default {
         if (hasBeenRevalidated) return undefined;
 
         // Check if tags are stale – entry is valid but needs background revalidation
-        const isStale = result.shouldBypassTagCache
+        const isCacheStale = result.shouldBypassTagCache
           ? false
-          : await hasBeenStale(
+          : await isStale(
               cacheKey,
               result.value.tags,
               result.lastModified,
             );
-        if (isStale) {
+        if (isCacheStale) {
           revalidate = -1;
         }
       }

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -1,6 +1,6 @@
 import type { ComposableCacheEntry, ComposableCacheHandler } from "types/cache";
 import type { CacheValue, OriginalTagCache } from "types/overrides";
-import { writeTags } from "utils/cache";
+import { hasBeenStale, writeTags } from "utils/cache";
 import { fromReadableStream, toReadableStream } from "utils/stream";
 import { debug } from "./logger";
 
@@ -50,10 +50,11 @@ export default {
         // Check if tags are stale – entry is valid but needs background revalidation
         const isStale = result.shouldBypassTagCache
           ? false
-          : ((await globalThis.tagCache.hasBeenStale?.(
+          : await hasBeenStale(
+              cacheKey,
               result.value.tags,
               result.lastModified,
-            )) ?? false);
+            );
         if (isStale) {
           revalidate = -1;
         }
@@ -72,10 +73,11 @@ export default {
         // Check if tags are stale – entry is valid but needs background revalidation
         const isStale = result.shouldBypassTagCache
           ? false
-          : ((await globalThis.tagCache.hasBeenStale?.(
+          : await hasBeenStale(
+              cacheKey,
               result.value.tags,
               result.lastModified,
-            )) ?? false);
+            );
         if (isStale) {
           revalidate = -1;
         }

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -200,14 +200,14 @@ export default {
             return {
               tag,
               stale: now,
-              expiry:
+              expire:
                 durations.expire !== undefined
                   ? now + durations.expire * 1000
                   : undefined,
             };
           }
           // Default: immediate expiry, no grace period
-          return { tag, expiry: now };
+          return { tag, expire: now };
         });
         await writeTags(tagsToWrite);
       } else {
@@ -222,13 +222,13 @@ export default {
                   path,
                   tag,
                   stale: now,
-                  expiry:
+                  expire:
                     durations.expire !== undefined
                       ? now + durations.expire * 1000
                       : undefined,
                 };
               }
-              return { path, tag, expiry: now };
+              return { path, tag, expire: now };
             });
           }),
         );

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -175,6 +175,7 @@ export default {
    *
    * When `durations` is provided, marks tags as stale immediately and optionally
    * sets an expiry timestamp. When omitted, immediately expires tags (no grace period).
+   * durations.expire is in seconds, but we convert it to milliseconds for storage and comparison.
    */
   async updateTags(tags: string[], durations?: { expire?: number }) {
     const config = globalThis.openNextConfig.dangerous;

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -1,5 +1,5 @@
 import type { ComposableCacheEntry, ComposableCacheHandler } from "types/cache";
-import type { CacheValue } from "types/overrides";
+import type { CacheValue, OriginalTagCache } from "types/overrides";
 import { writeTags } from "utils/cache";
 import { fromReadableStream, toReadableStream } from "utils/stream";
 import { debug } from "./logger";
@@ -34,6 +34,7 @@ export default {
       debug("composable cache result", result);
 
       // We need to check if the tags associated with this entry has been revalidated
+      let revalidate = result.value.revalidate;
       if (
         globalThis.tagCache.mode === "nextMode" &&
         result.value.tags.length > 0
@@ -45,6 +46,17 @@ export default {
               result.lastModified,
             );
         if (hasBeenRevalidated) return undefined;
+
+        // Check if tags are stale – entry is valid but needs background revalidation
+        const isStale = result.shouldBypassTagCache
+          ? false
+          : ((await globalThis.tagCache.hasBeenStale?.(
+              result.value.tags,
+              result.lastModified,
+            )) ?? false);
+        if (isStale) {
+          revalidate = -1;
+        }
       } else if (
         globalThis.tagCache.mode === "original" ||
         globalThis.tagCache.mode === undefined
@@ -56,10 +68,22 @@ export default {
               result.lastModified,
             )) === -1;
         if (hasBeenRevalidated) return undefined;
+
+        // Check if tags are stale – entry is valid but needs background revalidation
+        const isStale = result.shouldBypassTagCache
+          ? false
+          : ((await globalThis.tagCache.hasBeenStale?.(
+              result.value.tags,
+              result.lastModified,
+            )) ?? false);
+        if (isStale) {
+          revalidate = -1;
+        }
       }
 
       return {
         ...result.value,
+        revalidate,
         value: toReadableStream(result.value.value),
       };
     } catch (e) {
@@ -148,5 +172,71 @@ export default {
   async receiveExpiredTags(...tags: string[]) {
     // This function does absolutely nothing
     return;
+  },
+
+  /**
+   * Added in Next.js 16. Updates tags with optional stale/expire durations.
+   * Mirrors the logic in `Cache.revalidateTag` but without CDN invalidation
+   * since composable cache keys are not URL paths.
+   *
+   * When `durations` is provided, marks tags as stale immediately and optionally
+   * sets an expiry timestamp. When omitted, immediately expires tags (no grace period).
+   */
+  async updateTags(tags: string[], durations?: { expire?: number }) {
+    const config = globalThis.openNextConfig.dangerous;
+    if (config?.disableTagCache || config?.disableIncrementalCache) {
+      return;
+    }
+    if (tags.length === 0) {
+      return;
+    }
+    try {
+      const now = Date.now();
+      if (globalThis.tagCache.mode === "nextMode") {
+        const tagsToWrite = tags.map((tag) => {
+          if (durations) {
+            return {
+              tag,
+              stale: now,
+              expiry:
+                durations.expire !== undefined
+                  ? now + durations.expire * 1000
+                  : undefined,
+            };
+          }
+          // Default: immediate expiry, no grace period
+          return { tag, expiry: now };
+        });
+        await writeTags(tagsToWrite);
+      } else {
+        // Original mode: resolve tag → path mappings first
+        const originalTagCache = globalThis.tagCache as OriginalTagCache;
+        const pathsPerTag = await Promise.all(
+          tags.map(async (tag) => {
+            const paths = await originalTagCache.getByTag(tag);
+            return paths.map((path: string) => {
+              if (durations) {
+                return {
+                  path,
+                  tag,
+                  stale: now,
+                  expiry:
+                    durations.expire !== undefined
+                      ? now + durations.expire * 1000
+                      : undefined,
+                };
+              }
+              return { path, tag, expiry: now };
+            });
+          }),
+        );
+        const toWrite = pathsPerTag.flat();
+        if (toWrite.length > 0) {
+          await writeTags(toWrite);
+        }
+      }
+    } catch (e) {
+      debug("Failed to update tags", e);
+    }
   },
 } satisfies ComposableCacheHandler;

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -33,12 +33,12 @@ export default {
 
       debug("composable cache result", result);
 
-      // We need to check if the tags associated with this entry has been revalidated
       let revalidate = result.value.revalidate;
       if (
         globalThis.tagCache.mode === "nextMode" &&
         result.value.tags.length > 0
       ) {
+        // We need to check if the tags associated with this entry has been revalidated
         const hasBeenRevalidated = result.shouldBypassTagCache
           ? false
           : await globalThis.tagCache.hasBeenRevalidated(

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -50,11 +50,7 @@ export default {
         // Check if tags are stale – entry is valid but needs background revalidation
         const isCacheStale = result.shouldBypassTagCache
           ? false
-          : await isStale(
-              cacheKey,
-              result.value.tags,
-              result.lastModified,
-            );
+          : await isStale(cacheKey, result.value.tags, result.lastModified);
         if (isCacheStale) {
           revalidate = -1;
         }
@@ -73,11 +69,7 @@ export default {
         // Check if tags are stale – entry is valid but needs background revalidation
         const isCacheStale = result.shouldBypassTagCache
           ? false
-          : await isStale(
-              cacheKey,
-              result.value.tags,
-              result.lastModified,
-            );
+          : await isStale(cacheKey, result.value.tags, result.lastModified);
         if (isCacheStale) {
           revalidate = -1;
         }

--- a/packages/open-next/src/adapters/dynamo-provider.ts
+++ b/packages/open-next/src/adapters/dynamo-provider.ts
@@ -16,9 +16,15 @@ type DataType = {
   revalidatedAt: {
     N: string;
   };
+  /**
+   * The time at which the tag should be considered stale, in milliseconds since epoch.
+   */
   stale?: {
     N: string;
   };
+  /**
+   * The time at which the tag should expire, in milliseconds since epoch.
+   */
   expire?: {
     N: string;
   };

--- a/packages/open-next/src/adapters/dynamo-provider.ts
+++ b/packages/open-next/src/adapters/dynamo-provider.ts
@@ -19,7 +19,7 @@ type DataType = {
   stale?: {
     N: string;
   };
-  expiry?: {
+  expire?: {
     N: string;
   };
 };
@@ -70,7 +70,7 @@ async function insert(
     path: item.path.S,
     revalidatedAt: Number.parseInt(item.revalidatedAt.N),
     ...(item.stale && { stale: Number.parseInt(item.stale.N) }),
-    ...(item.expiry && { expiry: Number.parseInt(item.expiry.N) }),
+    ...(item.expire && { expire: Number.parseInt(item.expire.N) }),
   }));
 
   await tagCache.writeTags(parsedData);

--- a/packages/open-next/src/adapters/dynamo-provider.ts
+++ b/packages/open-next/src/adapters/dynamo-provider.ts
@@ -16,6 +16,12 @@ type DataType = {
   revalidatedAt: {
     N: string;
   };
+  stale?: {
+    N: string;
+  };
+  expiry?: {
+    N: string;
+  };
 };
 
 export interface InitializationFunctionEvent {
@@ -63,6 +69,8 @@ async function insert(
     tag: item.tag.S,
     path: item.path.S,
     revalidatedAt: Number.parseInt(item.revalidatedAt.N),
+    ...(item.stale && { stale: Number.parseInt(item.stale.N) }),
+    ...(item.expiry && { expiry: Number.parseInt(item.expiry.N) }),
   }));
 
   await tagCache.writeTags(parsedData);

--- a/packages/open-next/src/build/compileCache.ts
+++ b/packages/open-next/src/build/compileCache.ts
@@ -17,18 +17,6 @@ export function compileCache(
   const ext = format === "cjs" ? "cjs" : "mjs";
   const compiledCacheFile = path.join(options.buildDir, `cache.${ext}`);
 
-  const isAfter15 = buildHelper.compareSemver(
-    options.nextVersion,
-    ">=",
-    "15.0.0",
-  );
-
-  const isAfter16 = buildHelper.compareSemver(
-    options.nextVersion,
-    ">=",
-    "16.0.0",
-  );
-
   // Normal cache
   buildHelper.esbuildSync(
     {
@@ -45,8 +33,7 @@ export function compileCache(
           `globalThis.disableDynamoDBCache = ${
             config.dangerous?.disableTagCache ?? false
           };`,
-          `globalThis.isNextAfter15 = ${isAfter15};`,
-          `globalThis.isNextAfter16 = ${isAfter16};`,
+          `globalThis.nextVersion = "${options.nextVersion}";`,
         ].join(""),
       },
     },
@@ -76,8 +63,7 @@ export function compileCache(
           `globalThis.disableDynamoDBCache = ${
             config.dangerous?.disableTagCache ?? false
           };`,
-          `globalThis.isNextAfter15 = ${isAfter15};`,
-          `globalThis.isNextAfter16 = ${isAfter16};`,
+          `globalThis.nextVersion = "${options.nextVersion}";`,
         ].join(""),
       },
     },

--- a/packages/open-next/src/build/compileCache.ts
+++ b/packages/open-next/src/build/compileCache.ts
@@ -23,6 +23,12 @@ export function compileCache(
     "15.0.0",
   );
 
+  const isAfter16 = buildHelper.compareSemver(
+    options.nextVersion,
+    ">=",
+    "16.0.0",
+  );
+
   // Normal cache
   buildHelper.esbuildSync(
     {
@@ -40,6 +46,7 @@ export function compileCache(
             config.dangerous?.disableTagCache ?? false
           };`,
           `globalThis.isNextAfter15 = ${isAfter15};`,
+          `globalThis.isNextAfter16 = ${isAfter16};`,
         ].join(""),
       },
     },
@@ -70,6 +77,7 @@ export function compileCache(
             config.dangerous?.disableTagCache ?? false
           };`,
           `globalThis.isNextAfter15 = ${isAfter15};`,
+          `globalThis.isNextAfter16 = ${isAfter16};`,
         ].join(""),
       },
     },

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -297,66 +297,8 @@ export function getNextVersion(appPath: string): string {
   return version.split("-")[0];
 }
 
-export type SemverOp = "=" | ">=" | "<=" | ">" | "<";
-
-/**
- * Compare two semver versions.
- *
- * @param v1 - First version. Can be "latest", otherwise it should be a valid semver version in the format of `major.minor.patch`. Usually is the next version from the package.json without canary suffix. If minor or patch are missing, they are considered 0.
- * @param v2 - Second version. Should not be "latest", it should be a valid semver version in the format of `major.minor.patch`. If minor or patch are missing, they are considered 0.
- * @example
- *     compareSemver("2.0.0", ">=", "1.0.0") === true
- */
-export function compareSemver(
-  v1: string,
-  operator: SemverOp,
-  v2: string,
-): boolean {
-  // - = 0 when versions are equal
-  // - > 0 if v1 > v2
-  // - < 0 if v2 > v1
-  let versionDiff = 0;
-  if (v1 === "latest") {
-    versionDiff = 1;
-  } else {
-    if (/^[^\d]/.test(v1)) {
-      // biome-ignore lint/style/noParameterAssign:
-      v1 = v1.substring(1);
-    }
-    if (/^[^\d]/.test(v2)) {
-      // biome-ignore lint/style/noParameterAssign:
-      v2 = v2.substring(1);
-    }
-    const [major1, minor1 = 0, patch1 = 0] = v1.split(".").map(Number);
-    const [major2, minor2 = 0, patch2 = 0] = v2.split(".").map(Number);
-    if (Number.isNaN(major1) || Number.isNaN(major2)) {
-      throw new Error("The major version is required.");
-    }
-
-    if (major1 !== major2) {
-      versionDiff = major1 - major2;
-    } else if (minor1 !== minor2) {
-      versionDiff = minor1 - minor2;
-    } else if (patch1 !== patch2) {
-      versionDiff = patch1 - patch2;
-    }
-  }
-
-  switch (operator) {
-    case "=":
-      return versionDiff === 0;
-    case ">=":
-      return versionDiff >= 0;
-    case "<=":
-      return versionDiff <= 0;
-    case ">":
-      return versionDiff > 0;
-    case "<":
-      return versionDiff < 0;
-    default:
-      throw new Error(`Unsupported operator: ${operator}`);
-  }
-}
+export type { SemverOp } from "../utils/semver.js";
+export { compareSemver } from "../utils/semver.js";
 
 /**
  * Next.js major version release dates (YYYY-MM-DD).

--- a/packages/open-next/src/build/patch/patches/patchNextServer.ts
+++ b/packages/open-next/src/build/patch/patches/patchNextServer.ts
@@ -52,6 +52,20 @@ fix:
   this.handleNextImageRequest = async (req, res, parsedUrl) => false
 `;
 
+export const provideInternalWaitUntil = `
+rule:
+  kind: return_statement
+  inside:
+    kind: method_definition
+    stopBy: end
+    has:
+      kind: property_identifier
+      regex: getInternalWaitUntil
+
+fix:
+ return globalThis.__openNextAls.getStore()?.waitUntil;
+`;
+
 /**
  * Swaps the body for a throwing implementation
  *
@@ -129,6 +143,12 @@ export const patchNextServer: CodePatcher = {
       pathFilter,
       contentFilter: /getMiddlewareManifest/,
       patchCode: createPatchCode(removeMiddlewareManifestRule),
+    },
+    {
+      versions: ">=16.0.0",
+      pathFilter,
+      contentFilter: /getInternalWaitUntil/,
+      patchCode: createPatchCode(provideInternalWaitUntil),
     },
     ...babelPatches,
   ],

--- a/packages/open-next/src/overrides/tagCache/dummy.ts
+++ b/packages/open-next/src/overrides/tagCache/dummy.ts
@@ -16,7 +16,7 @@ const dummyTagCache: TagCache = {
   writeTags: async () => {
     return;
   },
-  hasBeenStale: async (_path: string) => {
+  isStale: async (_path: string) => {
     return false;
   },
 };

--- a/packages/open-next/src/overrides/tagCache/dummy.ts
+++ b/packages/open-next/src/overrides/tagCache/dummy.ts
@@ -16,6 +16,9 @@ const dummyTagCache: TagCache = {
   writeTags: async () => {
     return;
   },
+  hasBeenStale: async () => {
+    return false;
+  },
 };
 
 export default dummyTagCache;

--- a/packages/open-next/src/overrides/tagCache/dummy.ts
+++ b/packages/open-next/src/overrides/tagCache/dummy.ts
@@ -16,7 +16,7 @@ const dummyTagCache: TagCache = {
   writeTags: async () => {
     return;
   },
-  hasBeenStale: async () => {
+  hasBeenStale: async (_path: string) => {
     return false;
   },
 };

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -87,7 +87,9 @@ const tagCache: TagCache = {
       }
       const { CACHE_DYNAMO_TABLE, NEXT_BUILD_ID } = process.env;
       const store = globalThis.__openNextAls.getStore();
-      const cache = store?.requestCache.getOrCreate<string, string[]>("dynamoDb:getByPath");
+      const cache = store?.requestCache.getOrCreate<string, string[]>(
+        "dynamoDb:getByPath",
+      );
       if (cache?.has(path)) {
         return cache.get(path)!;
       }
@@ -114,7 +116,9 @@ const tagCache: TagCache = {
       const tags = Items?.map((item: any) => item.tag.S ?? "") ?? [];
       debug("tags for path", path, tags);
       // We need to remove the buildId from the path
-      const resultTags = tags.map((tag: string) => tag.replace(`${NEXT_BUILD_ID}/`, ""));
+      const resultTags = tags.map((tag: string) =>
+        tag.replace(`${NEXT_BUILD_ID}/`, ""),
+      );
       cache?.set(path, resultTags);
       return resultTags;
     } catch (e) {
@@ -129,7 +133,9 @@ const tagCache: TagCache = {
       }
       const { CACHE_DYNAMO_TABLE, NEXT_BUILD_ID } = process.env;
       const store = globalThis.__openNextAls.getStore();
-      const cache = store?.requestCache.getOrCreate<string, string[]>("dynamoDb:getByTag");
+      const cache = store?.requestCache.getOrCreate<string, string[]>(
+        "dynamoDb:getByTag",
+      );
       if (cache?.has(tag)) {
         return cache.get(tag)!;
       }
@@ -169,7 +175,9 @@ const tagCache: TagCache = {
       }
       const { CACHE_DYNAMO_TABLE } = process.env;
       const store = globalThis.__openNextAls.getStore();
-      const cache = store?.requestCache.getOrCreate<string, number>("dynamoDb:getLastModified");
+      const cache = store?.requestCache.getOrCreate<string, number>(
+        "dynamoDb:getLastModified",
+      );
       const cacheKey = `${key}:${lastModified ?? 0}`;
       if (cache?.has(cacheKey)) {
         return cache.get(cacheKey)!;
@@ -238,7 +246,9 @@ const tagCache: TagCache = {
       }
       const { CACHE_DYNAMO_TABLE } = process.env;
       const store = globalThis.__openNextAls.getStore();
-      const itemsCache = store?.requestCache.getOrCreate<string, any[]>("dynamoDb:revalidateQueryItems");
+      const itemsCache = store?.requestCache.getOrCreate<string, any[]>(
+        "dynamoDb:revalidateQueryItems",
+      );
       const cacheKey = `${key}:${lastModified ?? 0}`;
       let items: any[];
       if (itemsCache?.has(cacheKey)) {

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -178,7 +178,7 @@ const tagCache: TagCache = {
       }
       const revalidatedTags = ((await result.json()) as any).Items ?? [];
       debug("revalidatedTags", revalidatedTags);
-      
+
       // Check if any tag has expired
       const now = Date.now();
       const hasExpiredTag = revalidatedTags.some((item: any) => {
@@ -188,9 +188,11 @@ const tagCache: TagCache = {
         }
         return false;
       });
-      
+
       // If we have revalidated tags or expired tags we return -1 to force revalidation
-      return revalidatedTags.length > 0 || hasExpiredTag ? -1 : (lastModified ?? Date.now());
+      return revalidatedTags.length > 0 || hasExpiredTag
+        ? -1
+        : (lastModified ?? Date.now());
     } catch (e) {
       error("Failed to get revalidated tags", e);
       return lastModified ?? Date.now();

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -178,8 +178,19 @@ const tagCache: TagCache = {
       }
       const revalidatedTags = ((await result.json()) as any).Items ?? [];
       debug("revalidatedTags", revalidatedTags);
-      // If we have revalidated tags we return -1 to force revalidation
-      return revalidatedTags.length > 0 ? -1 : (lastModified ?? Date.now());
+      
+      // Check if any tag has expired
+      const now = Date.now();
+      const hasExpiredTag = revalidatedTags.some((item: any) => {
+        if (item.expiry?.N) {
+          const expiry = Number.parseInt(item.expiry.N);
+          return expiry <= now && expiry > (lastModified ?? 0);
+        }
+        return false;
+      });
+      
+      // If we have revalidated tags or expired tags we return -1 to force revalidation
+      return revalidatedTags.length > 0 || hasExpiredTag ? -1 : (lastModified ?? Date.now());
     } catch (e) {
       error("Failed to get revalidated tags", e);
       return lastModified ?? Date.now();

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -196,6 +196,47 @@ const tagCache: TagCache = {
       return lastModified ?? Date.now();
     }
   },
+  async hasBeenStale(tags: string[], lastModified?: number) {
+    try {
+      if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+        return false;
+      }
+      const { CACHE_DYNAMO_TABLE } = process.env;
+      // For each tag, query entries directly by tag (primary key) and check
+      // if any have a stale timestamp newer than lastModified
+      const results = await Promise.all(
+        tags.map(async (tag) => {
+          const result = await awsFetch(
+            JSON.stringify({
+              TableName: CACHE_DYNAMO_TABLE,
+              KeyConditionExpression: "#tag = :tag",
+              ExpressionAttributeNames: { "#tag": "tag" },
+              ExpressionAttributeValues: {
+                ":tag": { S: buildDynamoKey(tag) },
+              },
+            }),
+          );
+          if (result.status !== 200) {
+            throw new RecoverableError(
+              `Failed to check stale tags: ${result.status}`,
+            );
+          }
+          return ((await result.json()) as any).Items ?? [];
+        }),
+      );
+      return results.some((items: any[]) =>
+        items.some((item: any) => {
+          if (item.stale?.N) {
+            return Number.parseInt(item.stale.N) > (lastModified ?? 0);
+          }
+          return false;
+        }),
+      );
+    } catch (e) {
+      error("Failed to check stale tags", e);
+      return false;
+    }
+  },
   async writeTags(tags) {
     try {
       const { CACHE_DYNAMO_TABLE } = process.env;

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -70,7 +70,6 @@ function buildDynamoObject(
     revalidatedAt: { N: `${revalidatedAt ?? Date.now()}` },
     ...(stale !== undefined ? { stale: { N: `${stale}` } } : {}),
     ...(expire !== undefined ? { expire: { N: `${expire}` } } : {}),
-
   };
   return obj;
 }

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -86,6 +86,11 @@ const tagCache: TagCache = {
         return [];
       }
       const { CACHE_DYNAMO_TABLE, NEXT_BUILD_ID } = process.env;
+      const store = globalThis.__openNextAls.getStore();
+      const cache = store?.requestCache.getOrCreate<string, string[]>("dynamoDb:getByPath");
+      if (cache?.has(path)) {
+        return cache.get(path)!;
+      }
       const result = await awsFetch(
         JSON.stringify({
           TableName: CACHE_DYNAMO_TABLE,
@@ -109,7 +114,9 @@ const tagCache: TagCache = {
       const tags = Items?.map((item: any) => item.tag.S ?? "") ?? [];
       debug("tags for path", path, tags);
       // We need to remove the buildId from the path
-      return tags.map((tag: string) => tag.replace(`${NEXT_BUILD_ID}/`, ""));
+      const resultTags = tags.map((tag: string) => tag.replace(`${NEXT_BUILD_ID}/`, ""));
+      cache?.set(path, resultTags);
+      return resultTags;
     } catch (e) {
       error("Failed to get tags by path", e);
       return [];
@@ -121,6 +128,11 @@ const tagCache: TagCache = {
         return [];
       }
       const { CACHE_DYNAMO_TABLE, NEXT_BUILD_ID } = process.env;
+      const store = globalThis.__openNextAls.getStore();
+      const cache = store?.requestCache.getOrCreate<string, string[]>("dynamoDb:getByTag");
+      if (cache?.has(tag)) {
+        return cache.get(tag)!;
+      }
       const result = await awsFetch(
         JSON.stringify({
           TableName: CACHE_DYNAMO_TABLE,
@@ -137,13 +149,14 @@ const tagCache: TagCache = {
         throw new RecoverableError(`Failed to get by tag: ${result.status}`);
       }
       const { Items } = (await result.json()) as any;
-      return (
-        // We need to remove the buildId from the path
+      // We need to remove the buildId from the path
+      const paths =
         Items?.map(
           ({ path: { S: key } }: any) =>
             key?.replace(`${NEXT_BUILD_ID}/`, "") ?? "",
-        ) ?? []
-      );
+        ) ?? [];
+      cache?.set(tag, paths);
+      return paths;
     } catch (e) {
       error("Failed to get by tag", e);
       return [];
@@ -155,6 +168,12 @@ const tagCache: TagCache = {
         return lastModified ?? Date.now();
       }
       const { CACHE_DYNAMO_TABLE } = process.env;
+      const store = globalThis.__openNextAls.getStore();
+      const cache = store?.requestCache.getOrCreate<string, number>("dynamoDb:getLastModified");
+      const cacheKey = `${key}:${lastModified ?? 0}`;
+      if (cache?.has(cacheKey)) {
+        return cache.get(cacheKey)!;
+      }
       const result = await awsFetch(
         JSON.stringify({
           TableName: CACHE_DYNAMO_TABLE,
@@ -201,9 +220,12 @@ const tagCache: TagCache = {
         return true;
       });
       // If we have revalidated tags or expired tags we return -1 to force revalidation
-      return nonExpiredRevalidatedTags.length > 0 || hasExpiredTag
-        ? -1
-        : (lastModified ?? Date.now());
+      const resultValue =
+        nonExpiredRevalidatedTags.length > 0 || hasExpiredTag
+          ? -1
+          : (lastModified ?? Date.now());
+      cache?.set(cacheKey, resultValue);
+      return resultValue;
     } catch (e) {
       error("Failed to get revalidated tags", e);
       return lastModified ?? Date.now();
@@ -215,31 +237,40 @@ const tagCache: TagCache = {
         return false;
       }
       const { CACHE_DYNAMO_TABLE } = process.env;
-      // We can reuse the same query as getLastModified since it already checks for revalidatedAt > lastModified as revalidatedAt and stale have the same value
-      const result = await awsFetch(
-        JSON.stringify({
-          TableName: CACHE_DYNAMO_TABLE,
-          IndexName: "revalidate",
-          KeyConditionExpression:
-            "#key = :key AND #revalidatedAt > :lastModified",
-          ExpressionAttributeNames: {
-            "#key": "path",
-            "#revalidatedAt": "revalidatedAt",
-          },
-          ExpressionAttributeValues: {
-            ":key": { S: buildDynamoKey(key) },
-            ":lastModified": { N: String(lastModified ?? 0) },
-          },
-        }),
-      );
-      if (result.status !== 200) {
-        throw new RecoverableError(
-          `Failed to check stale tags: ${result.status}`,
+      const store = globalThis.__openNextAls.getStore();
+      const itemsCache = store?.requestCache.getOrCreate<string, any[]>("dynamoDb:revalidateQueryItems");
+      const cacheKey = `${key}:${lastModified ?? 0}`;
+      let items: any[];
+      if (itemsCache?.has(cacheKey)) {
+        items = itemsCache.get(cacheKey)!;
+      } else {
+        // We can reuse the same query as getLastModified since it already checks for revalidatedAt > lastModified as revalidatedAt and stale have the same value
+        const result = await awsFetch(
+          JSON.stringify({
+            TableName: CACHE_DYNAMO_TABLE,
+            IndexName: "revalidate",
+            KeyConditionExpression:
+              "#key = :key AND #revalidatedAt > :lastModified",
+            ExpressionAttributeNames: {
+              "#key": "path",
+              "#revalidatedAt": "revalidatedAt",
+            },
+            ExpressionAttributeValues: {
+              ":key": { S: buildDynamoKey(key) },
+              ":lastModified": { N: String(lastModified ?? 0) },
+            },
+          }),
         );
+        if (result.status !== 200) {
+          throw new RecoverableError(
+            `Failed to check stale tags: ${result.status}`,
+          );
+        }
+        items = ((await result.json()) as any).Items ?? [];
+        itemsCache?.set(cacheKey, items);
       }
-      const { Items } = (await result.json()) as any;
-      debug("hasBeenStale items", path, Items);
-      return (Items?.length ?? 0) > 0;
+      debug("hasBeenStale items", key, items);
+      return items.length > 0;
     } catch (e) {
       error("Failed to check stale tags", e);
       return false;

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -181,6 +181,7 @@ const tagCache: TagCache = {
 
       // Check if any tag has expired
       const now = Date.now();
+
       const hasExpiredTag = revalidatedTags.some((item: any) => {
         if (item.expiry?.N) {
           const expiry = Number.parseInt(item.expiry.N);
@@ -188,9 +189,16 @@ const tagCache: TagCache = {
         }
         return false;
       });
-
+      // Exclude expired tags from the revalidated count — they are handled
+      // separately via hasExpiredTag above.
+      const nonExpiredRevalidatedTags = revalidatedTags.filter((item: any) => {
+        if (item.expiry?.N) {
+          return Number.parseInt(item.expiry.N) === Number.parseInt(item.revalidatedAt.N);
+        }
+        return true;
+      });
       // If we have revalidated tags or expired tags we return -1 to force revalidation
-      return revalidatedTags.length > 0 || hasExpiredTag
+      return nonExpiredRevalidatedTags.length > 0 || hasExpiredTag
         ? -1
         : (lastModified ?? Date.now());
     } catch (e) {
@@ -198,42 +206,37 @@ const tagCache: TagCache = {
       return lastModified ?? Date.now();
     }
   },
-  async hasBeenStale(tags: string[], lastModified?: number) {
+  async hasBeenStale(key: string, lastModified?: number) {
     try {
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {
         return false;
       }
       const { CACHE_DYNAMO_TABLE } = process.env;
-      // For each tag, query entries directly by tag (primary key) and check
-      // if any have a stale timestamp newer than lastModified
-      const results = await Promise.all(
-        tags.map(async (tag) => {
-          const result = await awsFetch(
-            JSON.stringify({
-              TableName: CACHE_DYNAMO_TABLE,
-              KeyConditionExpression: "#tag = :tag",
-              ExpressionAttributeNames: { "#tag": "tag" },
-              ExpressionAttributeValues: {
-                ":tag": { S: buildDynamoKey(tag) },
-              },
-            }),
-          );
-          if (result.status !== 200) {
-            throw new RecoverableError(
-              `Failed to check stale tags: ${result.status}`,
-            );
-          }
-          return ((await result.json()) as any).Items ?? [];
+      // We can reuse the same query as getLastModified since it already checks for revalidatedAt > lastModified as revalidatedAt and stale have the same value
+      const result = await awsFetch(
+        JSON.stringify({
+          TableName: CACHE_DYNAMO_TABLE,
+          IndexName: "revalidate",
+          KeyConditionExpression:
+            "#key = :key AND #revalidatedAt > :lastModified",
+          ExpressionAttributeNames: {
+            "#key": "path",
+            "#revalidatedAt": "revalidatedAt",
+          },
+          ExpressionAttributeValues: {
+            ":key": { S: buildDynamoKey(key) },
+            ":lastModified": { N: String(lastModified ?? 0) },
+          },
         }),
       );
-      return results.some((items: any[]) =>
-        items.some((item: any) => {
-          if (item.stale?.N) {
-            return Number.parseInt(item.stale.N) > (lastModified ?? 0);
-          }
-          return false;
-        }),
-      );
+      if (result.status !== 200) {
+        throw new RecoverableError(
+          `Failed to check stale tags: ${result.status}`,
+        );
+      }
+      const { Items } = (await result.json()) as any;
+      debug("hasBeenStale items", path, Items);
+      return (Items?.length ?? 0) > 0;
     } catch (e) {
       error("Failed to check stale tags", e);
       return false;

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -57,12 +57,25 @@ function buildDynamoKey(key: string) {
   return path.posix.join(NEXT_BUILD_ID ?? "", key);
 }
 
-function buildDynamoObject(path: string, tags: string, revalidatedAt?: number) {
-  return {
+function buildDynamoObject(
+  path: string,
+  tags: string,
+  revalidatedAt?: number,
+  stale?: number,
+  expiry?: number,
+) {
+  const obj: Record<string, any> = {
     path: { S: buildDynamoKey(path) },
     tag: { S: buildDynamoKey(tags) },
     revalidatedAt: { N: `${revalidatedAt ?? Date.now()}` },
   };
+  if (stale !== undefined) {
+    obj.stale = { N: `${stale}` };
+  }
+  if (expiry !== undefined) {
+    obj.expiry = { N: `${expiry}` };
+  }
+  return obj;
 }
 
 const tagCache: TagCache = {
@@ -184,7 +197,13 @@ const tagCache: TagCache = {
             [CACHE_DYNAMO_TABLE ?? ""]: Items.map((Item) => ({
               PutRequest: {
                 Item: {
-                  ...buildDynamoObject(Item.path, Item.tag, Item.revalidatedAt),
+                  ...buildDynamoObject(
+                    Item.path,
+                    Item.tag,
+                    Item.revalidatedAt,
+                    Item.stale,
+                    Item.expiry,
+                  ),
                 },
               },
             })),

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -235,7 +235,7 @@ const tagCache: TagCache = {
       return lastModified ?? Date.now();
     }
   },
-  async hasBeenStale(key: string, lastModified?: number) {
+  async isStale(key: string, lastModified?: number) {
     try {
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {
         return false;
@@ -275,7 +275,7 @@ const tagCache: TagCache = {
         items = ((await result.json()) as any).Items ?? [];
         itemsCache?.set(cacheKey, items);
       }
-      debug("hasBeenStale items", key, items);
+      debug("isStale items", key, items);
       return items.length > 0;
     } catch (e) {
       error("Failed to check stale tags", e);

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -62,19 +62,16 @@ function buildDynamoObject(
   tags: string,
   revalidatedAt?: number,
   stale?: number,
-  expiry?: number,
+  expire?: number,
 ) {
   const obj: Record<string, any> = {
     path: { S: buildDynamoKey(path) },
     tag: { S: buildDynamoKey(tags) },
     revalidatedAt: { N: `${revalidatedAt ?? Date.now()}` },
+    ...(stale !== undefined ? { stale: { N: `${stale}` } } : {}),
+    ...(expire !== undefined ? { expire: { N: `${expire}` } } : {}),
+
   };
-  if (stale !== undefined) {
-    obj.stale = { N: `${stale}` };
-  }
-  if (expiry !== undefined) {
-    obj.expiry = { N: `${expiry}` };
-  }
   return obj;
 }
 
@@ -210,8 +207,8 @@ const tagCache: TagCache = {
       const now = Date.now();
 
       const hasExpiredTag = revalidatedTags.some((item: any) => {
-        if (item.expiry?.N) {
-          const expiry = Number.parseInt(item.expiry.N);
+        if (item.expire?.N) {
+          const expiry = Number.parseInt(item.expire.N);
           return expiry <= now && expiry > (lastModified ?? 0);
         }
         return false;
@@ -219,9 +216,9 @@ const tagCache: TagCache = {
       // Exclude expired tags from the revalidated count — they are handled
       // separately via hasExpiredTag above.
       const nonExpiredRevalidatedTags = revalidatedTags.filter((item: any) => {
-        if (item.expiry?.N) {
+        if (item.expire?.N) {
           return (
-            Number.parseInt(item.expiry.N) ===
+            Number.parseInt(item.expire.N) ===
             Number.parseInt(item.revalidatedAt.N)
           );
         }
@@ -303,7 +300,7 @@ const tagCache: TagCache = {
                     Item.tag,
                     Item.revalidatedAt,
                     Item.stale,
-                    Item.expiry,
+                    Item.expire,
                   ),
                 },
               },

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -193,7 +193,10 @@ const tagCache: TagCache = {
       // separately via hasExpiredTag above.
       const nonExpiredRevalidatedTags = revalidatedTags.filter((item: any) => {
         if (item.expiry?.N) {
-          return Number.parseInt(item.expiry.N) === Number.parseInt(item.revalidatedAt.N);
+          return (
+            Number.parseInt(item.expiry.N) ===
+            Number.parseInt(item.revalidatedAt.N)
+          );
         }
         return true;
       });

--- a/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
@@ -117,14 +117,25 @@ export default {
         `Failed to query dynamo item: ${response.status}`,
       );
     }
-    // Now we need to check for every item if lastModified is greater than the revalidatedAt
+    // Now we need to check for every item if they have expired or been revalidated
     const { Responses } = await response.json();
     if (!Responses) {
       return false;
     }
+    const now = Date.now();
     const revalidatedTags = Responses[CACHE_DYNAMO_TABLE ?? ""].filter(
-      (item: any) =>
-        Number.parseInt(item.revalidatedAt.N) > (lastModified ?? 0),
+      (item: any) => {
+        // Check if tag has expired
+        if (item.expiry?.N) {
+          const expiry = Number.parseInt(item.expiry.N);
+          const isExpired = expiry <= now && expiry > (lastModified ?? 0);
+          if (isExpired) {
+            return true;
+          }
+        }
+        // Check if tag has been revalidated
+        return Number.parseInt(item.revalidatedAt.N) > (lastModified ?? 0);
+      },
     );
     debug("retrieved tags", revalidatedTags);
     return revalidatedTags.length > 0;

--- a/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
@@ -190,7 +190,7 @@ export default {
     debug("retrieved tags for hasBeenRevalidated", tags);
     return result;
   },
-  hasBeenStale: async (tags: string[], lastModified?: number) => {
+  isStale: async (tags: string[], lastModified?: number) => {
     if (globalThis.openNextConfig.dangerous?.disableTagCache) {
       return false;
     }
@@ -220,7 +220,7 @@ export default {
     if (uncachedTags.length === 0) return false;
 
     const result = await fetchAndCacheItems(uncachedTags, itemsCache, compute);
-    debug("hasBeenStale result:", result);
+    debug("isStale result:", result);
     return result;
   },
   writeTags: async (tags) => {

--- a/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
@@ -140,6 +140,48 @@ export default {
     debug("retrieved tags", revalidatedTags);
     return revalidatedTags.length > 0;
   },
+  hasBeenStale: async (tags: string[], lastModified?: number) => {
+    if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+      return false;
+    }
+    if (tags.length === 0) return false;
+    if (tags.length > 100) {
+      throw new RecoverableError(
+        "Cannot query more than 100 tags at once. You should not be using this tagCache implementation for this amount of tags",
+      );
+    }
+    const { CACHE_DYNAMO_TABLE } = process.env;
+    const response = await awsFetch(
+      JSON.stringify({
+        RequestItems: {
+          [CACHE_DYNAMO_TABLE ?? ""]: {
+            Keys: tags.map((tag) => ({
+              path: { S: buildDynamoKey(tag) },
+              tag: { S: buildDynamoKey(tag) },
+            })),
+          },
+        },
+      }),
+      "query",
+    );
+    if (response.status !== 200) {
+      throw new RecoverableError(
+        `Failed to query dynamo item: ${response.status}`,
+      );
+    }
+    const { Responses } = await response.json();
+    if (!Responses) return false;
+    const hasStaleTag = Responses[CACHE_DYNAMO_TABLE ?? ""].some(
+      (item: any) => {
+        if (item.stale?.N) {
+          return Number.parseInt(item.stale.N) > (lastModified ?? 0);
+        }
+        return false;
+      },
+    );
+    debug("hasBeenStale result:", hasStaleTag);
+    return hasStaleTag;
+  },
   writeTags: async (tags) => {
     try {
       const { CACHE_DYNAMO_TABLE } = process.env;

--- a/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
@@ -63,19 +63,15 @@ function buildDynamoObject(
   tag: string,
   revalidatedAt?: number,
   stale?: number,
-  expiry?: number,
+  expire?: number,
 ) {
   const obj: Record<string, any> = {
     path: { S: buildDynamoKey(tag) },
     tag: { S: buildDynamoKey(tag) },
     revalidatedAt: { N: `${revalidatedAt ?? Date.now()}` },
+    ...(stale !== undefined ? { stale: { N: `${stale}` } } : {}),
+    ...(expire !== undefined ? { expire: { N: `${expire}` } } : {}),
   };
-  if (stale !== undefined) {
-    obj.stale = { N: `${stale}` };
-  }
-  if (expiry !== undefined) {
-    obj.expiry = { N: `${expiry}` };
-  }
   return obj;
 }
 
@@ -173,8 +169,8 @@ export default {
     const now = Date.now();
     const compute = (item: any): boolean => {
       if (!item) return false;
-      if (item.expiry?.N) {
-        const expiry = Number.parseInt(item.expiry.N);
+      if (item.expire?.N) {
+        const expiry = Number.parseInt(item.expire.N);
         if (expiry <= now && expiry > (lastModified ?? 0)) return true;
       }
       return Number.parseInt(item.revalidatedAt.N) > (lastModified ?? 0);
@@ -239,7 +235,7 @@ export default {
             [CACHE_DYNAMO_TABLE ?? ""]: Items.map((tag) => {
               const tagStr = typeof tag === "string" ? tag : tag.tag;
               const stale = typeof tag === "string" ? undefined : tag.stale;
-              const expiry = typeof tag === "string" ? undefined : tag.expiry;
+              const expiry = typeof tag === "string" ? undefined : tag.expire;
               return {
                 PutRequest: {
                   Item: {

--- a/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
@@ -180,7 +180,11 @@ export default {
       return Number.parseInt(item.revalidatedAt.N) > (lastModified ?? 0);
     };
 
-    const { uncachedTags, hasMatch } = checkItemsCache(tags, itemsCache, compute);
+    const { uncachedTags, hasMatch } = checkItemsCache(
+      tags,
+      itemsCache,
+      compute,
+    );
     if (hasMatch) return true;
     if (uncachedTags.length === 0) return false;
 
@@ -211,7 +215,11 @@ export default {
       return Number.parseInt(item.stale.N) > (lastModified ?? 0);
     };
 
-    const { uncachedTags, hasMatch } = checkItemsCache(tags, itemsCache, compute);
+    const { uncachedTags, hasMatch } = checkItemsCache(
+      tags,
+      itemsCache,
+      compute,
+    );
     if (hasMatch) return true;
     if (uncachedTags.length === 0) return false;
 

--- a/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
@@ -59,12 +59,24 @@ function buildDynamoKey(key: string) {
 // We use the same key for both path and tag
 // That's mostly for compatibility reason so that it's easier to use this with existing infra
 // FIXME: Allow a simpler object without an unnecessary path key
-function buildDynamoObject(tag: string, revalidatedAt?: number) {
-  return {
+function buildDynamoObject(
+  tag: string,
+  revalidatedAt?: number,
+  stale?: number,
+  expiry?: number,
+) {
+  const obj: Record<string, any> = {
     path: { S: buildDynamoKey(tag) },
     tag: { S: buildDynamoKey(tag) },
     revalidatedAt: { N: `${revalidatedAt ?? Date.now()}` },
   };
+  if (stale !== undefined) {
+    obj.stale = { N: `${stale}` };
+  }
+  if (expiry !== undefined) {
+    obj.expiry = { N: `${expiry}` };
+  }
+  return obj;
 }
 
 // This implementation does not support automatic invalidation of paths by the cdn
@@ -117,7 +129,7 @@ export default {
     debug("retrieved tags", revalidatedTags);
     return revalidatedTags.length > 0;
   },
-  writeTags: async (tags: string[]) => {
+  writeTags: async (tags) => {
     try {
       const { CACHE_DYNAMO_TABLE } = process.env;
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {
@@ -126,13 +138,18 @@ export default {
       const dataChunks = chunk(tags, MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT).map(
         (Items) => ({
           RequestItems: {
-            [CACHE_DYNAMO_TABLE ?? ""]: Items.map((tag) => ({
-              PutRequest: {
-                Item: {
-                  ...buildDynamoObject(tag),
+            [CACHE_DYNAMO_TABLE ?? ""]: Items.map((tag) => {
+              const tagStr = typeof tag === "string" ? tag : tag.tag;
+              const stale = typeof tag === "string" ? undefined : tag.stale;
+              const expiry = typeof tag === "string" ? undefined : tag.expiry;
+              return {
+                PutRequest: {
+                  Item: {
+                    ...buildDynamoObject(tagStr, undefined, stale, expiry),
+                  },
                 },
-              },
-            })),
+              };
+            }),
           },
         }),
       );

--- a/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
@@ -80,6 +80,74 @@ function buildDynamoObject(
 }
 
 // This implementation does not support automatic invalidation of paths by the cdn
+
+/**
+ * Checks the items cache for each tag. Returns tags not yet cached and whether
+ * a positive result was already found among the cached ones.
+ */
+function checkItemsCache(
+  tags: string[],
+  itemsCache: Map<string, any> | undefined,
+  compute: (item: any) => boolean,
+): { uncachedTags: string[]; hasMatch: boolean } {
+  const uncachedTags: string[] = [];
+  let hasMatch = false;
+  for (const tag of tags) {
+    if (itemsCache?.has(tag)) {
+      if (compute(itemsCache.get(tag))) hasMatch = true;
+    } else {
+      uncachedTags.push(tag);
+    }
+  }
+  return { uncachedTags, hasMatch };
+}
+
+/**
+ * Fetches uncached tags from DynamoDB via BatchGetItem, populates the items
+ * cache (storing null for absent tags), and returns whether any tag matched.
+ */
+async function fetchAndCacheItems(
+  uncachedTags: string[],
+  itemsCache: Map<string, any> | undefined,
+  compute: (item: any) => boolean,
+): Promise<boolean> {
+  const { CACHE_DYNAMO_TABLE } = process.env;
+  const response = await awsFetch(
+    JSON.stringify({
+      RequestItems: {
+        [CACHE_DYNAMO_TABLE ?? ""]: {
+          Keys: uncachedTags.map((tag) => ({
+            path: { S: buildDynamoKey(tag) },
+            tag: { S: buildDynamoKey(tag) },
+          })),
+        },
+      },
+    }),
+    "query",
+  );
+  if (response.status !== 200) {
+    throw new RecoverableError(
+      `Failed to query dynamo item: ${response.status}`,
+    );
+  }
+  const { Responses } = await response.json();
+  const responseItems: any[] = Responses?.[CACHE_DYNAMO_TABLE ?? ""] ?? [];
+
+  // Build a lookup map: DynamoDB key → item
+  const responseByKey = new Map<string, any>();
+  for (const item of responseItems) {
+    responseByKey.set(item.tag.S, item);
+  }
+
+  let hasMatch = false;
+  for (const tag of uncachedTags) {
+    const item = responseByKey.get(buildDynamoKey(tag)) ?? null;
+    itemsCache?.set(tag, item);
+    if (compute(item)) hasMatch = true;
+  }
+  return hasMatch;
+}
+
 export default {
   name: "ddb-nextMode",
   mode: "nextMode",
@@ -96,49 +164,31 @@ export default {
         "Cannot query more than 100 tags at once. You should not be using this tagCache implementation for this amount of tags",
       );
     }
-    const { CACHE_DYNAMO_TABLE } = process.env;
+
+    const store = globalThis.__openNextAls.getStore();
+    const itemsCache = store?.requestCache.getOrCreate<string, any>(
+      "ddb-nextMode:tagItems",
+    );
+
+    const now = Date.now();
+    const compute = (item: any): boolean => {
+      if (!item) return false;
+      if (item.expiry?.N) {
+        const expiry = Number.parseInt(item.expiry.N);
+        if (expiry <= now && expiry > (lastModified ?? 0)) return true;
+      }
+      return Number.parseInt(item.revalidatedAt.N) > (lastModified ?? 0);
+    };
+
+    const { uncachedTags, hasMatch } = checkItemsCache(tags, itemsCache, compute);
+    if (hasMatch) return true;
+    if (uncachedTags.length === 0) return false;
+
     // It's unlikely that we will have more than 100 items to query
     // If that's the case, you should not use this tagCache implementation
-    const response = await awsFetch(
-      JSON.stringify({
-        RequestItems: {
-          [CACHE_DYNAMO_TABLE ?? ""]: {
-            Keys: tags.map((tag) => ({
-              path: { S: buildDynamoKey(tag) },
-              tag: { S: buildDynamoKey(tag) },
-            })),
-          },
-        },
-      }),
-      "query",
-    );
-    if (response.status !== 200) {
-      throw new RecoverableError(
-        `Failed to query dynamo item: ${response.status}`,
-      );
-    }
-    // Now we need to check for every item if they have expired or been revalidated
-    const { Responses } = await response.json();
-    if (!Responses) {
-      return false;
-    }
-    const now = Date.now();
-    const revalidatedTags = Responses[CACHE_DYNAMO_TABLE ?? ""].filter(
-      (item: any) => {
-        // Check if tag has expired
-        if (item.expiry?.N) {
-          const expiry = Number.parseInt(item.expiry.N);
-          const isExpired = expiry <= now && expiry > (lastModified ?? 0);
-          if (isExpired) {
-            return true;
-          }
-        }
-        // Check if tag has been revalidated
-        return Number.parseInt(item.revalidatedAt.N) > (lastModified ?? 0);
-      },
-    );
-    debug("retrieved tags", revalidatedTags);
-    return revalidatedTags.length > 0;
+    const result = await fetchAndCacheItems(uncachedTags, itemsCache, compute);
+    debug("retrieved tags for hasBeenRevalidated", tags);
+    return result;
   },
   hasBeenStale: async (tags: string[], lastModified?: number) => {
     if (globalThis.openNextConfig.dangerous?.disableTagCache) {
@@ -150,37 +200,24 @@ export default {
         "Cannot query more than 100 tags at once. You should not be using this tagCache implementation for this amount of tags",
       );
     }
-    const { CACHE_DYNAMO_TABLE } = process.env;
-    const response = await awsFetch(
-      JSON.stringify({
-        RequestItems: {
-          [CACHE_DYNAMO_TABLE ?? ""]: {
-            Keys: tags.map((tag) => ({
-              path: { S: buildDynamoKey(tag) },
-              tag: { S: buildDynamoKey(tag) },
-            })),
-          },
-        },
-      }),
-      "query",
+
+    const store = globalThis.__openNextAls.getStore();
+    const itemsCache = store?.requestCache.getOrCreate<string, any>(
+      "ddb-nextMode:tagItems",
     );
-    if (response.status !== 200) {
-      throw new RecoverableError(
-        `Failed to query dynamo item: ${response.status}`,
-      );
-    }
-    const { Responses } = await response.json();
-    if (!Responses) return false;
-    const hasStaleTag = Responses[CACHE_DYNAMO_TABLE ?? ""].some(
-      (item: any) => {
-        if (item.stale?.N) {
-          return Number.parseInt(item.stale.N) > (lastModified ?? 0);
-        }
-        return false;
-      },
-    );
-    debug("hasBeenStale result:", hasStaleTag);
-    return hasStaleTag;
+
+    const compute = (item: any): boolean => {
+      if (!item?.stale?.N) return false;
+      return Number.parseInt(item.stale.N) > (lastModified ?? 0);
+    };
+
+    const { uncachedTags, hasMatch } = checkItemsCache(tags, itemsCache, compute);
+    if (hasMatch) return true;
+    if (uncachedTags.length === 0) return false;
+
+    const result = await fetchAndCacheItems(uncachedTags, itemsCache, compute);
+    debug("hasBeenStale result:", result);
+    return result;
   },
   writeTags: async (tags) => {
     try {

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -61,6 +61,11 @@ const tagCache: TagCache = {
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {
         return [];
       }
+      const store = globalThis.__openNextAls.getStore();
+      const cache = store?.requestCache.getOrCreate<string, string[]>("dynamoDb:getByPath");
+      if (cache?.has(path)) {
+        return cache.get(path)!;
+      }
       const result = await dynamoClient.send(
         new QueryCommand({
           TableName: CACHE_DYNAMO_TABLE,
@@ -77,7 +82,9 @@ const tagCache: TagCache = {
       const tags = result.Items?.map((item) => item.tag.S ?? "") ?? [];
       debug("tags for path", path, tags);
       // We need to remove the buildId from the path
-      return tags.map((tag) => tag.replace(`${NEXT_BUILD_ID}/`, ""));
+      const resultTags = tags.map((tag) => tag.replace(`${NEXT_BUILD_ID}/`, ""));
+      cache?.set(path, resultTags);
+      return resultTags;
     } catch (e) {
       error("Failed to get tags by path", e);
       return [];
@@ -87,6 +94,11 @@ const tagCache: TagCache = {
     try {
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {
         return [];
+      }
+      const store = globalThis.__openNextAls.getStore();
+      const cache = store?.requestCache.getOrCreate<string, string[]>("dynamoDb:getByTag");
+      if (cache?.has(tag)) {
+        return cache.get(tag)!;
       }
       const { Items } = await dynamoClient.send(
         new QueryCommand({
@@ -100,12 +112,13 @@ const tagCache: TagCache = {
           },
         }),
       );
-      return (
-        // We need to remove the buildId from the path
+      // We need to remove the buildId from the path
+      const paths =
         Items?.map(
           ({ path: { S: key } }) => key?.replace(`${NEXT_BUILD_ID}/`, "") ?? "",
-        ) ?? []
-      );
+        ) ?? [];
+      cache?.set(tag, paths);
+      return paths;
     } catch (e) {
       error("Failed to get by tag", e);
       return [];
@@ -116,23 +129,32 @@ const tagCache: TagCache = {
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {
         return lastModified ?? Date.now();
       }
-      const result = await dynamoClient.send(
-        new QueryCommand({
-          TableName: CACHE_DYNAMO_TABLE,
-          IndexName: "revalidate",
-          KeyConditionExpression:
-            "#key = :key AND #revalidatedAt > :lastModified",
-          ExpressionAttributeNames: {
-            "#key": "path",
-            "#revalidatedAt": "revalidatedAt",
-          },
-          ExpressionAttributeValues: {
-            ":key": { S: buildDynamoKey(key) },
-            ":lastModified": { N: String(lastModified ?? 0) },
-          },
-        }),
-      );
-      const revalidatedTags = result.Items ?? [];
+      const store = globalThis.__openNextAls.getStore();
+      const itemsCache = store?.requestCache.getOrCreate<string, any[]>("dynamoDb:revalidateQueryItems");
+      const cacheKey = `${key}:${lastModified ?? 0}`;
+      let revalidatedTags: any[];
+      if (itemsCache?.has(cacheKey)) {
+        revalidatedTags = itemsCache.get(cacheKey)!;
+      } else {
+        const result = await dynamoClient.send(
+          new QueryCommand({
+            TableName: CACHE_DYNAMO_TABLE,
+            IndexName: "revalidate",
+            KeyConditionExpression:
+              "#key = :key AND #revalidatedAt > :lastModified",
+            ExpressionAttributeNames: {
+              "#key": "path",
+              "#revalidatedAt": "revalidatedAt",
+            },
+            ExpressionAttributeValues: {
+              ":key": { S: buildDynamoKey(key) },
+              ":lastModified": { N: String(lastModified ?? 0) },
+            },
+          }),
+        );
+        revalidatedTags = result.Items ?? [];
+        itemsCache?.set(cacheKey, revalidatedTags);
+      }
       debug("revalidatedTags", revalidatedTags);
 
       // Check if any tag has expired
@@ -167,24 +189,34 @@ const tagCache: TagCache = {
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {
         return false;
       }
-      const result = await dynamoClient.send(
-        new QueryCommand({
-          TableName: CACHE_DYNAMO_TABLE,
-          IndexName: "revalidate",
-          KeyConditionExpression:
-            "#key = :key AND #revalidatedAt > :lastModified",
-          ExpressionAttributeNames: {
-            "#key": "path",
-            "#revalidatedAt": "revalidatedAt",
-          },
-          ExpressionAttributeValues: {
-            ":key": { S: buildDynamoKey(key) },
-            ":lastModified": { N: String(lastModified ?? 0) },
-          },
-        }),
-      );
-      debug("hasBeenStale items", key, result.Items);
-      return (result.Items?.length ?? 0) > 0;
+      const store = globalThis.__openNextAls.getStore();
+      const itemsCache = store?.requestCache.getOrCreate<string, any[]>("dynamoDb:revalidateQueryItems");
+      const cacheKey = `${key}:${lastModified ?? 0}`;
+      let items: any[];
+      if (itemsCache?.has(cacheKey)) {
+        items = itemsCache.get(cacheKey)!;
+      } else {
+        const result = await dynamoClient.send(
+          new QueryCommand({
+            TableName: CACHE_DYNAMO_TABLE,
+            IndexName: "revalidate",
+            KeyConditionExpression:
+              "#key = :key AND #revalidatedAt > :lastModified",
+            ExpressionAttributeNames: {
+              "#key": "path",
+              "#revalidatedAt": "revalidatedAt",
+            },
+            ExpressionAttributeValues: {
+              ":key": { S: buildDynamoKey(key) },
+              ":lastModified": { N: String(lastModified ?? 0) },
+            },
+          }),
+        );
+        items = result.Items ?? [];
+        itemsCache?.set(cacheKey, items);
+      }
+      debug("hasBeenStale items", key, items);
+      return items.length > 0;
     } catch (e) {
       error("Failed to check stale tags", e);
       return false;

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -33,12 +33,25 @@ function buildDynamoKey(key: string) {
   return path.posix.join(NEXT_BUILD_ID ?? "", key);
 }
 
-function buildDynamoObject(path: string, tags: string, revalidatedAt?: number) {
-  return {
+function buildDynamoObject(
+  path: string,
+  tags: string,
+  revalidatedAt?: number,
+  stale?: number,
+  expiry?: number,
+) {
+  const obj: Record<string, any> = {
     path: { S: buildDynamoKey(path) },
     tag: { S: buildDynamoKey(tags) },
     revalidatedAt: { N: `${revalidatedAt ?? Date.now()}` },
   };
+  if (stale !== undefined) {
+    obj.stale = { N: `${stale}` };
+  }
+  if (expiry !== undefined) {
+    obj.expiry = { N: `${expiry}` };
+  }
+  return obj;
 }
 
 const tagCache: TagCache = {
@@ -139,7 +152,13 @@ const tagCache: TagCache = {
             [CACHE_DYNAMO_TABLE ?? ""]: Items.map((Item) => ({
               PutRequest: {
                 Item: {
-                  ...buildDynamoObject(Item.path, Item.tag, Item.revalidatedAt),
+                  ...buildDynamoObject(
+                    Item.path,
+                    Item.tag,
+                    Item.revalidatedAt,
+                    Item.stale,
+                    Item.expiry,
+                  ),
                 },
               },
             })),

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -134,7 +134,7 @@ const tagCache: TagCache = {
       );
       const revalidatedTags = result.Items ?? [];
       debug("revalidatedTags", revalidatedTags);
-      
+
       // Check if any tag has expired
       const now = Date.now();
       const hasExpiredTag = revalidatedTags.some((item) => {
@@ -144,9 +144,11 @@ const tagCache: TagCache = {
         }
         return false;
       });
-      
+
       // If we have revalidated tags or expired tags we return -1 to force revalidation
-      return revalidatedTags.length > 0 || hasExpiredTag ? -1 : (lastModified ?? Date.now());
+      return revalidatedTags.length > 0 || hasExpiredTag
+        ? -1
+        : (lastModified ?? Date.now());
     } catch (e) {
       error("Failed to get revalidated tags", e);
       return lastModified ?? Date.now();

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -134,8 +134,19 @@ const tagCache: TagCache = {
       );
       const revalidatedTags = result.Items ?? [];
       debug("revalidatedTags", revalidatedTags);
-      // If we have revalidated tags we return -1 to force revalidation
-      return revalidatedTags.length > 0 ? -1 : (lastModified ?? Date.now());
+      
+      // Check if any tag has expired
+      const now = Date.now();
+      const hasExpiredTag = revalidatedTags.some((item) => {
+        if (item.expiry?.N) {
+          const expiry = Number.parseInt(item.expiry.N);
+          return expiry <= now && expiry > (lastModified ?? 0);
+        }
+        return false;
+      });
+      
+      // If we have revalidated tags or expired tags we return -1 to force revalidation
+      return revalidatedTags.length > 0 || hasExpiredTag ? -1 : (lastModified ?? Date.now());
     } catch (e) {
       error("Failed to get revalidated tags", e);
       return lastModified ?? Date.now();

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -62,7 +62,9 @@ const tagCache: TagCache = {
         return [];
       }
       const store = globalThis.__openNextAls.getStore();
-      const cache = store?.requestCache.getOrCreate<string, string[]>("dynamoDb:getByPath");
+      const cache = store?.requestCache.getOrCreate<string, string[]>(
+        "dynamoDb:getByPath",
+      );
       if (cache?.has(path)) {
         return cache.get(path)!;
       }
@@ -82,7 +84,9 @@ const tagCache: TagCache = {
       const tags = result.Items?.map((item) => item.tag.S ?? "") ?? [];
       debug("tags for path", path, tags);
       // We need to remove the buildId from the path
-      const resultTags = tags.map((tag) => tag.replace(`${NEXT_BUILD_ID}/`, ""));
+      const resultTags = tags.map((tag) =>
+        tag.replace(`${NEXT_BUILD_ID}/`, ""),
+      );
       cache?.set(path, resultTags);
       return resultTags;
     } catch (e) {
@@ -96,7 +100,9 @@ const tagCache: TagCache = {
         return [];
       }
       const store = globalThis.__openNextAls.getStore();
-      const cache = store?.requestCache.getOrCreate<string, string[]>("dynamoDb:getByTag");
+      const cache = store?.requestCache.getOrCreate<string, string[]>(
+        "dynamoDb:getByTag",
+      );
       if (cache?.has(tag)) {
         return cache.get(tag)!;
       }
@@ -130,7 +136,9 @@ const tagCache: TagCache = {
         return lastModified ?? Date.now();
       }
       const store = globalThis.__openNextAls.getStore();
-      const itemsCache = store?.requestCache.getOrCreate<string, any[]>("dynamoDb:revalidateQueryItems");
+      const itemsCache = store?.requestCache.getOrCreate<string, any[]>(
+        "dynamoDb:revalidateQueryItems",
+      );
       const cacheKey = `${key}:${lastModified ?? 0}`;
       let revalidatedTags: any[];
       if (itemsCache?.has(cacheKey)) {
@@ -190,7 +198,9 @@ const tagCache: TagCache = {
         return false;
       }
       const store = globalThis.__openNextAls.getStore();
-      const itemsCache = store?.requestCache.getOrCreate<string, any[]>("dynamoDb:revalidateQueryItems");
+      const itemsCache = store?.requestCache.getOrCreate<string, any[]>(
+        "dynamoDb:revalidateQueryItems",
+      );
       const cacheKey = `${key}:${lastModified ?? 0}`;
       let items: any[];
       if (itemsCache?.has(cacheKey)) {

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -144,9 +144,17 @@ const tagCache: TagCache = {
         }
         return false;
       });
+      // Exclude expired tags from the revalidated count — they are handled
+      // separately via hasExpiredTag above.
+      const nonExpiredRevalidatedTags = revalidatedTags.filter((item) => {
+        if (item.expiry?.N) {
+          return Number.parseInt(item.expiry.N) > now;
+        }
+        return true;
+      });
 
       // If we have revalidated tags or expired tags we return -1 to force revalidation
-      return revalidatedTags.length > 0 || hasExpiredTag
+      return nonExpiredRevalidatedTags.length > 0 || hasExpiredTag
         ? -1
         : (lastModified ?? Date.now());
     } catch (e) {
@@ -154,35 +162,29 @@ const tagCache: TagCache = {
       return lastModified ?? Date.now();
     }
   },
-  async hasBeenStale(tags: string[], lastModified?: number) {
+  async hasBeenStale(key: string, lastModified?: number) {
     try {
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {
         return false;
       }
-      // For each tag, query entries directly by tag (primary key) and check
-      // if any have a stale timestamp newer than lastModified
-      const results = await Promise.all(
-        tags.map((tag) =>
-          dynamoClient.send(
-            new QueryCommand({
-              TableName: CACHE_DYNAMO_TABLE,
-              KeyConditionExpression: "#tag = :tag",
-              ExpressionAttributeNames: { "#tag": "tag" },
-              ExpressionAttributeValues: {
-                ":tag": { S: buildDynamoKey(tag) },
-              },
-            }),
-          ),
-        ),
-      );
-      return results.some((result) =>
-        (result.Items ?? []).some((item) => {
-          if (item.stale?.N) {
-            return Number.parseInt(item.stale.N) > (lastModified ?? 0);
-          }
-          return false;
+      const result = await dynamoClient.send(
+        new QueryCommand({
+          TableName: CACHE_DYNAMO_TABLE,
+          IndexName: "revalidate",
+          KeyConditionExpression:
+            "#key = :key AND #revalidatedAt > :lastModified",
+          ExpressionAttributeNames: {
+            "#key": "path",
+            "#revalidatedAt": "revalidatedAt",
+          },
+          ExpressionAttributeValues: {
+            ":key": { S: buildDynamoKey(key) },
+            ":lastModified": { N: String(lastModified ?? 0) },
+          },
         }),
       );
+      debug("hasBeenStale items", key, result.Items);
+      return (result.Items?.length ?? 0) > 0;
     } catch (e) {
       error("Failed to check stale tags", e);
       return false;

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -152,6 +152,40 @@ const tagCache: TagCache = {
       return lastModified ?? Date.now();
     }
   },
+  async hasBeenStale(tags: string[], lastModified?: number) {
+    try {
+      if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+        return false;
+      }
+      // For each tag, query entries directly by tag (primary key) and check
+      // if any have a stale timestamp newer than lastModified
+      const results = await Promise.all(
+        tags.map((tag) =>
+          dynamoClient.send(
+            new QueryCommand({
+              TableName: CACHE_DYNAMO_TABLE,
+              KeyConditionExpression: "#tag = :tag",
+              ExpressionAttributeNames: { "#tag": "tag" },
+              ExpressionAttributeValues: {
+                ":tag": { S: buildDynamoKey(tag) },
+              },
+            }),
+          ),
+        ),
+      );
+      return results.some((result) =>
+        (result.Items ?? []).some((item) => {
+          if (item.stale?.N) {
+            return Number.parseInt(item.stale.N) > (lastModified ?? 0);
+          }
+          return false;
+        }),
+      );
+    } catch (e) {
+      error("Failed to check stale tags", e);
+      return false;
+    }
+  },
   async writeTags(tags) {
     try {
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -188,7 +188,7 @@ const tagCache: TagCache = {
       return lastModified ?? Date.now();
     }
   },
-  async hasBeenStale(key: string, lastModified?: number) {
+  async isStale(key: string, lastModified?: number) {
     try {
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {
         return false;
@@ -221,7 +221,7 @@ const tagCache: TagCache = {
         items = result.Items ?? [];
         itemsCache?.set(cacheKey, items);
       }
-      debug("hasBeenStale items", key, items);
+      debug("isStale items", key, items);
       return items.length > 0;
     } catch (e) {
       error("Failed to check stale tags", e);

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -38,19 +38,15 @@ function buildDynamoObject(
   tags: string,
   revalidatedAt?: number,
   stale?: number,
-  expiry?: number,
+  expire?: number,
 ) {
   const obj: Record<string, any> = {
     path: { S: buildDynamoKey(path) },
     tag: { S: buildDynamoKey(tags) },
     revalidatedAt: { N: `${revalidatedAt ?? Date.now()}` },
+    ...(stale !== undefined ? { stale: { N: `${stale}` } } : {}),
+    ...(expire !== undefined ? { expire: { N: `${expire}` } } : {}),
   };
-  if (stale !== undefined) {
-    obj.stale = { N: `${stale}` };
-  }
-  if (expiry !== undefined) {
-    obj.expiry = { N: `${expiry}` };
-  }
   return obj;
 }
 
@@ -168,8 +164,8 @@ const tagCache: TagCache = {
       // Check if any tag has expired
       const now = Date.now();
       const hasExpiredTag = revalidatedTags.some((item) => {
-        if (item.expiry?.N) {
-          const expiry = Number.parseInt(item.expiry.N);
+        if (item.expire?.N) {
+          const expiry = Number.parseInt(item.expire.N);
           return expiry <= now && expiry > (lastModified ?? 0);
         }
         return false;
@@ -177,8 +173,8 @@ const tagCache: TagCache = {
       // Exclude expired tags from the revalidated count — they are handled
       // separately via hasExpiredTag above.
       const nonExpiredRevalidatedTags = revalidatedTags.filter((item) => {
-        if (item.expiry?.N) {
-          return Number.parseInt(item.expiry.N) > now;
+        if (item.expire?.N) {
+          return Number.parseInt(item.expire.N) > now;
         }
         return true;
       });
@@ -248,7 +244,7 @@ const tagCache: TagCache = {
                     Item.tag,
                     Item.revalidatedAt,
                     Item.stale,
-                    Item.expiry,
+                    Item.expire,
                   ),
                 },
               },

--- a/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
@@ -53,6 +53,20 @@ export default {
     debug("hasBeenRevalidated result:", hasRevalidatedTag);
     return hasRevalidatedTag;
   },
+  hasBeenStale: async (tags: string[], lastModified?: number) => {
+    if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+      return false;
+    }
+    const hasStaleTag = tags.some((tag) => {
+      const tagData = tagsMap.get(tag);
+      if (!tagData || typeof tagData.stale !== "number") {
+        return false;
+      }
+      return tagData.stale > (lastModified ?? 0);
+    });
+    debug("hasBeenStale result:", hasStaleTag);
+    return hasStaleTag;
+  },
   writeTags: async (tags) => {
     if (
       globalThis.openNextConfig.dangerous?.disableTagCache ||

--- a/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
@@ -52,7 +52,7 @@ export default {
     debug("hasBeenRevalidated result:", hasRevalidatedTag);
     return hasRevalidatedTag;
   },
-  hasBeenStale: async (tags: string[], lastModified?: number) => {
+  isStale: async (tags: string[], lastModified?: number) => {
     if (globalThis.openNextConfig.dangerous?.disableTagCache) {
       return false;
     }
@@ -63,7 +63,7 @@ export default {
       }
       return tagData.stale > (lastModified ?? 0);
     });
-    debug("hasBeenStale result:", hasStaleTag);
+    debug("isStale result:", hasStaleTag);
     return hasStaleTag;
   },
   writeTags: async (tags) => {

--- a/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
@@ -37,13 +37,14 @@ export default {
       if (!tagData) {
         return false;
       }
-      
+
       // Check if tag has expired
-      if (typeof tagData.expiry === 'number') {
-        const isExpired = tagData.expiry <= now && tagData.expiry > (lastModified ?? 0);
+      if (typeof tagData.expiry === "number") {
+        const isExpired =
+          tagData.expiry <= now && tagData.expiry > (lastModified ?? 0);
         return isExpired;
       }
-      
+
       // Check if tag has been revalidated
       return tagData.revalidatedAt > (lastModified ?? 0);
     });
@@ -60,7 +61,6 @@ export default {
       if (!tagData || typeof tagData.stale !== "number") {
         return false;
       }
-      console.log('Checking stale for tag:', tag, 'stale:', tagData.stale, 'now:', Date.now(), 'lastModified:', lastModified);
       return tagData.stale > (lastModified ?? 0);
     });
     debug("hasBeenStale result:", hasStaleTag);
@@ -75,7 +75,6 @@ export default {
     }
 
     debug("writeTags", { tags: tags });
-    console.log("writeTags", { tags: tags });
 
     tags.forEach((tag) => {
       const tagStr = typeof tag === "string" ? tag : tag.tag;

--- a/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
@@ -41,9 +41,7 @@ export default {
       // Check if tag has expired
       if (typeof tagData.expiry === 'number') {
         const isExpired = tagData.expiry <= now && tagData.expiry > (lastModified ?? 0);
-        if (isExpired) {
-          return true;
-        }
+        return isExpired;
       }
       
       // Check if tag has been revalidated
@@ -62,6 +60,7 @@ export default {
       if (!tagData || typeof tagData.stale !== "number") {
         return false;
       }
+      console.log('Checking stale for tag:', tag, 'stale:', tagData.stale, 'now:', Date.now(), 'lastModified:', lastModified);
       return tagData.stale > (lastModified ?? 0);
     });
     debug("hasBeenStale result:", hasStaleTag);
@@ -76,6 +75,7 @@ export default {
     }
 
     debug("writeTags", { tags: tags });
+    console.log("writeTags", { tags: tags });
 
     tags.forEach((tag) => {
       const tagStr = typeof tag === "string" ? tag : tag.tag;

--- a/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
@@ -3,7 +3,7 @@ import { debug } from "../../adapters/logger";
 
 const tagsMap = new Map<
   string,
-  { revalidatedAt: number; stale?: number; expiry?: number }
+  { revalidatedAt: number; stale?: number; expire?: number }
 >();
 
 export default {
@@ -39,9 +39,9 @@ export default {
       }
 
       // Check if tag has expired
-      if (typeof tagData.expiry === "number") {
+      if (typeof tagData.expire === "number") {
         const isExpired =
-          tagData.expiry <= now && tagData.expiry > (lastModified ?? 0);
+          tagData.expire <= now && tagData.expire > (lastModified ?? 0);
         return isExpired;
       }
 
@@ -79,11 +79,11 @@ export default {
     tags.forEach((tag) => {
       const tagStr = typeof tag === "string" ? tag : tag.tag;
       const stale = typeof tag === "string" ? undefined : tag.stale;
-      const expiry = typeof tag === "string" ? undefined : tag.expiry;
+      const expire = typeof tag === "string" ? undefined : tag.expire;
       tagsMap.set(tagStr, {
         revalidatedAt: Date.now(),
         stale,
-        expiry,
+        expire,
       });
     });
 

--- a/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
@@ -1,7 +1,10 @@
 import type { NextModeTagCache } from "types/overrides";
 import { debug } from "../../adapters/logger";
 
-const tagsMap = new Map<string, number>();
+const tagsMap = new Map<
+  string,
+  { revalidatedAt: number; stale?: number; expiry?: number }
+>();
 
 export default {
   name: "fs-dev-nextMode",
@@ -14,9 +17,9 @@ export default {
     let lastRevalidated = 0;
 
     tags.forEach((tag) => {
-      const tagTime = tagsMap.get(tag);
-      if (tagTime && tagTime > lastRevalidated) {
-        lastRevalidated = tagTime;
+      const tagData = tagsMap.get(tag);
+      if (tagData && tagData.revalidatedAt > lastRevalidated) {
+        lastRevalidated = tagData.revalidatedAt;
       }
     });
 
@@ -29,14 +32,16 @@ export default {
     }
 
     const hasRevalidatedTag = tags.some((tag) => {
-      const tagRevalidatedAt = tagsMap.get(tag);
-      return tagRevalidatedAt ? tagRevalidatedAt > (lastModified ?? 0) : false;
+      const tagData = tagsMap.get(tag);
+      return tagData
+        ? tagData.revalidatedAt > (lastModified ?? 0)
+        : false;
     });
 
     debug("hasBeenRevalidated result:", hasRevalidatedTag);
     return hasRevalidatedTag;
   },
-  writeTags: async (tags: string[]) => {
+  writeTags: async (tags) => {
     if (
       globalThis.openNextConfig.dangerous?.disableTagCache ||
       tags.length === 0
@@ -47,7 +52,14 @@ export default {
     debug("writeTags", { tags: tags });
 
     tags.forEach((tag) => {
-      tagsMap.set(tag, Date.now());
+      const tagStr = typeof tag === "string" ? tag : tag.tag;
+      const stale = typeof tag === "string" ? undefined : tag.stale;
+      const expiry = typeof tag === "string" ? undefined : tag.expiry;
+      tagsMap.set(tagStr, {
+        revalidatedAt: Date.now(),
+        stale,
+        expiry,
+      });
     });
 
     debug("writeTags completed, written", tags.length, "tags");

--- a/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev-nextMode.ts
@@ -31,11 +31,23 @@ export default {
       return false;
     }
 
+    const now = Date.now();
     const hasRevalidatedTag = tags.some((tag) => {
       const tagData = tagsMap.get(tag);
-      return tagData
-        ? tagData.revalidatedAt > (lastModified ?? 0)
-        : false;
+      if (!tagData) {
+        return false;
+      }
+      
+      // Check if tag has expired
+      if (typeof tagData.expiry === 'number') {
+        const isExpired = tagData.expiry <= now && tagData.expiry > (lastModified ?? 0);
+        if (isExpired) {
+          return true;
+        }
+      }
+      
+      // Check if tag has been revalidated
+      return tagData.revalidatedAt > (lastModified ?? 0);
     });
 
     debug("hasBeenRevalidated result:", hasRevalidatedTag);

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -56,6 +56,15 @@ const tagCache: TagCache = {
     
     return revalidatedTags.length > 0 || hasExpiredTag ? -1 : (lastModified ?? Date.now());
   },
+  hasBeenStale: async (tagsToCheck: string[], lastModified?: number) => {
+    return tagsToCheck.some((tag) =>
+      tags.some((entry) => {
+        if (entry.tag.S !== buildKey(tag)) return false;
+        if (!entry.stale?.N) return false;
+        return Number.parseInt(entry.stale.N) > (lastModified ?? 0);
+      }),
+    );
+  },
   writeTags: async (newTags) => {
     const newTagsSet = new Set(
       newTags.map(({ tag, path }) => `${buildKey(tag)}-${buildKey(path)}`),

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { TagCacheMetaFile } from "types/cache";
 
 import type { TagCache } from "types/overrides";
 import { getMonorepoRelativePath } from "utils/normalize-path";
@@ -79,23 +80,17 @@ const tagCache: TagCache = {
     );
     tags = unchangedTags.concat(
       newTags.map((item) => {
-        const tagEntry: {
-          tag: { S: string };
-          path: { S: string };
-          revalidatedAt: { N: string };
-          stale?: { N: string };
-          expiry?: { N: string };
-        } = {
+        const tagEntry: TagCacheMetaFile = {
           tag: { S: buildKey(item.tag) },
           path: { S: buildKey(item.path) },
           revalidatedAt: { N: `${item.revalidatedAt ?? Date.now()}` },
+          ...(item.stale !== undefined
+            ? { stale: { N: `${item.stale}` } }
+             : undefined),
+          ...(item.expiry !== undefined
+            ? { expiry: { N: `${item.expiry}` } }
+             : undefined),
         };
-        if (item.stale !== undefined) {
-          tagEntry.stale = { N: `${item.stale}` };
-        }
-        if (item.expiry !== undefined) {
-          tagEntry.expiry = { N: `${item.expiry}` };
-        }
         return tagEntry;
       }),
     );

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -16,7 +16,7 @@ let tags = JSON.parse(tagContent) as {
   path: { S: string };
   revalidatedAt: { N: string };
   stale?: { N: string };
-  expiry?: { N: string };
+  expire?: { N: string };
 }[];
 
 const { NEXT_BUILD_ID } = process.env;
@@ -44,9 +44,9 @@ const tagCache: TagCache = {
     const hasExpiredTag = tags.some((tagPathMapping) => {
       if (
         tagPathMapping.path.S === buildKey(path) &&
-        tagPathMapping.expiry?.N
+        tagPathMapping.expire?.N
       ) {
-        const expiry = Number.parseInt(tagPathMapping.expiry.N);
+        const expiry = Number.parseInt(tagPathMapping.expire.N);
         return expiry <= now && expiry > (lastModified ?? 0);
       }
       return false;
@@ -56,8 +56,8 @@ const tagCache: TagCache = {
       (tagPathMapping) =>
         tagPathMapping.path.S === buildKey(path) &&
         Number.parseInt(tagPathMapping.revalidatedAt.N) > (lastModified ?? 0) &&
-        (!tagPathMapping.expiry?.N ||
-          Number.parseInt(tagPathMapping.expiry.N) > now),
+        (!tagPathMapping.expire?.N ||
+          Number.parseInt(tagPathMapping.expire.N) > now),
     );
 
     return nonExpiredRevalidatedTags.length > 0 || hasExpiredTag
@@ -87,8 +87,8 @@ const tagCache: TagCache = {
           ...(item.stale !== undefined
             ? { stale: { N: `${item.stale}` } }
              : undefined),
-          ...(item.expiry !== undefined
-            ? { expiry: { N: `${item.expiry}` } }
+          ...(item.expire !== undefined
+            ? { expire: { N: `${item.expire}` } }
              : undefined),
         };
         return tagEntry;

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -14,6 +14,8 @@ let tags = JSON.parse(tagContent) as {
   tag: { S: string };
   path: { S: string };
   revalidatedAt: { N: string };
+  stale?: { N: string };
+  expiry?: { N: string };
 }[];
 
 const { NEXT_BUILD_ID } = process.env;
@@ -51,11 +53,26 @@ const tagCache: TagCache = {
       ({ tag, path }) => !newTagsSet.has(`${tag.S}-${path.S}`),
     );
     tags = unchangedTags.concat(
-      newTags.map((item) => ({
-        tag: { S: buildKey(item.tag) },
-        path: { S: buildKey(item.path) },
-        revalidatedAt: { N: `${item.revalidatedAt ?? Date.now()}` },
-      })),
+      newTags.map((item) => {
+        const tagEntry: {
+          tag: { S: string };
+          path: { S: string };
+          revalidatedAt: { N: string };
+          stale?: { N: string };
+          expiry?: { N: string };
+        } = {
+          tag: { S: buildKey(item.tag) },
+          path: { S: buildKey(item.path) },
+          revalidatedAt: { N: `${item.revalidatedAt ?? Date.now()}` },
+        };
+        if (item.stale !== undefined) {
+          tagEntry.stale = { N: `${item.stale}` };
+        }
+        if (item.expiry !== undefined) {
+          tagEntry.expiry = { N: `${item.expiry}` };
+        }
+        return tagEntry;
+      }),
     );
   },
 };

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { TagCacheMetaFile } from "types/cache";
+import type { TagCacheMetaFile } from "types/cache";
 
 import type { TagCache } from "types/overrides";
 import { getMonorepoRelativePath } from "utils/normalize-path";
@@ -86,10 +86,10 @@ const tagCache: TagCache = {
           revalidatedAt: { N: `${item.revalidatedAt ?? Date.now()}` },
           ...(item.stale !== undefined
             ? { stale: { N: `${item.stale}` } }
-             : undefined),
+            : undefined),
           ...(item.expire !== undefined
             ? { expire: { N: `${item.expire}` } }
-             : undefined),
+            : undefined),
         };
         return tagEntry;
       }),

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -64,7 +64,7 @@ const tagCache: TagCache = {
       ? -1
       : (lastModified ?? Date.now());
   },
-  hasBeenStale: async (path: string, lastModified?: number) => {
+  isStale: async (path: string, lastModified?: number) => {
     return tags.some((entry) => {
       if (entry.path.S !== buildKey(path)) return false;
       if (!entry.stale?.N) return false;

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -38,12 +38,6 @@ const tagCache: TagCache = {
       .map((tagEntry) => tagEntry.path.S.replace(`${NEXT_BUILD_ID}/`, ""));
   },
   getLastModified: async (path: string, lastModified?: number) => {
-    const revalidatedTags = tags.filter(
-      (tagPathMapping) =>
-        tagPathMapping.path.S === buildKey(path) &&
-        Number.parseInt(tagPathMapping.revalidatedAt.N) > (lastModified ?? 0),
-    );
-
     // Check if any tag has expired
     const now = Date.now();
     const hasExpiredTag = tags.some((tagPathMapping) => {
@@ -57,18 +51,24 @@ const tagCache: TagCache = {
       return false;
     });
 
-    return revalidatedTags.length > 0 || hasExpiredTag
+    const nonExpiredRevalidatedTags = tags.filter(
+      (tagPathMapping) =>
+        tagPathMapping.path.S === buildKey(path) &&
+        Number.parseInt(tagPathMapping.revalidatedAt.N) > (lastModified ?? 0) &&
+        (!tagPathMapping.expiry?.N ||
+          Number.parseInt(tagPathMapping.expiry.N) > now),
+    );
+
+    return nonExpiredRevalidatedTags.length > 0 || hasExpiredTag
       ? -1
       : (lastModified ?? Date.now());
   },
-  hasBeenStale: async (tagsToCheck: string[], lastModified?: number) => {
-    return tagsToCheck.some((tag) =>
-      tags.some((entry) => {
-        if (entry.tag.S !== buildKey(tag)) return false;
-        if (!entry.stale?.N) return false;
-        return Number.parseInt(entry.stale.N) > (lastModified ?? 0);
-      }),
-    );
+  hasBeenStale: async (path: string, lastModified?: number) => {
+    return tags.some((entry) => {
+      if (entry.path.S !== buildKey(path)) return false;
+      if (!entry.stale?.N) return false;
+      return Number.parseInt(entry.stale.N) > (lastModified ?? 0);
+    });
   },
   writeTags: async (newTags) => {
     const newTagsSet = new Set(

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -43,18 +43,23 @@ const tagCache: TagCache = {
         tagPathMapping.path.S === buildKey(path) &&
         Number.parseInt(tagPathMapping.revalidatedAt.N) > (lastModified ?? 0),
     );
-    
+
     // Check if any tag has expired
     const now = Date.now();
     const hasExpiredTag = tags.some((tagPathMapping) => {
-      if (tagPathMapping.path.S === buildKey(path) && tagPathMapping.expiry?.N) {
+      if (
+        tagPathMapping.path.S === buildKey(path) &&
+        tagPathMapping.expiry?.N
+      ) {
         const expiry = Number.parseInt(tagPathMapping.expiry.N);
         return expiry <= now && expiry > (lastModified ?? 0);
       }
       return false;
     });
-    
-    return revalidatedTags.length > 0 || hasExpiredTag ? -1 : (lastModified ?? Date.now());
+
+    return revalidatedTags.length > 0 || hasExpiredTag
+      ? -1
+      : (lastModified ?? Date.now());
   },
   hasBeenStale: async (tagsToCheck: string[], lastModified?: number) => {
     return tagsToCheck.some((tag) =>

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -43,7 +43,18 @@ const tagCache: TagCache = {
         tagPathMapping.path.S === buildKey(path) &&
         Number.parseInt(tagPathMapping.revalidatedAt.N) > (lastModified ?? 0),
     );
-    return revalidatedTags.length > 0 ? -1 : (lastModified ?? Date.now());
+    
+    // Check if any tag has expired
+    const now = Date.now();
+    const hasExpiredTag = tags.some((tagPathMapping) => {
+      if (tagPathMapping.path.S === buildKey(path) && tagPathMapping.expiry?.N) {
+        const expiry = Number.parseInt(tagPathMapping.expiry.N);
+        return expiry <= now && expiry > (lastModified ?? 0);
+      }
+      return false;
+    });
+    
+    return revalidatedTags.length > 0 || hasExpiredTag ? -1 : (lastModified ?? Date.now());
   },
   writeTags: async (newTags) => {
     const newTagsSet = new Set(

--- a/packages/open-next/src/types/cache.ts
+++ b/packages/open-next/src/types/cache.ts
@@ -99,7 +99,13 @@ export type TagCacheMetaFile = {
   tag: { S: string };
   path: { S: string };
   revalidatedAt: { N: string };
+  /**
+   * The time at which the tag should be considered stale, in milliseconds since epoch. Optional, if not set the tag will never be stale.
+   */
   stale?: { N: string };
+  /**
+   * The time at which the tag should expire, in milliseconds since epoch. Optional, if not set the tag will never expire.
+   */
   expiry?: { N: string };
 };
 

--- a/packages/open-next/src/types/cache.ts
+++ b/packages/open-next/src/types/cache.ts
@@ -106,7 +106,7 @@ export type TagCacheMetaFile = {
   /**
    * The time at which the tag should expire, in milliseconds since epoch. Optional, if not set the tag will never expire.
    */
-  expiry?: { N: string };
+  expire?: { N: string };
 };
 
 // Cache context since vercel/next.js#76207

--- a/packages/open-next/src/types/cache.ts
+++ b/packages/open-next/src/types/cache.ts
@@ -177,4 +177,10 @@ export interface ComposableCacheHandler {
    * This function is only there for older versions and do nothing
    */
   receiveExpiredTags(...tags: string[]): Promise<void>;
+  /**
+   * Added in Next.js 16. Updates tags with optional stale/expire durations.
+   * When durations is provided, marks tags as stale immediately and sets expiry;
+   * when omitted, immediately expires tags (same as expireTags).
+   */
+  updateTags(tags: string[], durations?: { expire?: number }): Promise<void>;
 }

--- a/packages/open-next/src/types/cache.ts
+++ b/packages/open-next/src/types/cache.ts
@@ -99,6 +99,8 @@ export type TagCacheMetaFile = {
   tag: { S: string };
   path: { S: string };
   revalidatedAt: { N: string };
+  stale?: { N: string };
+  expiry?: { N: string };
 };
 
 // Cache context since vercel/next.js#76207

--- a/packages/open-next/src/types/global.ts
+++ b/packages/open-next/src/types/global.ts
@@ -11,6 +11,7 @@ import type {
 } from "types/overrides";
 
 import type { DetachedPromiseRunner } from "../utils/promise";
+import type { RequestCache } from "../utils/requestCache";
 import type { OpenNextConfig, WaitUntil } from "./open-next";
 
 export interface RequestData {
@@ -66,6 +67,8 @@ interface OpenNextRequestContext {
   waitUntil?: WaitUntil;
   /** We use this to deduplicate write of the tags*/
   writtenTags: Set<string>;
+  /** Per-request in-memory cache. Overrides can use this to store data scoped to the current request. */
+  requestCache: RequestCache;
 }
 
 declare global {

--- a/packages/open-next/src/types/global.ts
+++ b/packages/open-next/src/types/global.ts
@@ -113,6 +113,13 @@ declare global {
   var isNextAfter15: boolean;
 
   /**
+   * A boolean that indicates if Next is V16 or higher.
+   * Only available in the cache adapter.
+   * Defined in the esbuild banner for the cache adapter.
+   */
+  var isNextAfter16: boolean;
+
+  /**
    * A boolean that indicates if the runtime is Edge.
    * Only available in `edge` runtime functions (i.e. external middleware or function with edge runtime).
    * Defined in `adapters/edge-adapter.ts`.

--- a/packages/open-next/src/types/global.ts
+++ b/packages/open-next/src/types/global.ts
@@ -109,18 +109,11 @@ declare global {
   var disableIncrementalCache: boolean;
 
   /**
-   * A boolean that indicates if Next is V15 or higher.
+   * The Next.js version of the application.
    * Only available in the cache adapter.
    * Defined in the esbuild banner for the cache adapter.
    */
-  var isNextAfter15: boolean;
-
-  /**
-   * A boolean that indicates if Next is V16 or higher.
-   * Only available in the cache adapter.
-   * Defined in the esbuild banner for the cache adapter.
-   */
-  var isNextAfter16: boolean;
+  var nextVersion: string;
 
   /**
    * A boolean that indicates if the runtime is Edge.

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -162,7 +162,7 @@ export type NextModeTagCacheWriteInput =
   | {
       tag: string;
       /**
-       * Timestamp in milliseconds since epoch after which the tag should be considered stale. 
+       * Timestamp in milliseconds since epoch after which the tag should be considered stale.
        */
       stale?: number;
       /**
@@ -198,7 +198,7 @@ export interface OriginalTagCacheWriteInput {
   path: string;
   revalidatedAt?: number;
   /**
-   * Timestamp in milliseconds since epoch after which the tag/path combination should be considered stale. 
+   * Timestamp in milliseconds since epoch after which the tag/path combination should be considered stale.
    */
   stale?: number;
   /**

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -161,7 +161,13 @@ export type NextModeTagCacheWriteInput =
   | string
   | {
       tag: string;
+      /**
+       * Timestamp in milliseconds since epoch after which the tag should be considered stale. 
+       */
       stale?: number;
+      /**
+       * Timestamp in milliseconds since epoch after which the tag should be considered expired.
+       */
       expire?: number;
     };
 
@@ -179,7 +185,7 @@ export type NextModeTagCache = BaseTagCache & {
    * There are three possible states for a cache entry:
    * - **Fresh**: no tag has been revalidated since `lastModified` → returns `false`.
    * - **Stale**: at least one tag was revalidated after `lastModified` but has not yet expired →
-   *   returns `true`. The cache entry is still served but `revalidate` is set to `-1` to trigger
+   *   returns `true`. The cache entry is still served but `revalidate` is set to `1` to trigger
    *   background revalidation.
    * - **Expired**: at least one tag has fully expired → handled by `hasBeenRevalidated` returning
    *   `true`. This method is only called when `hasBeenRevalidated` returned `false`.
@@ -191,7 +197,13 @@ export interface OriginalTagCacheWriteInput {
   tag: string;
   path: string;
   revalidatedAt?: number;
+  /**
+   * Timestamp in milliseconds since epoch after which the tag/path combination should be considered stale. 
+   */
   stale?: number;
+  /**
+   * Timestamp in milliseconds since epoch after which the tag/path combination should be considered expired.
+   */
   expire?: number;
 }
 
@@ -225,7 +237,7 @@ export type OriginalTagCache = BaseTagCache & {
    * There are three possible states for a cache entry:
    * - **Fresh**: no tag/path combination has been revalidated since `lastModified` → returns `false`.
    * - **Stale**: at least one tag/path combination was revalidated after `lastModified` but has not
-   *   yet expired → returns `true`. The cache entry is still served but `revalidate` is set to `-1`
+   *   yet expired → returns `true`. The cache entry is still served but `revalidate` is set to `1`
    *   to trigger background revalidation.
    * - **Expired**: at least one tag/path combination has fully expired → handled by `getLastModified`
    *   returning `-1`. This method is only called when the entry is not fully expired.

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -220,7 +220,7 @@ export type OriginalTagCache = BaseTagCache & {
    * timestamp newer than lastModified. When stale, the cache entry is still
    * returned but revalidate is set to -1 to trigger background revalidation.
    */
-  hasBeenStale?(tags: string[], lastModified?: number): Promise<boolean>;
+  hasBeenStale?(path: string, lastModified?: number): Promise<boolean>;
 };
 
 export type TagCache = NextModeTagCache | OriginalTagCache;

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -174,6 +174,12 @@ export type NextModeTagCache = BaseTagCache & {
   // Optional method to get paths by tags
   // It is used to automatically invalidate paths in the CDN
   getPathsByTags?: (tags: string[]) => Promise<string[]>;
+  /**
+   * Optional method to check if any tag has become stale (but not yet expired).
+   * When tags are stale, the cache entry is still returned but revalidate is set to -1
+   * to trigger background revalidation.
+   */
+  hasBeenStale?(tags: string[], lastModified?: number): Promise<boolean>;
 };
 
 export interface OriginalTagCacheWriteInput {
@@ -209,6 +215,12 @@ export type OriginalTagCache = BaseTagCache & {
   getByPath(path: string): Promise<string[]>;
   getLastModified(path: string, lastModified?: number): Promise<number>;
   writeTags(tags: OriginalTagCacheWriteInput[]): Promise<void>;
+  /**
+   * Optional method to check if any tag entry for the given tags has a stale
+   * timestamp newer than lastModified. When stale, the cache entry is still
+   * returned but revalidate is set to -1 to trigger background revalidation.
+   */
+  hasBeenStale?(tags: string[], lastModified?: number): Promise<boolean>;
 };
 
 export type TagCache = NextModeTagCache | OriginalTagCache;

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -176,8 +176,13 @@ export type NextModeTagCache = BaseTagCache & {
   getPathsByTags?: (tags: string[]) => Promise<string[]>;
   /**
    * Optional method to check if any tag has become stale (but not yet expired).
-   * When tags are stale, the cache entry is still returned but revalidate is set to -1
-   * to trigger background revalidation.
+   * There are three possible states for a cache entry:
+   * - **Fresh**: no tag has been revalidated since `lastModified` → returns `false`.
+   * - **Stale**: at least one tag was revalidated after `lastModified` but has not yet expired →
+   *   returns `true`. The cache entry is still served but `revalidate` is set to `-1` to trigger
+   *   background revalidation.
+   * - **Expired**: at least one tag has fully expired → handled by `hasBeenRevalidated` returning
+   *   `true`. This method is only called when `hasBeenRevalidated` returned `false`.
    */
   hasBeenStale?(tags: string[], lastModified?: number): Promise<boolean>;
 };
@@ -216,9 +221,14 @@ export type OriginalTagCache = BaseTagCache & {
   getLastModified(path: string, lastModified?: number): Promise<number>;
   writeTags(tags: OriginalTagCacheWriteInput[]): Promise<void>;
   /**
-   * Optional method to check if any tag entry for the given tags has a stale
-   * timestamp newer than lastModified. When stale, the cache entry is still
-   * returned but revalidate is set to -1 to trigger background revalidation.
+   * Optional method to check if any tag entry for the given path has become stale (but not yet expired).
+   * There are three possible states for a cache entry:
+   * - **Fresh**: no tag/path combination has been revalidated since `lastModified` → returns `false`.
+   * - **Stale**: at least one tag/path combination was revalidated after `lastModified` but has not
+   *   yet expired → returns `true`. The cache entry is still served but `revalidate` is set to `-1`
+   *   to trigger background revalidation.
+   * - **Expired**: at least one tag/path combination has fully expired → handled by `getLastModified`
+   *   returning `-1`. This method is only called when the entry is not fully expired.
    */
   hasBeenStale?(path: string, lastModified?: number): Promise<boolean>;
 };

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -190,7 +190,7 @@ export type NextModeTagCache = BaseTagCache & {
    * - **Expired**: at least one tag has fully expired → handled by `hasBeenRevalidated` returning
    *   `true`. This method is only called when `hasBeenRevalidated` returned `false`.
    */
-  hasBeenStale?(tags: string[], lastModified?: number): Promise<boolean>;
+  isStale?(tags: string[], lastModified?: number): Promise<boolean>;
 };
 
 export interface OriginalTagCacheWriteInput {
@@ -242,7 +242,7 @@ export type OriginalTagCache = BaseTagCache & {
    * - **Expired**: at least one tag/path combination has fully expired → handled by `getLastModified`
    *   returning `-1`. This method is only called when the entry is not fully expired.
    */
-  hasBeenStale?(path: string, lastModified?: number): Promise<boolean>;
+  isStale?(path: string, lastModified?: number): Promise<boolean>;
 };
 
 export type TagCache = NextModeTagCache | OriginalTagCache;

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -156,12 +156,21 @@ Cons :
 - One page request (i.e. GET request) could require to check a lot of tags (And some of them multiple time when used with the fetch cache)
 - Almost impossible to do automatic cdn revalidation by itself
 */
+
+export type NextModeTagCacheWriteInput =
+  | string
+  | {
+      tag: string;
+      stale?: number;
+      expiry?: number;
+    };
+
 export type NextModeTagCache = BaseTagCache & {
   mode: "nextMode";
   // Necessary for the composable cache
   getLastRevalidated(tags: string[]): Promise<number>;
   hasBeenRevalidated(tags: string[], lastModified?: number): Promise<boolean>;
-  writeTags(tags: string[]): Promise<void>;
+  writeTags(tags: NextModeTagCacheWriteInput[]): Promise<void>;
   // Optional method to get paths by tags
   // It is used to automatically invalidate paths in the CDN
   getPathsByTags?: (tags: string[]) => Promise<string[]>;
@@ -171,6 +180,8 @@ export interface OriginalTagCacheWriteInput {
   tag: string;
   path: string;
   revalidatedAt?: number;
+  stale?: number;
+  expiry?: number;
 }
 
 /**

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -162,7 +162,7 @@ export type NextModeTagCacheWriteInput =
   | {
       tag: string;
       stale?: number;
-      expiry?: number;
+      expire?: number;
     };
 
 export type NextModeTagCache = BaseTagCache & {
@@ -192,7 +192,7 @@ export interface OriginalTagCacheWriteInput {
   path: string;
   revalidatedAt?: number;
   stale?: number;
-  expiry?: number;
+  expire?: number;
 }
 
 /**

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -5,12 +5,21 @@ import type {
   WithLastModified,
 } from "types/overrides";
 import { debug } from "../adapters/logger";
-
+/**
+ * 
+ * @param key The key for that specific cache entry
+ * @param tags Array of tags associated with that cache entry
+ * @param lastModified Time of the last update to the cache entry
+ * @returns A boolean indicating whether the cache entry has become stale -
+ * A cache entry is considered stale if at least one of its associated tags has been revalidated since the `lastModified` time, but none of them has expired yet. 
+ * In this case, the cache entry is still valid and can be served, but it should trigger a background revalidation to update the cache.
+ */
 export async function hasBeenStale(
   key: string,
   tags: string[],
   lastModified?: number,
 ): Promise<boolean> {
+  // SWR for revalidateTag has been implemented starting from Next.js 16
   if (!globalThis.isNextAfter16) {
     return false;
   }

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -14,7 +14,7 @@ import { debug } from "../adapters/logger";
  * A cache entry is considered stale if at least one of its associated tags has been revalidated since the `lastModified` time, but none of them has expired yet. 
  * In this case, the cache entry is still valid and can be served, but it should trigger a background revalidation to update the cache.
  */
-export async function hasBeenStale(
+export async function isStale(
   key: string,
   tags: string[],
   lastModified?: number,

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -36,6 +36,17 @@ export async function isStale(
   return (await globalThis.tagCache.hasBeenStale?.(key, lastModified)) ?? false;
 }
 
+
+/**
+ * @param key The key for that specific cache entry
+ * @param tags Array of tags associated with that cache entry
+ * @param cacheEntry The cache entry with its last modified time and value
+ * @returns A boolean indicating whether the cache entry has been revalidated -
+ * A cache entry is considered revalidated if at least one of its associated tags has been revalidated
+ * after the entry's `lastModified` time, meaning the cached data is stale and must be re-fetched.
+ * For Next 16+ you need {@link isStale}, to know if a revalidated entry is stale (valid but needs background revalidation) or expired (needs to be re-fetched immediately).
+ * Without it, we consider all revalidated entries as expired, which means that they will be re-fetched immediately without a chance to be served stale.
+ */
 export async function hasBeenRevalidated(
   key: string,
   tags: string[],

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -7,12 +7,12 @@ import type {
 import { debug } from "../adapters/logger";
 import { compareSemver } from "./semver";
 /**
- * 
+ *
  * @param key The key for that specific cache entry
  * @param tags Array of tags associated with that cache entry
  * @param lastModified Time of the last update to the cache entry
  * @returns A boolean indicating whether the cache entry has become stale -
- * A cache entry is considered stale if at least one of its associated tags has been revalidated since the `lastModified` time, but none of them has expired yet. 
+ * A cache entry is considered stale if at least one of its associated tags has been revalidated since the `lastModified` time, but none of them has expired yet.
  * In this case, the cache entry is still valid and can be served, but it should trigger a background revalidation to update the cache.
  */
 export async function isStale(

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -6,6 +6,26 @@ import type {
 } from "types/overrides";
 import { debug } from "../adapters/logger";
 
+export async function hasBeenStale(
+  key: string,
+  tags: string[],
+  lastModified?: number,
+): Promise<boolean> {
+  if (!globalThis.isNextAfter16) {
+    return false;
+  }
+  if (globalThis.openNextConfig.dangerous?.disableTagCache) {
+    return false;
+  }
+  if (globalThis.tagCache.mode === "nextMode") {
+    return tags.length === 0
+      ? false
+      : ((await globalThis.tagCache.hasBeenStale?.(tags, lastModified)) ??
+          false);
+  }
+  return (await globalThis.tagCache.hasBeenStale?.(key, lastModified)) ?? false;
+}
+
 export async function hasBeenRevalidated(
   key: string,
   tags: string[],

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -30,10 +30,10 @@ export async function isStale(
   if (globalThis.tagCache.mode === "nextMode") {
     return tags.length === 0
       ? false
-      : ((await globalThis.tagCache.hasBeenStale?.(tags, lastModified)) ??
+      : ((await globalThis.tagCache.isStale?.(tags, lastModified)) ??
           false);
   }
-  return (await globalThis.tagCache.hasBeenStale?.(key, lastModified)) ?? false;
+  return (await globalThis.tagCache.isStale?.(key, lastModified)) ?? false;
 }
 
 

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -1,5 +1,6 @@
 import type {
   CacheValue,
+  NextModeTagCacheWriteInput,
   OriginalTagCacheWriteInput,
   WithLastModified,
 } from "types/overrides";
@@ -50,18 +51,25 @@ export function getTagsFromValue(value?: CacheValue<"cache">) {
   }
 }
 
-function getTagKey(tag: string | OriginalTagCacheWriteInput): string {
+function getTagKey(
+  tag: string | OriginalTagCacheWriteInput | NextModeTagCacheWriteInput,
+): string {
   if (typeof tag === "string") {
     return tag;
   }
-  return JSON.stringify({
-    tag: tag.tag,
-    path: tag.path,
-  });
+  // For OriginalTagCacheWriteInput, include path in the key
+  if ("path" in tag) {
+    return JSON.stringify({
+      tag: tag.tag,
+      path: tag.path,
+    });
+  }
+  // For NextModeTagCacheWriteInput, just use the tag
+  return tag.tag;
 }
 
 export async function writeTags(
-  tags: (string | OriginalTagCacheWriteInput)[],
+  tags: (string | OriginalTagCacheWriteInput | NextModeTagCacheWriteInput)[],
 ): Promise<void> {
   const store = globalThis.__openNextAls.getStore();
   debug("Writing tags", tags, store);

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -30,12 +30,10 @@ export async function isStale(
   if (globalThis.tagCache.mode === "nextMode") {
     return tags.length === 0
       ? false
-      : ((await globalThis.tagCache.isStale?.(tags, lastModified)) ??
-          false);
+      : ((await globalThis.tagCache.isStale?.(tags, lastModified)) ?? false);
   }
   return (await globalThis.tagCache.isStale?.(key, lastModified)) ?? false;
 }
-
 
 /**
  * @param key The key for that specific cache entry

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -5,6 +5,7 @@ import type {
   WithLastModified,
 } from "types/overrides";
 import { debug } from "../adapters/logger";
+import { compareSemver } from "./semver";
 /**
  * 
  * @param key The key for that specific cache entry
@@ -20,7 +21,7 @@ export async function isStale(
   lastModified?: number,
 ): Promise<boolean> {
   // SWR for revalidateTag has been implemented starting from Next.js 16
-  if (!globalThis.isNextAfter16) {
+  if (!compareSemver(globalThis.nextVersion, ">=", "16.0.0")) {
     return false;
   }
   if (globalThis.openNextConfig.dangerous?.disableTagCache) {

--- a/packages/open-next/src/utils/promise.ts
+++ b/packages/open-next/src/utils/promise.ts
@@ -1,5 +1,6 @@
 import type { WaitUntil } from "types/open-next";
 import { debug, error } from "../adapters/logger";
+import { RequestCache } from "./requestCache";
 
 /**
  * A `Promise.withResolvers` implementation that exposes the `resolve` and
@@ -122,6 +123,7 @@ export function runWithOpenNextRequestContext<T>(
       isISRRevalidation,
       waitUntil,
       writtenTags: new Set<string>(),
+      requestCache: new RequestCache(),
     },
     async () => {
       provideNextAfterProvider();

--- a/packages/open-next/src/utils/requestCache.ts
+++ b/packages/open-next/src/utils/requestCache.ts
@@ -1,0 +1,28 @@
+/**
+ * A per-request cache that provides named Map instances.
+ * Overrides can use this to store and share data within the scope of a single request
+ * without polluting global state.
+ *
+ * Retrieve it from the ALS context:
+ * ```ts
+ * const store = globalThis.__openNextAls.getStore();
+ * const myMap = store?.requestCache.getOrCreate<MyKey, MyValue>("my-override");
+ * ```
+ */
+export class RequestCache {
+  private _caches = new Map<string, Map<unknown, unknown>>();
+
+  /**
+   * Returns the Map registered under `key`.
+   * If no Map exists yet for that key, a new empty Map is created, stored, and returned.
+   * Repeated calls with the same key always return the **same** Map instance.
+   */
+  getOrCreate<K = unknown, V = unknown>(key: string): Map<K, V> {
+    let cache = this._caches.get(key);
+    if (!cache) {
+      cache = new Map<unknown, unknown>();
+      this._caches.set(key, cache);
+    }
+    return cache as Map<K, V>;
+  }
+}

--- a/packages/open-next/src/utils/requestCache.ts
+++ b/packages/open-next/src/utils/requestCache.ts
@@ -18,11 +18,11 @@ export class RequestCache {
    * Repeated calls with the same key always return the **same** Map instance.
    */
   getOrCreate<K = unknown, V = unknown>(key: string): Map<K, V> {
-    let cache = this._caches.get(key);
+    let cache = this._caches.get(key) as Map<K, V> | undefined;
     if (!cache) {
-      cache = new Map<unknown, unknown>();
+      cache = new Map<K, V>();
       this._caches.set(key, cache);
     }
-    return cache as Map<K, V>;
+    return cache;
   }
 }

--- a/packages/open-next/src/utils/semver.ts
+++ b/packages/open-next/src/utils/semver.ts
@@ -1,0 +1,60 @@
+export type SemverOp = "=" | ">=" | "<=" | ">" | "<";
+
+/**
+ * Compare two semver versions.
+ *
+ * @param v1 - First version. Can be "latest", otherwise it should be a valid semver version in the format of `major.minor.patch`. Usually is the next version from the package.json without canary suffix. If minor or patch are missing, they are considered 0.
+ * @param v2 - Second version. Should not be "latest", it should be a valid semver version in the format of `major.minor.patch`. If minor or patch are missing, they are considered 0.
+ * @example
+ *     compareSemver("2.0.0", ">=", "1.0.0") === true
+ */
+export function compareSemver(
+  v1: string,
+  operator: SemverOp,
+  v2: string,
+): boolean {
+  // - = 0 when versions are equal
+  // - > 0 if v1 > v2
+  // - < 0 if v2 > v1
+  let versionDiff = 0;
+  if (v1 === "latest") {
+    versionDiff = 1;
+  } else {
+    if (/^[^\d]/.test(v1)) {
+      // biome-ignore lint/style/noParameterAssign:
+      v1 = v1.substring(1);
+    }
+    if (/^[^\d]/.test(v2)) {
+      // biome-ignore lint/style/noParameterAssign:
+      v2 = v2.substring(1);
+    }
+    const [major1, minor1 = 0, patch1 = 0] = v1.split(".").map(Number);
+    const [major2, minor2 = 0, patch2 = 0] = v2.split(".").map(Number);
+    if (Number.isNaN(major1) || Number.isNaN(major2)) {
+      throw new Error("The major version is required.");
+    }
+
+    if (major1 !== major2) {
+      versionDiff = major1 - major2;
+    } else if (minor1 !== minor2) {
+      versionDiff = minor1 - minor2;
+    } else if (patch1 !== patch2) {
+      versionDiff = patch1 - patch2;
+    }
+  }
+
+  switch (operator) {
+    case "=":
+      return versionDiff === 0;
+    case ">=":
+      return versionDiff >= 0;
+    case "<=":
+      return versionDiff <= 0;
+    case ">":
+      return versionDiff > 0;
+    case "<":
+      return versionDiff < 0;
+    default:
+      throw new Error(`Unsupported operator: ${operator}`);
+  }
+}

--- a/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
+++ b/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
@@ -70,6 +70,77 @@ test("Revalidate tag", async ({ page, request }) => {
   expect(nextCacheHeaderNested).toEqual("HIT");
 });
 
+test("Revalidate tag - stale data served first", async ({ page, request }) => {
+  test.setTimeout(45000);
+
+  // Warm up: visit several times so the page is firmly cached (HIT)
+  for (let i = 0; i < 3; i++) {
+    await page.goto("/revalidate-tag/stale");
+    await page.waitForSelector("[data-testid='cached-time']");
+  }
+
+  let responsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/revalidate-tag/stale") &&
+      response.status() === 200,
+  );
+  await page.goto("/revalidate-tag/stale");
+  const warmupResponse = await responsePromise;
+  const warmupHeaders = warmupResponse.headers();
+  const warmupCache =
+    warmupHeaders["x-nextjs-cache"] ?? warmupHeaders["x-opennext-cache"];
+  // Must be cached after warm-up
+  expect(warmupCache).toMatch(/^(HIT|STALE)$/);
+
+  // Record the currently cached value
+  const cachedTimeEl = page.getByTestId("cached-time");
+  const originalTime = await cachedTimeEl.textContent();
+
+  // Trigger revalidateTag WITHOUT expire — marks the tag stale but does NOT
+  // immediately purge the cache; the next request should get STALE data.
+  const revalidateRes = await request.get("/api/revalidate-tag-stale");
+  expect(revalidateRes.status()).toEqual(200);
+  expect(await revalidateRes.text()).toEqual("ok");
+
+  // First request after revalidation — expect STALE header and OLD content
+  responsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/revalidate-tag/stale") &&
+      response.status() === 200,
+  );
+  await page.goto("/revalidate-tag/stale");
+  const staleResponse = await responsePromise;
+  const staleHeaders = staleResponse.headers();
+  const staleCache =
+    staleHeaders["x-nextjs-cache"] ?? staleHeaders["x-opennext-cache"];
+  expect(staleCache).toEqual("HIT");
+
+  const staleTime = await page.getByTestId("cached-time").textContent();
+  // Stale content must match the pre-revalidation value
+  expect(staleTime).toEqual(originalTime);
+
+  // Wait for the background regeneration to finish, then verify fresh data
+  let freshTime: string | null = null;
+  let attempts = 0;
+  while (attempts < 10) {
+    await page.waitForTimeout(2000);
+    await page.goto("/revalidate-tag/stale");
+
+    
+      freshTime = await page.getByTestId("cached-time").textContent();
+      if(freshTime !== originalTime) {
+        break;
+      }
+    
+    attempts++;
+  }
+
+  // After background regen the cached value must have been updated
+  expect(freshTime).not.toBeNull();
+  expect(freshTime).not.toEqual(originalTime);
+  expect(attempts).toBeGreaterThan(2); // We should serve stale data for at least a couple of attempts
+});
+
 test("Revalidate path", async ({ page, request }) => {
   await page.goto("/revalidate-path");
 

--- a/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
+++ b/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
@@ -126,12 +126,11 @@ test("Revalidate tag - stale data served first", async ({ page, request }) => {
     await page.waitForTimeout(2000);
     await page.goto("/revalidate-tag/stale");
 
-    
-      freshTime = await page.getByTestId("cached-time").textContent();
-      if(freshTime !== originalTime) {
-        break;
-      }
-    
+    freshTime = await page.getByTestId("cached-time").textContent();
+    if (freshTime !== originalTime) {
+      break;
+    }
+
     attempts++;
   }
 

--- a/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
+++ b/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
@@ -113,7 +113,7 @@ test("Revalidate tag - stale data served first", async ({ page, request }) => {
   const staleHeaders = staleResponse.headers();
   const staleCache =
     staleHeaders["x-nextjs-cache"] ?? staleHeaders["x-opennext-cache"];
-  expect(staleCache).toEqual("HIT");
+  expect(staleCache).toMatch(/^(STALE|HIT)$/);
 
   const staleTime = await page.getByTestId("cached-time").textContent();
   // Stale content must match the pre-revalidation value
@@ -137,7 +137,6 @@ test("Revalidate tag - stale data served first", async ({ page, request }) => {
   // After background regen the cached value must have been updated
   expect(freshTime).not.toBeNull();
   expect(freshTime).not.toEqual(originalTime);
-  expect(attempts).toBeGreaterThan(2); // We should serve stale data for at least a couple of attempts
 });
 
 test("Revalidate path", async ({ page, request }) => {

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -868,7 +868,6 @@ describe("CacheHandler", () => {
     });
 
     describe("durations parameter", () => {
-
       it("Should set stale and expiry when durations.expire is provided - original mode", async () => {
         tagCache.getByTag.mockResolvedValueOnce(["/path"]);
         tagCache.getByPath.mockResolvedValueOnce([]);

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -7,8 +7,7 @@ declare global {
   var openNextConfig: {
     dangerous: { disableIncrementalCache?: boolean; disableTagCache?: boolean };
   };
-  var isNextAfter15: boolean;
-  var isNextAfter16: boolean;
+  var nextVersion: string;
 }
 
 describe("CacheHandler", () => {
@@ -77,8 +76,7 @@ describe("CacheHandler", () => {
         disableIncrementalCache: false,
       },
     };
-    globalThis.isNextAfter15 = false;
-    globalThis.isNextAfter16 = true;
+    globalThis.nextVersion = "14.0.0";
     tagCache.mode = "original";
     tagCache.getPathsByTags = undefined;
   });
@@ -135,7 +133,7 @@ describe("CacheHandler", () => {
 
       describe("next15", () => {
         beforeEach(() => {
-          globalThis.isNextAfter15 = true;
+          globalThis.nextVersion = "15.0.0";
         });
 
         it("Should retrieve cache from fetch cache when hint is fetch", async () => {
@@ -179,6 +177,10 @@ describe("CacheHandler", () => {
       });
 
       describe("stale tags", () => {
+        beforeEach(() => {
+          globalThis.nextVersion = "16.0.0";
+        });
+
         it("Should return lastModified as 1 when tag is stale", async () => {
           tagCache.mode = "nextMode";
           tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
@@ -407,7 +409,7 @@ describe("CacheHandler", () => {
       });
 
       it("Should return value when cache data type is app with segmentData and postponed (Next 15+)", async () => {
-        globalThis.isNextAfter15 = true;
+        globalThis.nextVersion = "15.0.0";
         incrementalCache.get.mockResolvedValueOnce({
           value: {
             type: "app",
@@ -475,6 +477,10 @@ describe("CacheHandler", () => {
       });
 
       describe("stale tags", () => {
+        beforeEach(() => {
+          globalThis.nextVersion = "16.0.0";
+        });
+
         it("Should set store.lastModified to 1 when tag is stale", async () => {
           tagCache.hasBeenStale.mockResolvedValueOnce(true);
           const cachedLastModified = Date.now();

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -739,7 +739,7 @@ describe("CacheHandler", () => {
         tagCache.getByTag.mockResolvedValueOnce(["/path"]);
         tagCache.getByPath.mockResolvedValueOnce([]);
         const now = Date.now();
-        
+
         await cache.revalidateTag("tag", { expire: 60 });
 
         expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
@@ -756,7 +756,7 @@ describe("CacheHandler", () => {
       it("Should set stale and expiry when durations.expire is provided - nextMode", async () => {
         tagCache.mode = "nextMode";
         const now = Date.now();
-        
+
         await cache.revalidateTag("tag", { expire: 60 });
 
         expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
@@ -772,7 +772,7 @@ describe("CacheHandler", () => {
       it("Should set stale without expiry when durations.expire is undefined", async () => {
         tagCache.mode = "nextMode";
         const now = Date.now();
-        
+
         await cache.revalidateTag("tag", { expire: undefined });
 
         expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
@@ -790,7 +790,7 @@ describe("CacheHandler", () => {
           .mockResolvedValueOnce(["/path1"])
           .mockResolvedValueOnce(["/path2"]);
         const now = Date.now();
-        
+
         await cache.revalidateTag(["tag1", "tag2"], { expire: 30 });
 
         expect(tagCache.writeTags).toHaveBeenCalledTimes(2);
@@ -815,7 +815,7 @@ describe("CacheHandler", () => {
       it("Should handle multiple tags with durations - nextMode", async () => {
         tagCache.mode = "nextMode";
         const now = Date.now();
-        
+
         await cache.revalidateTag(["tag1", "tag2"], { expire: 30 });
 
         expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
@@ -838,7 +838,7 @@ describe("CacheHandler", () => {
         tagCache.getByTag.mockResolvedValueOnce(["/path"]);
         tagCache.getByPath.mockResolvedValueOnce([]); // No hard tags
         const now = Date.now();
-        
+
         await cache.revalidateTag(`${SOFT_TAG_PREFIX}path`, { expire: 60 });
 
         expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
@@ -855,7 +855,7 @@ describe("CacheHandler", () => {
       it("Should handle immediate expiration (expire: 0) - original mode", async () => {
         tagCache.getByTag.mockResolvedValueOnce(["/test-path"]);
         const now = Date.now();
-        
+
         await cache.revalidateTag("testtag", { expire: 0 });
 
         expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
@@ -872,7 +872,7 @@ describe("CacheHandler", () => {
       it("Should handle immediate expiration (expire: 0) - nextMode", async () => {
         tagCache.mode = "nextMode";
         const now = Date.now();
-        
+
         await cache.revalidateTag("tag", { expire: 0 });
 
         expect(tagCache.writeTags).toHaveBeenCalledTimes(1);

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -41,7 +41,7 @@ describe("CacheHandler", () => {
       .fn()
       .mockResolvedValue(new Date("2024-01-02T00:00:00Z").getTime()),
     writeTags: vi.fn(),
-    hasBeenStale: vi.fn().mockResolvedValue(false),
+    isStale: vi.fn().mockResolvedValue(false),
     getPathsByTags: undefined as Mock | undefined,
   };
   globalThis.tagCache = tagCache;
@@ -184,7 +184,7 @@ describe("CacheHandler", () => {
         it("Should return lastModified as 1 when tag is stale", async () => {
           tagCache.mode = "nextMode";
           tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
-          tagCache.hasBeenStale.mockResolvedValueOnce(true);
+          tagCache.isStale.mockResolvedValueOnce(true);
           const cachedLastModified = Date.now();
           incrementalCache.get.mockResolvedValueOnce({
             value: {
@@ -211,7 +211,7 @@ describe("CacheHandler", () => {
         it("Should return original lastModified when tag is not stale", async () => {
           tagCache.mode = "nextMode";
           tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
-          tagCache.hasBeenStale.mockResolvedValueOnce(false);
+          tagCache.isStale.mockResolvedValueOnce(false);
           const cachedLastModified = Date.now();
           incrementalCache.get.mockResolvedValueOnce({
             value: {
@@ -235,7 +235,7 @@ describe("CacheHandler", () => {
           expect(result?.lastModified).toEqual(cachedLastModified);
         });
 
-        it("Should not call hasBeenStale when shouldBypassTagCache is true", async () => {
+        it("Should not call isStale when shouldBypassTagCache is true", async () => {
           incrementalCache.get.mockResolvedValueOnce({
             value: {
               kind: "FETCH",
@@ -252,7 +252,7 @@ describe("CacheHandler", () => {
 
           await cache.get("key", { kind: "FETCH", tags: ["tag1"] });
 
-          expect(tagCache.hasBeenStale).not.toHaveBeenCalled();
+          expect(tagCache.isStale).not.toHaveBeenCalled();
         });
       });
     });
@@ -482,7 +482,7 @@ describe("CacheHandler", () => {
         });
 
         it("Should set store.lastModified to 1 when tag is stale", async () => {
-          tagCache.hasBeenStale.mockResolvedValueOnce(true);
+          tagCache.isStale.mockResolvedValueOnce(true);
           const cachedLastModified = Date.now();
           const store: Record<string, any> = {
             pendingPromiseRunner: {
@@ -505,7 +505,7 @@ describe("CacheHandler", () => {
         });
 
         it("Should set store.lastModified to original lastModified when tag is not stale", async () => {
-          tagCache.hasBeenStale.mockResolvedValueOnce(false);
+          tagCache.isStale.mockResolvedValueOnce(false);
           const cachedLastModified = Date.now();
           const store: Record<string, any> = {
             pendingPromiseRunner: {
@@ -524,7 +524,7 @@ describe("CacheHandler", () => {
           expect(store.lastModified).toEqual(cachedLastModified);
         });
 
-        it("Should not call hasBeenStale when shouldBypassTagCache is true", async () => {
+        it("Should not call isStale when shouldBypassTagCache is true", async () => {
           incrementalCache.get.mockResolvedValueOnce({
             value: { type: "route", body: "{}" },
             lastModified: Date.now(),
@@ -533,7 +533,7 @@ describe("CacheHandler", () => {
 
           await cache.get("key", { kindHint: "app" });
 
-          expect(tagCache.hasBeenStale).not.toHaveBeenCalled();
+          expect(tagCache.isStale).not.toHaveBeenCalled();
         });
       });
     });

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -7,6 +7,7 @@ declare global {
     dangerous: { disableIncrementalCache?: boolean; disableTagCache?: boolean };
   };
   var isNextAfter15: boolean;
+  var isNextAfter16: boolean;
 }
 
 describe("CacheHandler", () => {
@@ -76,6 +77,7 @@ describe("CacheHandler", () => {
       },
     };
     globalThis.isNextAfter15 = false;
+    globalThis.isNextAfter16 = true;
     tagCache.mode = "original";
     tagCache.getPathsByTags = undefined;
   });

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -51,18 +51,21 @@ describe("CacheHandler", () => {
   globalThis.cdnInvalidationHandler = invalidateCdnHandler;
 
   globalThis.__openNextAls = {
-    getStore: vi.fn().mockReturnValue({
+    getStore: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Reset the getStore mock to return a fresh Set for each test
+    (globalThis.__openNextAls.getStore as Mock).mockReturnValue({
       pendingPromiseRunner: {
         withResolvers: vi.fn().mockReturnValue({
           resolve: vi.fn(),
         }),
       },
       writtenTags: new Set(),
-    }),
-  };
-
-  beforeEach(() => {
-    vi.clearAllMocks();
+    });
 
     cache = new Cache();
 
@@ -631,6 +634,7 @@ describe("CacheHandler", () => {
         {
           path: "/path",
           tag: "tag",
+          expiry: Date.now(),
         },
       ]);
     });
@@ -645,6 +649,7 @@ describe("CacheHandler", () => {
         {
           path: "/path",
           tag: `${SOFT_TAG_PREFIX}path`,
+          expiry: Date.now(),
         },
       ]);
 
@@ -660,6 +665,7 @@ describe("CacheHandler", () => {
         {
           path: "123456",
           tag: "tag",
+          expiry: Date.now(),
         },
       ]);
 
@@ -671,7 +677,16 @@ describe("CacheHandler", () => {
       await cache.revalidateTag(["tag1", "tag2"]);
 
       expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
-      expect(tagCache.writeTags).toHaveBeenCalledWith(["tag1", "tag2"]);
+      expect(tagCache.writeTags).toHaveBeenCalledWith([
+        {
+          tag: "tag1",
+          expiry: Date.now(),
+        },
+        {
+          tag: "tag2",
+          expiry: Date.now(),
+        },
+      ]);
       expect(invalidateCdnHandler.invalidatePaths).not.toHaveBeenCalled();
     });
 
@@ -689,7 +704,12 @@ describe("CacheHandler", () => {
       await cache.revalidateTag("tag");
 
       expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
-      expect(tagCache.writeTags).toHaveBeenCalledWith(["tag"]);
+      expect(tagCache.writeTags).toHaveBeenCalledWith([
+        {
+          tag: "tag",
+          expiry: Date.now(),
+        },
+      ]);
       expect(invalidateCdnHandler.invalidatePaths).toHaveBeenCalledWith([
         {
           initialPath: "/path",
@@ -702,6 +722,168 @@ describe("CacheHandler", () => {
           ],
         },
       ]);
+    });
+
+    describe("durations parameter", () => {
+      it("Should set expiry immediately when no durations provided (default behavior) - original mode", async () => {
+        // This is a duplicate test - see "Should call tagCache.writeTags" above
+        // which already tests this behavior
+      });
+
+      it("Should set expiry immediately when no durations provided (default behavior) - nextMode", async () => {
+        // This is a duplicate test - see "Should only call writeTags for nextMode" above
+        // which already tests this behavior
+      });
+
+      it("Should set stale and expiry when durations.expire is provided - original mode", async () => {
+        tagCache.getByTag.mockResolvedValueOnce(["/path"]);
+        tagCache.getByPath.mockResolvedValueOnce([]);
+        const now = Date.now();
+        
+        await cache.revalidateTag("tag", { expire: 60 });
+
+        expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
+        expect(tagCache.writeTags).toHaveBeenCalledWith([
+          {
+            path: "/path",
+            tag: "tag",
+            stale: now,
+            expiry: now + 60 * 1000,
+          },
+        ]);
+      });
+
+      it("Should set stale and expiry when durations.expire is provided - nextMode", async () => {
+        tagCache.mode = "nextMode";
+        const now = Date.now();
+        
+        await cache.revalidateTag("tag", { expire: 60 });
+
+        expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
+        expect(tagCache.writeTags).toHaveBeenCalledWith([
+          {
+            tag: "tag",
+            stale: now,
+            expiry: now + 60 * 1000,
+          },
+        ]);
+      });
+
+      it("Should set stale without expiry when durations.expire is undefined", async () => {
+        tagCache.mode = "nextMode";
+        const now = Date.now();
+        
+        await cache.revalidateTag("tag", { expire: undefined });
+
+        expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
+        expect(tagCache.writeTags).toHaveBeenCalledWith([
+          {
+            tag: "tag",
+            stale: now,
+            expiry: undefined,
+          },
+        ]);
+      });
+
+      it("Should handle multiple tags with durations - original mode", async () => {
+        tagCache.getByTag
+          .mockResolvedValueOnce(["/path1"])
+          .mockResolvedValueOnce(["/path2"]);
+        const now = Date.now();
+        
+        await cache.revalidateTag(["tag1", "tag2"], { expire: 30 });
+
+        expect(tagCache.writeTags).toHaveBeenCalledTimes(2);
+        expect(tagCache.writeTags).toHaveBeenNthCalledWith(1, [
+          {
+            path: "/path1",
+            tag: "tag1",
+            stale: now,
+            expiry: now + 30 * 1000,
+          },
+        ]);
+        expect(tagCache.writeTags).toHaveBeenNthCalledWith(2, [
+          {
+            path: "/path2",
+            tag: "tag2",
+            stale: now,
+            expiry: now + 30 * 1000,
+          },
+        ]);
+      });
+
+      it("Should handle multiple tags with durations - nextMode", async () => {
+        tagCache.mode = "nextMode";
+        const now = Date.now();
+        
+        await cache.revalidateTag(["tag1", "tag2"], { expire: 30 });
+
+        expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
+        expect(tagCache.writeTags).toHaveBeenCalledWith([
+          {
+            tag: "tag1",
+            stale: now,
+            expiry: now + 30 * 1000,
+          },
+          {
+            tag: "tag2",
+            stale: now,
+            expiry: now + 30 * 1000,
+          },
+        ]);
+      });
+
+      it("Should set expiry with durations for soft tags - original mode", async () => {
+        // Test soft tag without hard tags (simpler case)
+        tagCache.getByTag.mockResolvedValueOnce(["/path"]);
+        tagCache.getByPath.mockResolvedValueOnce([]); // No hard tags
+        const now = Date.now();
+        
+        await cache.revalidateTag(`${SOFT_TAG_PREFIX}path`, { expire: 60 });
+
+        expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
+        expect(tagCache.writeTags).toHaveBeenCalledWith([
+          {
+            path: "/path",
+            tag: `${SOFT_TAG_PREFIX}path`,
+            stale: now,
+            expiry: now + 60 * 1000,
+          },
+        ]);
+      });
+
+      it("Should handle immediate expiration (expire: 0) - original mode", async () => {
+        tagCache.getByTag.mockResolvedValueOnce(["/test-path"]);
+        const now = Date.now();
+        
+        await cache.revalidateTag("testtag", { expire: 0 });
+
+        expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
+        expect(tagCache.writeTags).toHaveBeenCalledWith([
+          {
+            path: "/test-path",
+            tag: "testtag",
+            stale: now,
+            expiry: now,
+          },
+        ]);
+      });
+
+      it("Should handle immediate expiration (expire: 0) - nextMode", async () => {
+        tagCache.mode = "nextMode";
+        const now = Date.now();
+        
+        await cache.revalidateTag("tag", { expire: 0 });
+
+        expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
+        expect(tagCache.writeTags).toHaveBeenCalledWith([
+          {
+            tag: "tag",
+            stale: now,
+            expiry: now,
+          },
+        ]);
+      });
     });
   });
 

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -771,7 +771,7 @@ describe("CacheHandler", () => {
         {
           path: "/path",
           tag: "tag",
-          expiry: Date.now(),
+          expire: Date.now(),
         },
       ]);
     });
@@ -786,7 +786,7 @@ describe("CacheHandler", () => {
         {
           path: "/path",
           tag: `${SOFT_TAG_PREFIX}path`,
-          expiry: Date.now(),
+          expire: Date.now(),
         },
       ]);
 
@@ -802,7 +802,7 @@ describe("CacheHandler", () => {
         {
           path: "123456",
           tag: "tag",
-          expiry: Date.now(),
+          expire: Date.now(),
         },
       ]);
 
@@ -817,11 +817,11 @@ describe("CacheHandler", () => {
       expect(tagCache.writeTags).toHaveBeenCalledWith([
         {
           tag: "tag1",
-          expiry: Date.now(),
+          expire: Date.now(),
         },
         {
           tag: "tag2",
-          expiry: Date.now(),
+          expire: Date.now(),
         },
       ]);
       expect(invalidateCdnHandler.invalidatePaths).not.toHaveBeenCalled();
@@ -844,7 +844,7 @@ describe("CacheHandler", () => {
       expect(tagCache.writeTags).toHaveBeenCalledWith([
         {
           tag: "tag",
-          expiry: Date.now(),
+          expire: Date.now(),
         },
       ]);
       expect(invalidateCdnHandler.invalidatePaths).toHaveBeenCalledWith([
@@ -876,7 +876,7 @@ describe("CacheHandler", () => {
             path: "/path",
             tag: "tag",
             stale: now,
-            expiry: now + 60 * 1000,
+            expire: now + 60 * 1000,
           },
         ]);
       });
@@ -892,7 +892,7 @@ describe("CacheHandler", () => {
           {
             tag: "tag",
             stale: now,
-            expiry: now + 60 * 1000,
+            expire: now + 60 * 1000,
           },
         ]);
       });
@@ -908,7 +908,7 @@ describe("CacheHandler", () => {
           {
             tag: "tag",
             stale: now,
-            expiry: undefined,
+            expire: undefined,
           },
         ]);
       });
@@ -927,7 +927,7 @@ describe("CacheHandler", () => {
             path: "/path1",
             tag: "tag1",
             stale: now,
-            expiry: now + 30 * 1000,
+            expire: now + 30 * 1000,
           },
         ]);
         expect(tagCache.writeTags).toHaveBeenNthCalledWith(2, [
@@ -935,7 +935,7 @@ describe("CacheHandler", () => {
             path: "/path2",
             tag: "tag2",
             stale: now,
-            expiry: now + 30 * 1000,
+            expire: now + 30 * 1000,
           },
         ]);
       });
@@ -951,12 +951,12 @@ describe("CacheHandler", () => {
           {
             tag: "tag1",
             stale: now,
-            expiry: now + 30 * 1000,
+            expire: now + 30 * 1000,
           },
           {
             tag: "tag2",
             stale: now,
-            expiry: now + 30 * 1000,
+            expire: now + 30 * 1000,
           },
         ]);
       });
@@ -975,7 +975,7 @@ describe("CacheHandler", () => {
             path: "/path",
             tag: `${SOFT_TAG_PREFIX}path`,
             stale: now,
-            expiry: now + 60 * 1000,
+            expire: now + 60 * 1000,
           },
         ]);
       });
@@ -992,7 +992,7 @@ describe("CacheHandler", () => {
             path: "/test-path",
             tag: "testtag",
             stale: now,
-            expiry: now,
+            expire: now,
           },
         ]);
       });
@@ -1008,7 +1008,7 @@ describe("CacheHandler", () => {
           {
             tag: "tag",
             stale: now,
-            expiry: now,
+            expire: now,
           },
         ]);
       });

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import Cache, { SOFT_TAG_PREFIX } from "@opennextjs/aws/adapters/cache.js";
+import { RequestCache } from "@opennextjs/aws/utils/requestCache.js";
 import { type Mock, vi } from "vitest";
 
 declare global {
@@ -482,6 +483,7 @@ describe("CacheHandler", () => {
               withResolvers: vi.fn().mockReturnValue({ resolve: vi.fn() }),
             },
             writtenTags: new Set(),
+            requestCache: new RequestCache(),
           };
           (globalThis.__openNextAls.getStore as Mock).mockReturnValue(store);
           incrementalCache.get.mockResolvedValueOnce({
@@ -492,7 +494,7 @@ describe("CacheHandler", () => {
           const result = await cache.get("key", { kindHint: "app" });
 
           expect(result).not.toBeNull();
-          expect(result?.lastModified).toEqual(cachedLastModified);
+          expect(result?.lastModified).toEqual(1);
           expect(store.lastModified).toEqual(1);
         });
 

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -862,15 +862,6 @@ describe("CacheHandler", () => {
     });
 
     describe("durations parameter", () => {
-      it("Should set expiry immediately when no durations provided (default behavior) - original mode", async () => {
-        // This is a duplicate test - see "Should call tagCache.writeTags" above
-        // which already tests this behavior
-      });
-
-      it("Should set expiry immediately when no durations provided (default behavior) - nextMode", async () => {
-        // This is a duplicate test - see "Should only call writeTags for nextMode" above
-        // which already tests this behavior
-      });
 
       it("Should set stale and expiry when durations.expire is provided - original mode", async () => {
         tagCache.getByTag.mockResolvedValueOnce(["/path"]);

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -40,6 +40,7 @@ describe("CacheHandler", () => {
       .fn()
       .mockResolvedValue(new Date("2024-01-02T00:00:00Z").getTime()),
     writeTags: vi.fn(),
+    hasBeenStale: vi.fn().mockResolvedValue(false),
     getPathsByTags: undefined as Mock | undefined,
   };
   globalThis.tagCache = tagCache;
@@ -171,6 +172,82 @@ describe("CacheHandler", () => {
 
           expect(getFetchCacheSpy).toHaveBeenCalled();
           expect(result).toBeNull();
+        });
+      });
+
+      describe("stale tags", () => {
+        it("Should return lastModified as 1 when tag is stale", async () => {
+          tagCache.mode = "nextMode";
+          tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
+          tagCache.hasBeenStale.mockResolvedValueOnce(true);
+          const cachedLastModified = Date.now();
+          incrementalCache.get.mockResolvedValueOnce({
+            value: {
+              kind: "FETCH",
+              data: {
+                headers: {},
+                body: "{}",
+                url: "https://example.com",
+                status: 200,
+              },
+            },
+            lastModified: cachedLastModified,
+          });
+
+          const result = await cache.get("key", {
+            kind: "FETCH",
+            tags: ["tag1"],
+          });
+
+          expect(result).not.toBeNull();
+          expect(result?.lastModified).toEqual(1);
+        });
+
+        it("Should return original lastModified when tag is not stale", async () => {
+          tagCache.mode = "nextMode";
+          tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
+          tagCache.hasBeenStale.mockResolvedValueOnce(false);
+          const cachedLastModified = Date.now();
+          incrementalCache.get.mockResolvedValueOnce({
+            value: {
+              kind: "FETCH",
+              data: {
+                headers: {},
+                body: "{}",
+                url: "https://example.com",
+                status: 200,
+              },
+            },
+            lastModified: cachedLastModified,
+          });
+
+          const result = await cache.get("key", {
+            kind: "FETCH",
+            tags: ["tag1"],
+          });
+
+          expect(result).not.toBeNull();
+          expect(result?.lastModified).toEqual(cachedLastModified);
+        });
+
+        it("Should not call hasBeenStale when shouldBypassTagCache is true", async () => {
+          incrementalCache.get.mockResolvedValueOnce({
+            value: {
+              kind: "FETCH",
+              data: {
+                headers: {},
+                body: "{}",
+                url: "https://example.com",
+                status: 200,
+              },
+            },
+            lastModified: Date.now(),
+            shouldBypassTagCache: true,
+          });
+
+          await cache.get("key", { kind: "FETCH", tags: ["tag1"] });
+
+          expect(tagCache.hasBeenStale).not.toHaveBeenCalled();
         });
       });
     });
@@ -392,6 +469,62 @@ describe("CacheHandler", () => {
 
         expect(getIncrementalCache).toHaveBeenCalled();
         expect(result).toBeNull();
+      });
+
+      describe("stale tags", () => {
+        it("Should set store.lastModified to 1 when tag is stale", async () => {
+          tagCache.hasBeenStale.mockResolvedValueOnce(true);
+          const cachedLastModified = Date.now();
+          const store: Record<string, any> = {
+            pendingPromiseRunner: {
+              withResolvers: vi.fn().mockReturnValue({ resolve: vi.fn() }),
+            },
+            writtenTags: new Set(),
+          };
+          (globalThis.__openNextAls.getStore as Mock).mockReturnValue(store);
+          incrementalCache.get.mockResolvedValueOnce({
+            value: { type: "route", body: "{}" },
+            lastModified: cachedLastModified,
+          });
+
+          const result = await cache.get("key", { kindHint: "app" });
+
+          expect(result).not.toBeNull();
+          expect(result?.lastModified).toEqual(cachedLastModified);
+          expect(store.lastModified).toEqual(1);
+        });
+
+        it("Should set store.lastModified to original lastModified when tag is not stale", async () => {
+          tagCache.hasBeenStale.mockResolvedValueOnce(false);
+          const cachedLastModified = Date.now();
+          const store: Record<string, any> = {
+            pendingPromiseRunner: {
+              withResolvers: vi.fn().mockReturnValue({ resolve: vi.fn() }),
+            },
+            writtenTags: new Set(),
+          };
+          (globalThis.__openNextAls.getStore as Mock).mockReturnValue(store);
+          incrementalCache.get.mockResolvedValueOnce({
+            value: { type: "route", body: "{}" },
+            lastModified: cachedLastModified,
+          });
+
+          await cache.get("key", { kindHint: "app" });
+
+          expect(store.lastModified).toEqual(cachedLastModified);
+        });
+
+        it("Should not call hasBeenStale when shouldBypassTagCache is true", async () => {
+          incrementalCache.get.mockResolvedValueOnce({
+            value: { type: "route", body: "{}" },
+            lastModified: Date.now(),
+            shouldBypassTagCache: true,
+          });
+
+          await cache.get("key", { kindHint: "app" });
+
+          expect(tagCache.hasBeenStale).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/packages/tests-unit/tests/adapters/composable-cache.test.ts
+++ b/packages/tests-unit/tests/adapters/composable-cache.test.ts
@@ -32,7 +32,7 @@ describe("Composable cache handler", () => {
     name: "mock",
     mode: "original" as string | undefined,
     hasBeenRevalidated: vi.fn(),
-    hasBeenStale: vi.fn().mockResolvedValue(false),
+    isStale: vi.fn().mockResolvedValue(false),
     getByTag: vi.fn().mockResolvedValue(["path1", "path2"]),
     getByPath: vi.fn().mockResolvedValue(["tag1"]),
     getLastModified: vi
@@ -188,11 +188,11 @@ describe("Composable cache handler", () => {
     it("should return entry with revalidate=-1 when tags are stale in nextMode", async () => {
       tagCache.mode = "nextMode";
       tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
-      tagCache.hasBeenStale.mockResolvedValueOnce(true);
+      tagCache.isStale.mockResolvedValueOnce(true);
 
       const result = await ComposableCache.get("test-key");
 
-      expect(tagCache.hasBeenStale).toHaveBeenCalledWith(
+      expect(tagCache.isStale).toHaveBeenCalledWith(
         ["tag1", "tag2"],
         expect.any(Number),
       );
@@ -203,7 +203,7 @@ describe("Composable cache handler", () => {
     it("should not override revalidate when tags are not stale in nextMode", async () => {
       tagCache.mode = "nextMode";
       tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
-      tagCache.hasBeenStale.mockResolvedValueOnce(false);
+      tagCache.isStale.mockResolvedValueOnce(false);
 
       const result = await ComposableCache.get("test-key");
 
@@ -218,17 +218,17 @@ describe("Composable cache handler", () => {
       const result = await ComposableCache.get("test-key");
 
       expect(result).toBeUndefined();
-      expect(tagCache.hasBeenStale).not.toHaveBeenCalled();
+      expect(tagCache.isStale).not.toHaveBeenCalled();
     });
 
     it("should return entry with revalidate=-1 when path is stale in original mode", async () => {
       tagCache.mode = "original";
       tagCache.getLastModified.mockResolvedValueOnce(Date.now()); // not expired
-      tagCache.hasBeenStale.mockResolvedValueOnce(true);
+      tagCache.isStale.mockResolvedValueOnce(true);
 
       const result = await ComposableCache.get("test-key");
 
-      expect(tagCache.hasBeenStale).toHaveBeenCalledWith(
+      expect(tagCache.isStale).toHaveBeenCalledWith(
         "test-key",
         expect.any(Number),
       );
@@ -243,7 +243,7 @@ describe("Composable cache handler", () => {
       const result = await ComposableCache.get("test-key");
 
       expect(result).toBeUndefined();
-      expect(tagCache.hasBeenStale).not.toHaveBeenCalled();
+      expect(tagCache.isStale).not.toHaveBeenCalled();
     });
 
     it("should return pending write promise if available", async () => {

--- a/packages/tests-unit/tests/adapters/composable-cache.test.ts
+++ b/packages/tests-unit/tests/adapters/composable-cache.test.ts
@@ -70,6 +70,7 @@ describe("Composable cache handler", () => {
         disableTagCache: false,
       },
     };
+    globalThis.isNextAfter16 = true;
   });
 
   describe("get", () => {
@@ -228,7 +229,7 @@ describe("Composable cache handler", () => {
       const result = await ComposableCache.get("test-key");
 
       expect(tagCache.hasBeenStale).toHaveBeenCalledWith(
-        ["tag1", "tag2"],
+        "test-key",
         expect.any(Number),
       );
       expect(result).toBeDefined();

--- a/packages/tests-unit/tests/adapters/composable-cache.test.ts
+++ b/packages/tests-unit/tests/adapters/composable-cache.test.ts
@@ -70,7 +70,7 @@ describe("Composable cache handler", () => {
         disableTagCache: false,
       },
     };
-    globalThis.isNextAfter16 = true;
+    globalThis.nextVersion = "16.0.0";
   });
 
   describe("get", () => {

--- a/packages/tests-unit/tests/adapters/composable-cache.test.ts
+++ b/packages/tests-unit/tests/adapters/composable-cache.test.ts
@@ -32,6 +32,7 @@ describe("Composable cache handler", () => {
     name: "mock",
     mode: "original" as string | undefined,
     hasBeenRevalidated: vi.fn(),
+    hasBeenStale: vi.fn().mockResolvedValue(false),
     getByTag: vi.fn().mockResolvedValue(["path1", "path2"]),
     getByPath: vi.fn().mockResolvedValue(["tag1"]),
     getLastModified: vi
@@ -181,6 +182,67 @@ describe("Composable cache handler", () => {
       const result = await ComposableCache.get("test-key");
 
       expect(result).toBeUndefined();
+    });
+
+    it("should return entry with revalidate=-1 when tags are stale in nextMode", async () => {
+      tagCache.mode = "nextMode";
+      tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
+      tagCache.hasBeenStale.mockResolvedValueOnce(true);
+
+      const result = await ComposableCache.get("test-key");
+
+      expect(tagCache.hasBeenStale).toHaveBeenCalledWith(
+        ["tag1", "tag2"],
+        expect.any(Number),
+      );
+      expect(result).toBeDefined();
+      expect(result?.revalidate).toBe(-1);
+    });
+
+    it("should not override revalidate when tags are not stale in nextMode", async () => {
+      tagCache.mode = "nextMode";
+      tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
+      tagCache.hasBeenStale.mockResolvedValueOnce(false);
+
+      const result = await ComposableCache.get("test-key");
+
+      expect(result).toBeDefined();
+      expect(result?.revalidate).not.toBe(-1);
+    });
+
+    it("should not check stale when tags are already expired in nextMode", async () => {
+      tagCache.mode = "nextMode";
+      tagCache.hasBeenRevalidated.mockResolvedValueOnce(true);
+
+      const result = await ComposableCache.get("test-key");
+
+      expect(result).toBeUndefined();
+      expect(tagCache.hasBeenStale).not.toHaveBeenCalled();
+    });
+
+    it("should return entry with revalidate=-1 when path is stale in original mode", async () => {
+      tagCache.mode = "original";
+      tagCache.getLastModified.mockResolvedValueOnce(Date.now()); // not expired
+      tagCache.hasBeenStale.mockResolvedValueOnce(true);
+
+      const result = await ComposableCache.get("test-key");
+
+      expect(tagCache.hasBeenStale).toHaveBeenCalledWith(
+        ["tag1", "tag2"],
+        expect.any(Number),
+      );
+      expect(result).toBeDefined();
+      expect(result?.revalidate).toBe(-1);
+    });
+
+    it("should not check stale when path is already expired in original mode", async () => {
+      tagCache.mode = "original";
+      tagCache.getLastModified.mockResolvedValueOnce(-1); // expired
+
+      const result = await ComposableCache.get("test-key");
+
+      expect(result).toBeUndefined();
+      expect(tagCache.hasBeenStale).not.toHaveBeenCalled();
     });
 
     it("should return pending write promise if available", async () => {
@@ -461,6 +523,125 @@ describe("Composable cache handler", () => {
       // Should not call any methods
       expect(incrementalCache.get).not.toHaveBeenCalled();
       expect(incrementalCache.set).not.toHaveBeenCalled();
+      expect(tagCache.writeTags).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateTags", () => {
+    beforeEach(() => {
+      writtenTags.clear();
+    });
+
+    it("should immediately expire tags when no durations provided - nextMode", async () => {
+      tagCache.mode = "nextMode";
+      const now = Date.now();
+
+      await ComposableCache.updateTags(["tag1", "tag2"]);
+
+      expect(tagCache.writeTags).toHaveBeenCalledWith([
+        { tag: "tag1", expiry: now },
+        { tag: "tag2", expiry: now },
+      ]);
+    });
+
+    it("should set stale and expiry when durations.expire provided - nextMode", async () => {
+      tagCache.mode = "nextMode";
+      const now = Date.now();
+
+      await ComposableCache.updateTags(["tag1", "tag2"], { expire: 60 });
+
+      expect(tagCache.writeTags).toHaveBeenCalledWith([
+        { tag: "tag1", stale: now, expiry: now + 60 * 1000 },
+        { tag: "tag2", stale: now, expiry: now + 60 * 1000 },
+      ]);
+    });
+
+    it("should set stale without expiry when durations.expire is undefined - nextMode", async () => {
+      tagCache.mode = "nextMode";
+      const now = Date.now();
+
+      await ComposableCache.updateTags(["tag1"], { expire: undefined });
+
+      expect(tagCache.writeTags).toHaveBeenCalledWith([
+        { tag: "tag1", stale: now, expiry: undefined },
+      ]);
+    });
+
+    it("should immediately expire tags when no durations provided - original mode", async () => {
+      tagCache.mode = "original";
+      tagCache.getByTag.mockImplementation(async (tag: string) => {
+        if (tag === "tag1") return ["/path1"];
+        if (tag === "tag2") return ["/path2"];
+        return [];
+      });
+      const now = Date.now();
+
+      await ComposableCache.updateTags(["tag1", "tag2"]);
+
+      expect(tagCache.writeTags).toHaveBeenCalledWith([
+        { path: "/path1", tag: "tag1", expiry: now },
+        { path: "/path2", tag: "tag2", expiry: now },
+      ]);
+    });
+
+    it("should set stale and expiry when durations.expire provided - original mode", async () => {
+      tagCache.mode = "original";
+      tagCache.getByTag.mockImplementation(async (tag: string) => {
+        if (tag === "tag1") return ["/path1", "/path2"];
+        return [];
+      });
+      const now = Date.now();
+
+      await ComposableCache.updateTags(["tag1"], { expire: 30 });
+
+      expect(tagCache.writeTags).toHaveBeenCalledWith([
+        { path: "/path1", tag: "tag1", stale: now, expiry: now + 30 * 1000 },
+        { path: "/path2", tag: "tag1", stale: now, expiry: now + 30 * 1000 },
+      ]);
+    });
+
+    it("should do nothing when tags list is empty", async () => {
+      tagCache.mode = "nextMode";
+
+      await ComposableCache.updateTags([]);
+
+      expect(tagCache.writeTags).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing when disableTagCache is true", async () => {
+      tagCache.mode = "nextMode";
+      globalThis.openNextConfig = {
+        dangerous: {
+          disableTagCache: true,
+          disableIncrementalCache: false,
+        },
+      };
+
+      await ComposableCache.updateTags(["tag1"]);
+
+      expect(tagCache.writeTags).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing when disableIncrementalCache is true", async () => {
+      tagCache.mode = "nextMode";
+      globalThis.openNextConfig = {
+        dangerous: {
+          disableTagCache: false,
+          disableIncrementalCache: true,
+        },
+      };
+
+      await ComposableCache.updateTags(["tag1"]);
+
+      expect(tagCache.writeTags).not.toHaveBeenCalled();
+    });
+
+    it("should not write tags when all paths are empty in original mode", async () => {
+      tagCache.mode = "original";
+      tagCache.getByTag.mockResolvedValue([]);
+
+      await ComposableCache.updateTags(["tag1"]);
+
       expect(tagCache.writeTags).not.toHaveBeenCalled();
     });
   });

--- a/packages/tests-unit/tests/adapters/composable-cache.test.ts
+++ b/packages/tests-unit/tests/adapters/composable-cache.test.ts
@@ -540,8 +540,8 @@ describe("Composable cache handler", () => {
       await ComposableCache.updateTags(["tag1", "tag2"]);
 
       expect(tagCache.writeTags).toHaveBeenCalledWith([
-        { tag: "tag1", expiry: now },
-        { tag: "tag2", expiry: now },
+        { tag: "tag1", expire: now },
+        { tag: "tag2", expire: now },
       ]);
     });
 
@@ -552,8 +552,8 @@ describe("Composable cache handler", () => {
       await ComposableCache.updateTags(["tag1", "tag2"], { expire: 60 });
 
       expect(tagCache.writeTags).toHaveBeenCalledWith([
-        { tag: "tag1", stale: now, expiry: now + 60 * 1000 },
-        { tag: "tag2", stale: now, expiry: now + 60 * 1000 },
+        { tag: "tag1", stale: now, expire: now + 60 * 1000 },
+        { tag: "tag2", stale: now, expire: now + 60 * 1000 },
       ]);
     });
 
@@ -564,7 +564,7 @@ describe("Composable cache handler", () => {
       await ComposableCache.updateTags(["tag1"], { expire: undefined });
 
       expect(tagCache.writeTags).toHaveBeenCalledWith([
-        { tag: "tag1", stale: now, expiry: undefined },
+        { tag: "tag1", stale: now, expire: undefined },
       ]);
     });
 
@@ -580,8 +580,8 @@ describe("Composable cache handler", () => {
       await ComposableCache.updateTags(["tag1", "tag2"]);
 
       expect(tagCache.writeTags).toHaveBeenCalledWith([
-        { path: "/path1", tag: "tag1", expiry: now },
-        { path: "/path2", tag: "tag2", expiry: now },
+        { path: "/path1", tag: "tag1", expire: now },
+        { path: "/path2", tag: "tag2", expire: now },
       ]);
     });
 
@@ -596,8 +596,8 @@ describe("Composable cache handler", () => {
       await ComposableCache.updateTags(["tag1"], { expire: 30 });
 
       expect(tagCache.writeTags).toHaveBeenCalledWith([
-        { path: "/path1", tag: "tag1", stale: now, expiry: now + 30 * 1000 },
-        { path: "/path2", tag: "tag1", stale: now, expiry: now + 30 * 1000 },
+        { path: "/path1", tag: "tag1", stale: now, expire: now + 30 * 1000 },
+        { path: "/path2", tag: "tag1", stale: now, expire: now + 30 * 1000 },
       ]);
     });
 

--- a/packages/tests-unit/tests/build/patch/patches/patchNextServer.test.ts
+++ b/packages/tests-unit/tests/build/patch/patches/patchNextServer.test.ts
@@ -3,6 +3,7 @@ import {
   createEmptyBodyRule,
   disablePreloadingRule,
   emptyHandleNextImageRequestRule,
+  provideInternalWaitUntil,
   removeMiddlewareManifestRule,
 } from "@opennextjs/aws/build/patch/patches/patchNextServer.js";
 import { describe, it } from "vitest";
@@ -411,6 +412,26 @@ async imageOptimizer(req, res, paramsResult, previousCacheEntry) {
 `;
 
 describe("patchNextServer", () => {
+  it("should provide internal waitUntil", () => {
+    const code = `
+class NextNodeServer extends _baseserver.default {
+    getInternalWaitUntil() {
+        this.internalWaitUntil ??= this.createInternalWaitUntil();
+        return this.internalWaitUntil;
+    }
+}
+`;
+    expect(patchCode(code, provideInternalWaitUntil)).toMatchInlineSnapshot(`
+      "class NextNodeServer extends _baseserver.default {
+          getInternalWaitUntil() {
+              this.internalWaitUntil ??= this.createInternalWaitUntil();
+              return globalThis.__openNextAls.getStore()?.waitUntil;
+          }
+      }
+      "
+    `);
+  });
+
   it("should patch getMiddlewareManifest", async () => {
     expect(
       patchCode(

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb-lite.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb-lite.test.ts
@@ -186,7 +186,9 @@ describe("dynamodb-lite tagCache", () => {
     it("returns -1 when revalidated tags exist", async () => {
       mockFetch.mockResolvedValueOnce(
         makeJsonResponse({
-          Items: [{ revalidatedAt: { N: "99999" }, tag: { S: `${BUILD_ID}/t` } }],
+          Items: [
+            { revalidatedAt: { N: "99999" }, tag: { S: `${BUILD_ID}/t` } },
+          ],
         }),
       );
 
@@ -354,7 +356,9 @@ describe("dynamodb-lite tagCache", () => {
     it("does not include stale or expiry when not provided", async () => {
       mockFetch.mockResolvedValue({ status: 200 });
 
-      await tagCache.writeTags([{ path: "/path1", tag: "tag1", revalidatedAt: 1000 }]);
+      await tagCache.writeTags([
+        { path: "/path1", tag: "tag1", revalidatedAt: 1000 },
+      ]);
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
       const item = body.RequestItems[TABLE_NAME][0].PutRequest.Item;
@@ -376,7 +380,9 @@ describe("dynamodb-lite tagCache", () => {
     it("skips write when disableTagCache is true", async () => {
       globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
 
-      await tagCache.writeTags([{ path: "/path1", tag: "tag1", revalidatedAt: 1000 }]);
+      await tagCache.writeTags([
+        { path: "/path1", tag: "tag1", revalidatedAt: 1000 },
+      ]);
 
       expect(mockFetch).not.toHaveBeenCalled();
     });

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb-lite.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb-lite.test.ts
@@ -207,7 +207,7 @@ describe("dynamodb-lite tagCache", () => {
           Items: [
             {
               revalidatedAt: { N: String(expiry) },
-              expiry: { N: String(expiry) },
+              expire: { N: String(expiry) },
               tag: { S: `${BUILD_ID}/t` },
             },
           ],
@@ -231,7 +231,7 @@ describe("dynamodb-lite tagCache", () => {
           Items: [
             {
               revalidatedAt: { N: String(revalidatedAt) },
-              expiry: { N: String(expiry) },
+              expire: { N: String(expiry) },
               tag: { S: `${BUILD_ID}/t` },
             },
           ],
@@ -343,14 +343,14 @@ describe("dynamodb-lite tagCache", () => {
           tag: "tag1",
           revalidatedAt: 1000,
           stale: 500,
-          expiry: 9999,
+          expire: 9999,
         },
       ]);
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
       const item = body.RequestItems[TABLE_NAME][0].PutRequest.Item;
       expect(item.stale).toEqual({ N: "500" });
-      expect(item.expiry).toEqual({ N: "9999" });
+      expect(item.expire).toEqual({ N: "9999" });
     });
 
     it("does not include stale or expiry when not provided", async () => {
@@ -363,7 +363,7 @@ describe("dynamodb-lite tagCache", () => {
       const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
       const item = body.RequestItems[TABLE_NAME][0].PutRequest.Item;
       expect(item.stale).toBeUndefined();
-      expect(item.expiry).toBeUndefined();
+      expect(item.expire).toBeUndefined();
     });
 
     it("builds the DynamoDB key with the buildId prefix", async () => {

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb-lite.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb-lite.test.ts
@@ -1,0 +1,407 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RequestCache } from "@opennextjs/aws/utils/requestCache.js";
+
+vi.mock("@opennextjs/aws/adapters/logger.js", () => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+}));
+
+const mockFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("aws4fetch", () => ({
+  AwsClient: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("@opennextjs/aws/utils/fetch.js", () => ({
+  customFetchClient: vi.fn().mockReturnValue(mockFetch),
+}));
+
+import tagCache from "@opennextjs/aws/overrides/tagCache/dynamodb-lite.js";
+
+declare global {
+  //@ts-ignore
+  var openNextConfig: { dangerous?: { disableTagCache?: boolean } };
+  //@ts-ignore
+  var __openNextAls: { getStore: () => any };
+}
+
+const BUILD_ID = "test-build-id";
+const TABLE_NAME = "test-table";
+
+function makeStore() {
+  return { requestCache: new RequestCache() };
+}
+
+function makeJsonResponse(body: unknown, status = 200) {
+  return {
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEXT_BUILD_ID = BUILD_ID;
+  process.env.CACHE_DYNAMO_TABLE = TABLE_NAME;
+  process.env.CACHE_BUCKET_REGION = "us-east-1";
+  process.env.AWS_ACCESS_KEY_ID = "test-key";
+  process.env.AWS_SECRET_ACCESS_KEY = "test-secret";
+  globalThis.openNextConfig = { dangerous: { disableTagCache: false } };
+  globalThis.__openNextAls = {
+    getStore: vi.fn().mockReturnValue(makeStore()),
+  };
+});
+
+describe("dynamodb-lite tagCache", () => {
+  describe("getByPath", () => {
+    it("returns tags with buildId prefix stripped", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({
+          Items: [
+            { tag: { S: `${BUILD_ID}/tag1` } },
+            { tag: { S: `${BUILD_ID}/tag2` } },
+          ],
+        }),
+      );
+
+      const result = await tagCache.getByPath("/some/path");
+
+      expect(result).toEqual(["tag1", "tag2"]);
+    });
+
+    it("sends a Query request with the correct key", async () => {
+      mockFetch.mockResolvedValueOnce(makeJsonResponse({ Items: [] }));
+
+      await tagCache.getByPath("/some/path");
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      expect(body.ExpressionAttributeValues[":key"]).toEqual({
+        S: `${BUILD_ID}/some/path`,
+      });
+    });
+
+    it("returns [] when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      const result = await tagCache.getByPath("/some/path");
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("returns cached result on second call without re-fetching", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({ Items: [{ tag: { S: `${BUILD_ID}/tag1` } }] }),
+      );
+
+      await tagCache.getByPath("/some/path");
+      const result = await tagCache.getByPath("/some/path");
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(["tag1"]);
+    });
+
+    it("throws a RecoverableError when the response status is not 200", async () => {
+      mockFetch.mockResolvedValueOnce({ status: 500, json: vi.fn() });
+
+      await expect(tagCache.getByPath("/some/path")).resolves.toEqual([]);
+    });
+
+    it("returns [] on fetch error", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("network error"));
+
+      const result = await tagCache.getByPath("/some/path");
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getByTag", () => {
+    it("returns paths with buildId prefix stripped", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({
+          Items: [
+            { path: { S: `${BUILD_ID}/path1` } },
+            { path: { S: `${BUILD_ID}/path2` } },
+          ],
+        }),
+      );
+
+      const result = await tagCache.getByTag("my-tag");
+
+      expect(result).toEqual(["path1", "path2"]);
+    });
+
+    it("sends a Query request with the correct tag key", async () => {
+      mockFetch.mockResolvedValueOnce(makeJsonResponse({ Items: [] }));
+
+      await tagCache.getByTag("my-tag");
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      expect(body.ExpressionAttributeValues[":tag"]).toEqual({
+        S: `${BUILD_ID}/my-tag`,
+      });
+    });
+
+    it("returns [] when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      const result = await tagCache.getByTag("my-tag");
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("returns cached result on second call", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({ Items: [{ path: { S: `${BUILD_ID}/path1` } }] }),
+      );
+
+      await tagCache.getByTag("some-tag");
+      const result = await tagCache.getByTag("some-tag");
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(["path1"]);
+    });
+
+    it("returns [] on fetch error", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("fetch error"));
+
+      const result = await tagCache.getByTag("my-tag");
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getLastModified", () => {
+    it("returns lastModified when no revalidated tags exist", async () => {
+      mockFetch.mockResolvedValueOnce(makeJsonResponse({ Items: [] }));
+
+      const result = await tagCache.getLastModified("/key", 12345);
+
+      expect(result).toBe(12345);
+    });
+
+    it("returns -1 when revalidated tags exist", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({
+          Items: [{ revalidatedAt: { N: "99999" }, tag: { S: `${BUILD_ID}/t` } }],
+        }),
+      );
+
+      const result = await tagCache.getLastModified("/key", 12345);
+
+      expect(result).toBe(-1);
+    });
+
+    it("returns -1 when an expired tag falls between lastModified and now", async () => {
+      const now = Date.now();
+      const expiry = now - 1000;
+      const lastModified = now - 2000;
+
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({
+          Items: [
+            {
+              revalidatedAt: { N: String(expiry) },
+              expiry: { N: String(expiry) },
+              tag: { S: `${BUILD_ID}/t` },
+            },
+          ],
+        }),
+      );
+
+      const result = await tagCache.getLastModified("/key", lastModified);
+
+      expect(result).toBe(-1);
+    });
+
+    it("excludes a tag whose expiry !== revalidatedAt from the non-expired count", async () => {
+      // In dynamodb-lite, a non-expired tag satisfies expiry === revalidatedAt
+      // A tag where expiry > now but expiry !== revalidatedAt counts as non-expired revalidated
+      const now = Date.now();
+      const revalidatedAt = now - 5000;
+      const expiry = now + 60_000; // not expired, and expiry !== revalidatedAt
+
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({
+          Items: [
+            {
+              revalidatedAt: { N: String(revalidatedAt) },
+              expiry: { N: String(expiry) },
+              tag: { S: `${BUILD_ID}/t` },
+            },
+          ],
+        }),
+      );
+
+      // expiry !== revalidatedAt, so filter returns false => nonExpiredRevalidatedTags is empty
+      // hasExpiredTag is also false (expiry > now), so result is lastModified
+      const result = await tagCache.getLastModified("/key", 0);
+
+      expect(result).toBe(0);
+    });
+
+    it("returns lastModified when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      const result = await tagCache.getLastModified("/key", 12345);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toBe(12345);
+    });
+
+    it("returns cached result on second call with same key+lastModified", async () => {
+      mockFetch.mockResolvedValueOnce(makeJsonResponse({ Items: [] }));
+
+      await tagCache.getLastModified("/key", 100);
+      const result = await tagCache.getLastModified("/key", 100);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result).toBe(100);
+    });
+
+    it("returns lastModified on fetch error", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("fetch error"));
+
+      const result = await tagCache.getLastModified("/key", 12345);
+
+      expect(result).toBe(12345);
+    });
+  });
+
+  describe("hasBeenStale", () => {
+    it("returns true when items exist beyond lastModified", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({ Items: [{ revalidatedAt: { N: "99999" } }] }),
+      );
+
+      const result = await tagCache.hasBeenStale("/key", 12345);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when no items exist", async () => {
+      mockFetch.mockResolvedValueOnce(makeJsonResponse({ Items: [] }));
+
+      const result = await tagCache.hasBeenStale("/key", 12345);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      const result = await tagCache.hasBeenStale("/key", 12345);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it("reuses cached items with getLastModified for the same key+lastModified", async () => {
+      mockFetch.mockResolvedValueOnce(makeJsonResponse({ Items: [] }));
+
+      // getLastModified does NOT share cache with hasBeenStale in dynamodb-lite
+      // (getLastModified caches the numeric result; hasBeenStale caches raw items)
+      // Both keys bring their own fetch, but hasBeenStale cache key uses raw items
+      await tagCache.hasBeenStale("/key", 100);
+      await tagCache.hasBeenStale("/key", 100);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns false on fetch error", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("fetch error"));
+
+      const result = await tagCache.hasBeenStale("/key", 12345);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("writeTags", () => {
+    it("calls fetch for the batch of tags", async () => {
+      mockFetch.mockResolvedValue({ status: 200 });
+
+      await tagCache.writeTags([
+        { path: "/path1", tag: "tag1", revalidatedAt: 1000 },
+        { path: "/path2", tag: "tag2", revalidatedAt: 2000 },
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("includes stale and expiry in the put item when provided", async () => {
+      mockFetch.mockResolvedValue({ status: 200 });
+
+      await tagCache.writeTags([
+        {
+          path: "/path1",
+          tag: "tag1",
+          revalidatedAt: 1000,
+          stale: 500,
+          expiry: 9999,
+        },
+      ]);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      const item = body.RequestItems[TABLE_NAME][0].PutRequest.Item;
+      expect(item.stale).toEqual({ N: "500" });
+      expect(item.expiry).toEqual({ N: "9999" });
+    });
+
+    it("does not include stale or expiry when not provided", async () => {
+      mockFetch.mockResolvedValue({ status: 200 });
+
+      await tagCache.writeTags([{ path: "/path1", tag: "tag1", revalidatedAt: 1000 }]);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      const item = body.RequestItems[TABLE_NAME][0].PutRequest.Item;
+      expect(item.stale).toBeUndefined();
+      expect(item.expiry).toBeUndefined();
+    });
+
+    it("builds the DynamoDB key with the buildId prefix", async () => {
+      mockFetch.mockResolvedValue({ status: 200 });
+
+      await tagCache.writeTags([{ path: "/p", tag: "t", revalidatedAt: 1000 }]);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      const item = body.RequestItems[TABLE_NAME][0].PutRequest.Item;
+      expect(item.path.S).toBe(`${BUILD_ID}/p`);
+      expect(item.tag.S).toBe(`${BUILD_ID}/t`);
+    });
+
+    it("skips write when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      await tagCache.writeTags([{ path: "/path1", tag: "tag1", revalidatedAt: 1000 }]);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("splits writes into multiple batches when tags exceed MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT", async () => {
+      mockFetch.mockResolvedValue({ status: 200 });
+
+      const tags = Array.from({ length: 26 }, (_, i) => ({
+        path: `/path${i}`,
+        tag: `tag${i}`,
+        revalidatedAt: 1000,
+      }));
+
+      await tagCache.writeTags(tags);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws when the response status is not 200", async () => {
+      mockFetch.mockResolvedValueOnce({ status: 500 });
+
+      // error is caught internally, should not propagate
+      await expect(
+        tagCache.writeTags([{ path: "/p", tag: "t", revalidatedAt: 0 }]),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb-lite.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb-lite.test.ts
@@ -273,13 +273,13 @@ describe("dynamodb-lite tagCache", () => {
     });
   });
 
-  describe("hasBeenStale", () => {
+  describe("isStale", () => {
     it("returns true when items exist beyond lastModified", async () => {
       mockFetch.mockResolvedValueOnce(
         makeJsonResponse({ Items: [{ revalidatedAt: { N: "99999" } }] }),
       );
 
-      const result = await tagCache.hasBeenStale("/key", 12345);
+      const result = await tagCache.isStale("/key", 12345);
 
       expect(result).toBe(true);
     });
@@ -287,7 +287,7 @@ describe("dynamodb-lite tagCache", () => {
     it("returns false when no items exist", async () => {
       mockFetch.mockResolvedValueOnce(makeJsonResponse({ Items: [] }));
 
-      const result = await tagCache.hasBeenStale("/key", 12345);
+      const result = await tagCache.isStale("/key", 12345);
 
       expect(result).toBe(false);
     });
@@ -295,7 +295,7 @@ describe("dynamodb-lite tagCache", () => {
     it("returns false when disableTagCache is true", async () => {
       globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
 
-      const result = await tagCache.hasBeenStale("/key", 12345);
+      const result = await tagCache.isStale("/key", 12345);
 
       expect(mockFetch).not.toHaveBeenCalled();
       expect(result).toBe(false);
@@ -304,11 +304,11 @@ describe("dynamodb-lite tagCache", () => {
     it("reuses cached items with getLastModified for the same key+lastModified", async () => {
       mockFetch.mockResolvedValueOnce(makeJsonResponse({ Items: [] }));
 
-      // getLastModified does NOT share cache with hasBeenStale in dynamodb-lite
-      // (getLastModified caches the numeric result; hasBeenStale caches raw items)
-      // Both keys bring their own fetch, but hasBeenStale cache key uses raw items
-      await tagCache.hasBeenStale("/key", 100);
-      await tagCache.hasBeenStale("/key", 100);
+      // getLastModified does NOT share cache with isStale in dynamodb-lite
+      // (getLastModified caches the numeric result; isStale caches raw items)
+      // Both keys bring their own fetch, but isStale cache key uses raw items
+      await tagCache.isStale("/key", 100);
+      await tagCache.isStale("/key", 100);
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
@@ -316,7 +316,7 @@ describe("dynamodb-lite tagCache", () => {
     it("returns false on fetch error", async () => {
       mockFetch.mockRejectedValueOnce(new Error("fetch error"));
 
-      const result = await tagCache.hasBeenStale("/key", 12345);
+      const result = await tagCache.isStale("/key", 12345);
 
       expect(result).toBe(false);
     });

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
@@ -142,7 +142,7 @@ describe("dynamodb-nextMode tagCache", () => {
               {
                 tag: { S: buildKey("tag1") },
                 revalidatedAt: { N: String(lastModified - 1) }, // before lastModified normally
-                expiry: { N: String(expiry) },
+                expire: { N: String(expiry) },
               },
             ],
           },
@@ -333,12 +333,12 @@ describe("dynamodb-nextMode tagCache", () => {
     it("writes object tags including stale and expiry", async () => {
       mockFetch.mockResolvedValue({ status: 200 });
 
-      await tagCache.writeTags([{ tag: "tag1", stale: 500, expiry: 9999 }]);
+      await tagCache.writeTags([{ tag: "tag1", stale: 500, expire: 9999 }]);
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
       const item = body.RequestItems[TABLE_NAME][0].PutRequest.Item;
       expect(item.stale).toEqual({ N: "500" });
-      expect(item.expiry).toEqual({ N: "9999" });
+      expect(item.expire).toEqual({ N: "9999" });
     });
 
     it("does not include stale or expiry when not provided in objects", async () => {
@@ -349,7 +349,7 @@ describe("dynamodb-nextMode tagCache", () => {
       const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
       const item = body.RequestItems[TABLE_NAME][0].PutRequest.Item;
       expect(item.stale).toBeUndefined();
-      expect(item.expiry).toBeUndefined();
+      expect(item.expire).toBeUndefined();
     });
 
     it("skips write when disableTagCache is true", async () => {

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
@@ -203,18 +203,18 @@ describe("dynamodb-nextMode tagCache", () => {
     });
   });
 
-  describe("hasBeenStale", () => {
+  describe("isStale", () => {
     it("returns false when disableTagCache is true", async () => {
       globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
 
-      const result = await tagCache.hasBeenStale(["tag1"], 12345);
+      const result = await tagCache.isStale(["tag1"], 12345);
 
       expect(mockFetch).not.toHaveBeenCalled();
       expect(result).toBe(false);
     });
 
     it("returns false when tags array is empty", async () => {
-      const result = await tagCache.hasBeenStale([], 12345);
+      const result = await tagCache.isStale([], 12345);
 
       expect(mockFetch).not.toHaveBeenCalled();
       expect(result).toBe(false);
@@ -223,7 +223,7 @@ describe("dynamodb-nextMode tagCache", () => {
     it("throws RecoverableError when tags.length > 100", async () => {
       const tags = Array.from({ length: 101 }, (_, i) => `tag${i}`);
 
-      await expect(tagCache.hasBeenStale(tags, 0)).rejects.toThrow(
+      await expect(tagCache.isStale(tags, 0)).rejects.toThrow(
         RecoverableError,
       );
     });
@@ -246,7 +246,7 @@ describe("dynamodb-nextMode tagCache", () => {
         }),
       );
 
-      const result = await tagCache.hasBeenStale(["tag1"], lastModified);
+      const result = await tagCache.isStale(["tag1"], lastModified);
 
       expect(result).toBe(false);
     });
@@ -269,7 +269,7 @@ describe("dynamodb-nextMode tagCache", () => {
         }),
       );
 
-      const result = await tagCache.hasBeenStale(["tag1"], lastModified);
+      const result = await tagCache.isStale(["tag1"], lastModified);
 
       expect(result).toBe(true);
     });
@@ -288,7 +288,7 @@ describe("dynamodb-nextMode tagCache", () => {
         }),
       );
 
-      const result = await tagCache.hasBeenStale(["tag1"], 0);
+      const result = await tagCache.isStale(["tag1"], 0);
 
       expect(result).toBe(false);
     });
@@ -301,7 +301,7 @@ describe("dynamodb-nextMode tagCache", () => {
       // First call populates cached tag items
       await tagCache.hasBeenRevalidated(["tag1"], 0);
       // Second call uses the cache — no additional fetch
-      await tagCache.hasBeenStale(["tag1"], 0);
+      await tagCache.isStale(["tag1"], 0);
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
@@ -309,7 +309,7 @@ describe("dynamodb-nextMode tagCache", () => {
     it("throws RecoverableError when the response status is not 200", async () => {
       mockFetch.mockResolvedValueOnce({ status: 500, json: vi.fn() });
 
-      await expect(tagCache.hasBeenStale(["tag1"], 0)).rejects.toThrow(
+      await expect(tagCache.isStale(["tag1"], 0)).rejects.toThrow(
         RecoverableError,
       );
     });

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
@@ -223,9 +223,7 @@ describe("dynamodb-nextMode tagCache", () => {
     it("throws RecoverableError when tags.length > 100", async () => {
       const tags = Array.from({ length: 101 }, (_, i) => `tag${i}`);
 
-      await expect(tagCache.isStale(tags, 0)).rejects.toThrow(
-        RecoverableError,
-      );
+      await expect(tagCache.isStale(tags, 0)).rejects.toThrow(RecoverableError);
     });
 
     it("returns false when no tag has a stale timestamp after lastModified", async () => {

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
@@ -23,7 +23,7 @@ import tagCache from "@opennextjs/aws/overrides/tagCache/dynamodb-nextMode.js";
 declare global {
   //@ts-ignore
   var openNextConfig: { dangerous?: { disableTagCache?: boolean } };
-    //@ts-ignore
+  //@ts-ignore
   var __openNextAls: { getStore: () => any };
 }
 

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
@@ -1,0 +1,380 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RecoverableError } from "@opennextjs/aws/utils/error.js";
+import { RequestCache } from "@opennextjs/aws/utils/requestCache.js";
+
+vi.mock("@opennextjs/aws/adapters/logger.js", () => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+}));
+
+const mockFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("aws4fetch", () => ({
+  AwsClient: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("@opennextjs/aws/utils/fetch.js", () => ({
+  customFetchClient: vi.fn().mockReturnValue(mockFetch),
+}));
+
+import tagCache from "@opennextjs/aws/overrides/tagCache/dynamodb-nextMode.js";
+
+declare global {
+  //@ts-ignore
+  var openNextConfig: { dangerous?: { disableTagCache?: boolean } };
+    //@ts-ignore
+  var __openNextAls: { getStore: () => any };
+}
+
+const BUILD_ID = "test-build-id";
+const TABLE_NAME = "test-table";
+
+function makeStore() {
+  return { requestCache: new RequestCache() };
+}
+
+function makeJsonResponse(body: unknown, status = 200) {
+  return {
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEXT_BUILD_ID = BUILD_ID;
+  process.env.CACHE_DYNAMO_TABLE = TABLE_NAME;
+  process.env.CACHE_BUCKET_REGION = "us-east-1";
+  process.env.AWS_ACCESS_KEY_ID = "test-key";
+  process.env.AWS_SECRET_ACCESS_KEY = "test-secret";
+  globalThis.openNextConfig = { dangerous: { disableTagCache: false } };
+  globalThis.__openNextAls = {
+    getStore: vi.fn().mockReturnValue(makeStore()),
+  };
+});
+
+// Builds the key as dynamodb-nextMode does: <buildId>/_tag/<tag>
+function buildKey(tag: string) {
+  return `${BUILD_ID}/_tag/${tag}`;
+}
+
+describe("dynamodb-nextMode tagCache", () => {
+  describe("getLastRevalidated", () => {
+    it("always returns 0", async () => {
+      const result = await tagCache.getLastRevalidated(["tag1", "tag2"]);
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("hasBeenRevalidated", () => {
+    it("returns false when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      const result = await tagCache.hasBeenRevalidated(["tag1"], 12345);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it("throws RecoverableError when tags.length > 100", async () => {
+      const tags = Array.from({ length: 101 }, (_, i) => `tag${i}`);
+
+      await expect(tagCache.hasBeenRevalidated(tags, 0)).rejects.toThrow(
+        RecoverableError,
+      );
+    });
+
+    it("returns false when no tags were revalidated after lastModified", async () => {
+      const lastModified = 50000;
+      const revalidatedAt = 30000; // before lastModified
+
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({
+          Responses: {
+            [TABLE_NAME]: [
+              {
+                tag: { S: buildKey("tag1") },
+                revalidatedAt: { N: String(revalidatedAt) },
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await tagCache.hasBeenRevalidated(["tag1"], lastModified);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns true when a tag was revalidated after lastModified", async () => {
+      const lastModified = 50000;
+      const revalidatedAt = 80000; // after lastModified
+
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({
+          Responses: {
+            [TABLE_NAME]: [
+              {
+                tag: { S: buildKey("tag1") },
+                revalidatedAt: { N: String(revalidatedAt) },
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await tagCache.hasBeenRevalidated(["tag1"], lastModified);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns true when a tag has an expired TTL between lastModified and now", async () => {
+      const now = Date.now();
+      const expiry = now - 1000; // expired 1s ago
+      const lastModified = now - 2000;
+
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({
+          Responses: {
+            [TABLE_NAME]: [
+              {
+                tag: { S: buildKey("tag1") },
+                revalidatedAt: { N: String(lastModified - 1) }, // before lastModified normally
+                expiry: { N: String(expiry) },
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await tagCache.hasBeenRevalidated(["tag1"], lastModified);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false for a tag absent from DynamoDB", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({ Responses: { [TABLE_NAME]: [] } }),
+      );
+
+      const result = await tagCache.hasBeenRevalidated(["unknown-tag"], 0);
+
+      expect(result).toBe(false);
+    });
+
+    it("sends a BatchGetItem request with the correct keys", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({ Responses: { [TABLE_NAME]: [] } }),
+      );
+
+      await tagCache.hasBeenRevalidated(["tag1", "tag2"], 0);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      const keys = body.RequestItems[TABLE_NAME].Keys;
+      expect(keys).toContainEqual({
+        path: { S: buildKey("tag1") },
+        tag: { S: buildKey("tag1") },
+      });
+      expect(keys).toContainEqual({
+        path: { S: buildKey("tag2") },
+        tag: { S: buildKey("tag2") },
+      });
+    });
+
+    it("uses cached items on second call for the same tags", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({ Responses: { [TABLE_NAME]: [] } }),
+      );
+
+      await tagCache.hasBeenRevalidated(["tag1"], 0);
+      await tagCache.hasBeenRevalidated(["tag1"], 0);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws RecoverableError when the response status is not 200", async () => {
+      mockFetch.mockResolvedValueOnce({ status: 500, json: vi.fn() });
+
+      await expect(tagCache.hasBeenRevalidated(["tag1"], 0)).rejects.toThrow(
+        RecoverableError,
+      );
+    });
+  });
+
+  describe("hasBeenStale", () => {
+    it("returns false when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      const result = await tagCache.hasBeenStale(["tag1"], 12345);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it("returns false when tags array is empty", async () => {
+      const result = await tagCache.hasBeenStale([], 12345);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it("throws RecoverableError when tags.length > 100", async () => {
+      const tags = Array.from({ length: 101 }, (_, i) => `tag${i}`);
+
+      await expect(tagCache.hasBeenStale(tags, 0)).rejects.toThrow(
+        RecoverableError,
+      );
+    });
+
+    it("returns false when no tag has a stale timestamp after lastModified", async () => {
+      const lastModified = 50000;
+      const stale = 30000; // before lastModified
+
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({
+          Responses: {
+            [TABLE_NAME]: [
+              {
+                tag: { S: buildKey("tag1") },
+                revalidatedAt: { N: "1000" },
+                stale: { N: String(stale) },
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await tagCache.hasBeenStale(["tag1"], lastModified);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns true when a tag has a stale timestamp after lastModified", async () => {
+      const lastModified = 50000;
+      const stale = 80000;
+
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({
+          Responses: {
+            [TABLE_NAME]: [
+              {
+                tag: { S: buildKey("tag1") },
+                revalidatedAt: { N: "1000" },
+                stale: { N: String(stale) },
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await tagCache.hasBeenStale(["tag1"], lastModified);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when the tag has no stale field", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({
+          Responses: {
+            [TABLE_NAME]: [
+              {
+                tag: { S: buildKey("tag1") },
+                revalidatedAt: { N: "1000" },
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await tagCache.hasBeenStale(["tag1"], 0);
+
+      expect(result).toBe(false);
+    });
+
+    it("shares the per-request cache with hasBeenRevalidated across calls", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeJsonResponse({ Responses: { [TABLE_NAME]: [] } }),
+      );
+
+      // First call populates cached tag items
+      await tagCache.hasBeenRevalidated(["tag1"], 0);
+      // Second call uses the cache — no additional fetch
+      await tagCache.hasBeenStale(["tag1"], 0);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws RecoverableError when the response status is not 200", async () => {
+      mockFetch.mockResolvedValueOnce({ status: 500, json: vi.fn() });
+
+      await expect(tagCache.hasBeenStale(["tag1"], 0)).rejects.toThrow(
+        RecoverableError,
+      );
+    });
+  });
+
+  describe("writeTags", () => {
+    it("writes string tags using the tag as both path and tag key", async () => {
+      mockFetch.mockResolvedValue({ status: 200 });
+
+      await tagCache.writeTags(["tag1", "tag2"]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      const items = body.RequestItems[TABLE_NAME].map(
+        (r: any) => r.PutRequest.Item,
+      );
+      expect(items[0].path.S).toBe(buildKey("tag1"));
+      expect(items[0].tag.S).toBe(buildKey("tag1"));
+    });
+
+    it("writes object tags including stale and expiry", async () => {
+      mockFetch.mockResolvedValue({ status: 200 });
+
+      await tagCache.writeTags([{ tag: "tag1", stale: 500, expiry: 9999 }]);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      const item = body.RequestItems[TABLE_NAME][0].PutRequest.Item;
+      expect(item.stale).toEqual({ N: "500" });
+      expect(item.expiry).toEqual({ N: "9999" });
+    });
+
+    it("does not include stale or expiry when not provided in objects", async () => {
+      mockFetch.mockResolvedValue({ status: 200 });
+
+      await tagCache.writeTags([{ tag: "tag1" }]);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      const item = body.RequestItems[TABLE_NAME][0].PutRequest.Item;
+      expect(item.stale).toBeUndefined();
+      expect(item.expiry).toBeUndefined();
+    });
+
+    it("skips write when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      await tagCache.writeTags(["tag1"]);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("splits writes into multiple batches when tags exceed MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT", async () => {
+      mockFetch.mockResolvedValue({ status: 200 });
+
+      const tags = Array.from({ length: 26 }, (_, i) => `tag${i}`);
+
+      await tagCache.writeTags(tags);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws a RecoverableError when the response status is not 200", async () => {
+      mockFetch.mockResolvedValueOnce({ status: 500 });
+
+      // Error is caught inside writeTags, should not propagate
+      await expect(tagCache.writeTags(["tag1"])).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb.test.ts
@@ -26,9 +26,9 @@ vi.mock("@aws-sdk/client-dynamodb", () => ({
 import tagCache from "@opennextjs/aws/overrides/tagCache/dynamodb.js";
 
 declare global {
-    //@ts-ignore
+  //@ts-ignore
   var openNextConfig: { dangerous?: { disableTagCache?: boolean } };
-    //@ts-ignore
+  //@ts-ignore
   var __openNextAls: { getStore: () => any };
 }
 
@@ -349,7 +349,9 @@ describe("dynamodb tagCache", () => {
     it("does not include stale or expiry in the item when not provided", async () => {
       mockSend.mockResolvedValue({});
 
-      await tagCache.writeTags([{ path: "/path1", tag: "tag1", revalidatedAt: 1000 }]);
+      await tagCache.writeTags([
+        { path: "/path1", tag: "tag1", revalidatedAt: 1000 },
+      ]);
 
       const sentCommand = mockSend.mock.calls[0][0];
       const item = sentCommand.RequestItems[TABLE_NAME][0].PutRequest.Item;
@@ -371,7 +373,9 @@ describe("dynamodb tagCache", () => {
     it("skips write when disableTagCache is true", async () => {
       globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
 
-      await tagCache.writeTags([{ path: "/path1", tag: "tag1", revalidatedAt: 1000 }]);
+      await tagCache.writeTags([
+        { path: "/path1", tag: "tag1", revalidatedAt: 1000 },
+      ]);
 
       expect(mockSend).not.toHaveBeenCalled();
     });

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb.test.ts
@@ -1,0 +1,394 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RequestCache } from "@opennextjs/aws/utils/requestCache.js";
+
+vi.mock("@opennextjs/aws/adapters/logger.js", () => ({
+  awsLogger: {},
+  debug: vi.fn(),
+  error: vi.fn(),
+}));
+
+// dynamodb.ts captures NEXT_BUILD_ID, CACHE_DYNAMO_TABLE, and CACHE_BUCKET_REGION
+// from process.env at module load time, so they must be set before the import.
+const mockSend = vi.hoisted(() => {
+  process.env.NEXT_BUILD_ID = "test-build-id";
+  process.env.CACHE_DYNAMO_TABLE = "test-table";
+  process.env.CACHE_BUCKET_REGION = "us-east-1";
+  return vi.fn();
+});
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: vi.fn().mockReturnValue({ send: mockSend }),
+  QueryCommand: vi.fn().mockImplementation((params: any) => params),
+  BatchWriteItemCommand: vi.fn().mockImplementation((params: any) => params),
+}));
+
+import tagCache from "@opennextjs/aws/overrides/tagCache/dynamodb.js";
+
+declare global {
+    //@ts-ignore
+  var openNextConfig: { dangerous?: { disableTagCache?: boolean } };
+    //@ts-ignore
+  var __openNextAls: { getStore: () => any };
+}
+
+const BUILD_ID = "test-build-id";
+const TABLE_NAME = "test-table";
+
+function makeStore() {
+  return { requestCache: new RequestCache() };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEXT_BUILD_ID = BUILD_ID;
+  process.env.CACHE_DYNAMO_TABLE = TABLE_NAME;
+  process.env.CACHE_BUCKET_REGION = "us-east-1";
+  globalThis.openNextConfig = { dangerous: { disableTagCache: false } };
+  globalThis.__openNextAls = {
+    getStore: vi.fn().mockReturnValue(makeStore()),
+  };
+});
+
+describe("dynamodb tagCache", () => {
+  describe("getByPath", () => {
+    it("returns tags with buildId prefix stripped", async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [
+          { tag: { S: `${BUILD_ID}/tag1` } },
+          { tag: { S: `${BUILD_ID}/tag2` } },
+        ],
+      });
+
+      const result = await tagCache.getByPath("/some/path");
+
+      expect(result).toEqual(["tag1", "tag2"]);
+    });
+
+    it("queries DynamoDB with the correct key", async () => {
+      mockSend.mockResolvedValueOnce({ Items: [] });
+
+      await tagCache.getByPath("/some/path");
+
+      const sentCommand = mockSend.mock.calls[0][0];
+      expect(sentCommand.ExpressionAttributeValues[":key"]).toEqual({
+        S: `${BUILD_ID}/some/path`,
+      });
+    });
+
+    it("returns [] when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      const result = await tagCache.getByPath("/some/path");
+
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("returns cached result on second call without re-querying DynamoDB", async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [{ tag: { S: `${BUILD_ID}/tag1` } }],
+      });
+
+      await tagCache.getByPath("/some/path");
+      const result = await tagCache.getByPath("/some/path");
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(["tag1"]);
+    });
+
+    it("returns [] on DynamoDB error", async () => {
+      mockSend.mockRejectedValueOnce(new Error("DynamoDB error"));
+
+      const result = await tagCache.getByPath("/some/path");
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when Items is undefined", async () => {
+      mockSend.mockResolvedValueOnce({ Items: undefined });
+
+      const result = await tagCache.getByPath("/some/path");
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getByTag", () => {
+    it("returns paths with buildId prefix stripped", async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [
+          { path: { S: `${BUILD_ID}/path1` } },
+          { path: { S: `${BUILD_ID}/path2` } },
+        ],
+      });
+
+      const result = await tagCache.getByTag("my-tag");
+
+      expect(result).toEqual(["path1", "path2"]);
+    });
+
+    it("queries DynamoDB with the correct tag key", async () => {
+      mockSend.mockResolvedValueOnce({ Items: [] });
+
+      await tagCache.getByTag("my-tag");
+
+      const sentCommand = mockSend.mock.calls[0][0];
+      expect(sentCommand.ExpressionAttributeValues[":tag"]).toEqual({
+        S: `${BUILD_ID}/my-tag`,
+      });
+    });
+
+    it("returns [] when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      const result = await tagCache.getByTag("my-tag");
+
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("returns cached result on second call without re-querying DynamoDB", async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [{ path: { S: `${BUILD_ID}/path1` } }],
+      });
+
+      await tagCache.getByTag("some-tag");
+      const result = await tagCache.getByTag("some-tag");
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(["path1"]);
+    });
+
+    it("returns [] on DynamoDB error", async () => {
+      mockSend.mockRejectedValueOnce(new Error("DynamoDB error"));
+
+      const result = await tagCache.getByTag("my-tag");
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getLastModified", () => {
+    it("returns lastModified when no revalidated tags exist", async () => {
+      mockSend.mockResolvedValueOnce({ Items: [] });
+
+      const result = await tagCache.getLastModified("/key", 12345);
+
+      expect(result).toBe(12345);
+    });
+
+    it("returns -1 when revalidated tags exist", async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [{ revalidatedAt: { N: "99999" }, tag: { S: `${BUILD_ID}/t` } }],
+      });
+
+      const result = await tagCache.getLastModified("/key", 12345);
+
+      expect(result).toBe(-1);
+    });
+
+    it("returns -1 when an expired tag falls between lastModified and now", async () => {
+      const now = Date.now();
+      const expiry = now - 1000; // expired 1s ago
+      const lastModified = now - 2000; // last checked 2s ago
+
+      mockSend.mockResolvedValueOnce({
+        Items: [
+          {
+            revalidatedAt: { N: String(expiry) },
+            expiry: { N: String(expiry) },
+            tag: { S: `${BUILD_ID}/t` },
+          },
+        ],
+      });
+
+      const result = await tagCache.getLastModified("/key", lastModified);
+
+      expect(result).toBe(-1);
+    });
+
+    it("ignores a still-active expiry tag in the revalidated-tag count", async () => {
+      const now = Date.now();
+      const expiry = now + 60_000; // not yet expired
+
+      mockSend.mockResolvedValueOnce({
+        Items: [
+          {
+            revalidatedAt: { N: String(now - 5000) },
+            expiry: { N: String(expiry) },
+            tag: { S: `${BUILD_ID}/t` },
+          },
+        ],
+      });
+
+      // expiry > now so the entry is not expired, meaning it still counts
+      const result = await tagCache.getLastModified("/key", now - 10_000);
+
+      // The non-expired revalidated tag causes -1
+      expect(result).toBe(-1);
+    });
+
+    it("returns lastModified when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      const result = await tagCache.getLastModified("/key", 12345);
+
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(result).toBe(12345);
+    });
+
+    it("uses cached items when called twice with the same key and lastModified", async () => {
+      mockSend.mockResolvedValueOnce({ Items: [] });
+
+      await tagCache.getLastModified("/key", 100);
+      await tagCache.getLastModified("/key", 100);
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns lastModified on DynamoDB error", async () => {
+      mockSend.mockRejectedValueOnce(new Error("DynamoDB error"));
+
+      const result = await tagCache.getLastModified("/key", 12345);
+
+      expect(result).toBe(12345);
+    });
+
+    it("returns Date.now() when lastModified is undefined and no tags", async () => {
+      vi.useFakeTimers().setSystemTime(50000);
+      mockSend.mockResolvedValueOnce({ Items: [] });
+
+      const result = await tagCache.getLastModified("/key", undefined);
+
+      expect(result).toBe(50000);
+      vi.useRealTimers();
+    });
+  });
+
+  describe("hasBeenStale", () => {
+    it("returns true when items exist beyond lastModified", async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [{ revalidatedAt: { N: "99999" } }],
+      });
+
+      const result = await tagCache.hasBeenStale("/key", 12345);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when no items exist", async () => {
+      mockSend.mockResolvedValueOnce({ Items: [] });
+
+      const result = await tagCache.hasBeenStale("/key", 12345);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      const result = await tagCache.hasBeenStale("/key", 12345);
+
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it("shares cached items with getLastModified for the same key+lastModified", async () => {
+      mockSend.mockResolvedValueOnce({ Items: [] });
+
+      // First call populates the shared cache
+      await tagCache.getLastModified("/key", 100);
+      // Second call reuses it
+      const result = await tagCache.hasBeenStale("/key", 100);
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(result).toBe(false);
+    });
+
+    it("returns false on DynamoDB error", async () => {
+      mockSend.mockRejectedValueOnce(new Error("DynamoDB error"));
+
+      const result = await tagCache.hasBeenStale("/key", 12345);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("writeTags", () => {
+    it("calls send for each chunk of tags", async () => {
+      mockSend.mockResolvedValue({});
+
+      await tagCache.writeTags([
+        { path: "/path1", tag: "tag1", revalidatedAt: 1000 },
+        { path: "/path2", tag: "tag2", revalidatedAt: 2000 },
+      ]);
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+
+    it("includes stale and expiry in the DynamoDB item when provided", async () => {
+      mockSend.mockResolvedValue({});
+
+      await tagCache.writeTags([
+        {
+          path: "/path1",
+          tag: "tag1",
+          revalidatedAt: 1000,
+          stale: 500,
+          expiry: 9999,
+        },
+      ]);
+
+      const sentCommand = mockSend.mock.calls[0][0];
+      const item = sentCommand.RequestItems[TABLE_NAME][0].PutRequest.Item;
+      expect(item.stale).toEqual({ N: "500" });
+      expect(item.expiry).toEqual({ N: "9999" });
+    });
+
+    it("does not include stale or expiry in the item when not provided", async () => {
+      mockSend.mockResolvedValue({});
+
+      await tagCache.writeTags([{ path: "/path1", tag: "tag1", revalidatedAt: 1000 }]);
+
+      const sentCommand = mockSend.mock.calls[0][0];
+      const item = sentCommand.RequestItems[TABLE_NAME][0].PutRequest.Item;
+      expect(item.stale).toBeUndefined();
+      expect(item.expiry).toBeUndefined();
+    });
+
+    it("builds the DynamoDB key with the buildId prefix", async () => {
+      mockSend.mockResolvedValue({});
+
+      await tagCache.writeTags([{ path: "/p", tag: "t", revalidatedAt: 1000 }]);
+
+      const sentCommand = mockSend.mock.calls[0][0];
+      const item = sentCommand.RequestItems[TABLE_NAME][0].PutRequest.Item;
+      expect(item.path.S).toBe(`${BUILD_ID}/p`);
+      expect(item.tag.S).toBe(`${BUILD_ID}/t`);
+    });
+
+    it("skips write when disableTagCache is true", async () => {
+      globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
+
+      await tagCache.writeTags([{ path: "/path1", tag: "tag1", revalidatedAt: 1000 }]);
+
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it("splits writes into multiple batches when tags exceed MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT", async () => {
+      mockSend.mockResolvedValue({});
+
+      // 26 tags = two batches (25 + 1)
+      const tags = Array.from({ length: 26 }, (_, i) => ({
+        path: `/path${i}`,
+        tag: `tag${i}`,
+        revalidatedAt: 1000,
+      }));
+
+      await tagCache.writeTags(tags);
+
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb.test.ts
@@ -266,13 +266,13 @@ describe("dynamodb tagCache", () => {
     });
   });
 
-  describe("hasBeenStale", () => {
+  describe("isStale", () => {
     it("returns true when items exist beyond lastModified", async () => {
       mockSend.mockResolvedValueOnce({
         Items: [{ revalidatedAt: { N: "99999" } }],
       });
 
-      const result = await tagCache.hasBeenStale("/key", 12345);
+      const result = await tagCache.isStale("/key", 12345);
 
       expect(result).toBe(true);
     });
@@ -280,7 +280,7 @@ describe("dynamodb tagCache", () => {
     it("returns false when no items exist", async () => {
       mockSend.mockResolvedValueOnce({ Items: [] });
 
-      const result = await tagCache.hasBeenStale("/key", 12345);
+      const result = await tagCache.isStale("/key", 12345);
 
       expect(result).toBe(false);
     });
@@ -288,7 +288,7 @@ describe("dynamodb tagCache", () => {
     it("returns false when disableTagCache is true", async () => {
       globalThis.openNextConfig = { dangerous: { disableTagCache: true } };
 
-      const result = await tagCache.hasBeenStale("/key", 12345);
+      const result = await tagCache.isStale("/key", 12345);
 
       expect(mockSend).not.toHaveBeenCalled();
       expect(result).toBe(false);
@@ -300,7 +300,7 @@ describe("dynamodb tagCache", () => {
       // First call populates the shared cache
       await tagCache.getLastModified("/key", 100);
       // Second call reuses it
-      const result = await tagCache.hasBeenStale("/key", 100);
+      const result = await tagCache.isStale("/key", 100);
 
       expect(mockSend).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
@@ -309,7 +309,7 @@ describe("dynamodb tagCache", () => {
     it("returns false on DynamoDB error", async () => {
       mockSend.mockRejectedValueOnce(new Error("DynamoDB error"));
 
-      const result = await tagCache.hasBeenStale("/key", 12345);
+      const result = await tagCache.isStale("/key", 12345);
 
       expect(result).toBe(false);
     });

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb.test.ts
@@ -197,7 +197,7 @@ describe("dynamodb tagCache", () => {
         Items: [
           {
             revalidatedAt: { N: String(expiry) },
-            expiry: { N: String(expiry) },
+            expire: { N: String(expiry) },
             tag: { S: `${BUILD_ID}/t` },
           },
         ],
@@ -216,7 +216,7 @@ describe("dynamodb tagCache", () => {
         Items: [
           {
             revalidatedAt: { N: String(now - 5000) },
-            expiry: { N: String(expiry) },
+            expire: { N: String(expiry) },
             tag: { S: `${BUILD_ID}/t` },
           },
         ],
@@ -336,14 +336,14 @@ describe("dynamodb tagCache", () => {
           tag: "tag1",
           revalidatedAt: 1000,
           stale: 500,
-          expiry: 9999,
+          expire: 9999,
         },
       ]);
 
       const sentCommand = mockSend.mock.calls[0][0];
       const item = sentCommand.RequestItems[TABLE_NAME][0].PutRequest.Item;
       expect(item.stale).toEqual({ N: "500" });
-      expect(item.expiry).toEqual({ N: "9999" });
+      expect(item.expire).toEqual({ N: "9999" });
     });
 
     it("does not include stale or expiry in the item when not provided", async () => {
@@ -356,7 +356,7 @@ describe("dynamodb tagCache", () => {
       const sentCommand = mockSend.mock.calls[0][0];
       const item = sentCommand.RequestItems[TABLE_NAME][0].PutRequest.Item;
       expect(item.stale).toBeUndefined();
-      expect(item.expiry).toBeUndefined();
+      expect(item.expire).toBeUndefined();
     });
 
     it("builds the DynamoDB key with the buildId prefix", async () => {


### PR DESCRIPTION
Add support for swr with revalidateTag.

It introduces a new methods in the tag cache (`hasBeenStale`, optional), both for the original and the next mode tag cache.

It also introduces a RequestCache utils that can be used to cache things scoped to a request (stored in our internal AsyncLocalStorage context)
