### PR TITLE
✨ Quality: Configure deterministic auth secret for local/e2e runs

### DIFF
--- a/examples/app-router/.env
+++ b/examples/app-router/.env
@@ -1,0 +1,3 @@
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=opennext-local-e2e-auth-secret
+AUTH_SECRET=opennext-local-e2e-auth-secret


### PR DESCRIPTION
## Problem

JWT generation in Playwright must use the same secret as the app. The fixture should expose a stable secret and URL values so both NextAuth and test helpers can sign/validate session tokens consistently.

**Severity**: `medium`
**File**: `examples/app-router/.env`

## Solution

Add `NEXTAUTH_SECRET` (and/or `AUTH_SECRET` depending on version), plus `NEXTAUTH_URL` pointing to the local app URL used in e2e. Keep values explicitly test-scoped (non-production) and documented as fixture-only.

## Changes

- `examples/app-router/.env` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #583