### PR TITLE
Add support for prefetch inlining

### DIFF
--- a/.changeset/eager-masks-work.md
+++ b/.changeset/eager-masks-work.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+add support for prefetch inlining in the cache interceptor

--- a/packages/open-next/src/adapters/revalidate.ts
+++ b/packages/open-next/src/adapters/revalidate.ts
@@ -25,7 +25,7 @@ export interface RevalidateEvent {
   }[];
 }
 
-const ALLOWED_STATUS_CODES = [200, 307, 308, 404]
+const ALLOWED_STATUS_CODES = [200, 307, 308, 404];
 
 const defaultHandler = async (event: RevalidateEvent) => {
   const failedRecords: RevalidateEvent["records"] = [];

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -117,7 +117,8 @@ function getBodyForAppRouter(
     const segmentHeader = `${event.headers[NEXT_SEGMENT_PREFETCH_HEADER]}`;
     const isSegmentResponse =
       Boolean(segmentHeader) &&
-      segmentHeader in (cachedValue.segmentData || {});
+      segmentHeader in (cachedValue.segmentData || {}) &&
+      !NextConfig.experimental?.prefetchInlining;
 
     const body = isSegmentResponse
       ? cachedValue.segmentData![segmentHeader]

--- a/packages/open-next/src/types/next-types.ts
+++ b/packages/open-next/src/types/next-types.ts
@@ -85,6 +85,7 @@ export interface NextConfig {
     optimizeCss?: boolean;
     // Used by Next to know if we should send a single RSC or split it into multiple ones.
     // Can be an object but only the boolean is supported for now in OpenNext.
+    // Added in Next 16.2
     prefetchInlining?: boolean;
   };
   images: ImageConfig;

--- a/packages/open-next/src/types/next-types.ts
+++ b/packages/open-next/src/types/next-types.ts
@@ -83,6 +83,9 @@ export interface NextConfig {
     serverActions?: boolean;
     appDir?: boolean;
     optimizeCss?: boolean;
+    // Used by Next to know if we should send a single RSC or split it into multiple ones.
+    // Can be an object but only the boolean is supported for now in OpenNext.
+    prefetchInlining?: boolean;
   };
   images: ImageConfig;
   poweredByHeader?: boolean;

--- a/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
+++ b/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
+import { NextConfig } from "@opennextjs/aws/adapters/config/index.js";
 import { cacheInterceptor } from "@opennextjs/aws/core/routing/cacheInterceptor.js";
 import { convertFromQueryString } from "@opennextjs/aws/core/routing/util.js";
 import type { MiddlewareEvent } from "@opennextjs/aws/types/open-next.js";
@@ -537,5 +538,119 @@ describe("cacheInterceptor", () => {
 
     const result = await cacheInterceptor(event);
     expect(result.statusCode).toBe(200);
+  });
+
+  describe("app RSC output", () => {
+    afterEach(() => {
+      delete (NextConfig as any).experimental;
+    });
+
+    it("should return RSC content for RSC data requests", async () => {
+      const event = createEvent({
+        url: "/albums",
+        headers: { rsc: "1" },
+      });
+      incrementalCache.get.mockResolvedValueOnce({
+        value: {
+          type: "app",
+          html: "HTML content",
+          rsc: "RSC content",
+        },
+      });
+
+      const result = await cacheInterceptor(event);
+
+      const body = await fromReadableStream(result.body);
+      expect(body).toEqual("RSC content");
+      expect(result).toEqual(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "content-type": "text/x-component",
+          }),
+        }),
+      );
+    });
+
+    it("should return segment data when next-router-segment-prefetch header matches segmentData", async () => {
+      const event = createEvent({
+        url: "/albums",
+        headers: {
+          rsc: "1",
+          "next-router-segment-prefetch": "/layout",
+        },
+      });
+      incrementalCache.get.mockResolvedValueOnce({
+        value: {
+          type: "app",
+          html: "HTML content",
+          rsc: "RSC content",
+          segmentData: { "/layout": "Segment content" },
+        },
+      });
+
+      const result = await cacheInterceptor(event);
+
+      const body = await fromReadableStream(result.body);
+      expect(body).toEqual("Segment content");
+      expect(result).toEqual(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "x-nextjs-prerender": "1",
+            "x-nextjs-postponed": "2",
+          }),
+        }),
+      );
+    });
+
+    it("should fall back to RSC when segment key does not exist in segmentData", async () => {
+      const event = createEvent({
+        url: "/albums",
+        headers: {
+          rsc: "1",
+          "next-router-segment-prefetch": "/not-here",
+        },
+      });
+      incrementalCache.get.mockResolvedValueOnce({
+        value: {
+          type: "app",
+          html: "HTML content",
+          rsc: "RSC content",
+          segmentData: { "/layout": "Segment content" },
+        },
+      });
+
+      const result = await cacheInterceptor(event);
+
+      const body = await fromReadableStream(result.body);
+      expect(body).toEqual("RSC content");
+      expect((result as any).headers["x-nextjs-prerender"]).toBeUndefined();
+      expect((result as any).headers["x-nextjs-postponed"]).toBeUndefined();
+    });
+
+    it("should fall back to RSC when prefetchInlining is enabled", async () => {
+      const event = createEvent({
+        url: "/albums",
+        headers: {
+          rsc: "1",
+          "next-router-segment-prefetch": "/layout",
+        },
+      });
+      incrementalCache.get.mockResolvedValueOnce({
+        value: {
+          type: "app",
+          html: "HTML content",
+          rsc: "RSC content",
+          segmentData: { "/layout": "Segment content" },
+        },
+      });
+      (NextConfig as any).experimental = { prefetchInlining: true };
+
+      const result = await cacheInterceptor(event);
+
+      const body = await fromReadableStream(result.body);
+      expect(body).toEqual("RSC content");
+      expect((result as any).headers["x-nextjs-prerender"]).toBeUndefined();
+      expect((result as any).headers["x-nextjs-postponed"]).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
Introduce support for prefetch inlining in the cache interceptor, enhancing the handling of segment data and RSC content based on the new configuration option.