### PR TITLE
fix: Handle multiple same-name headers as array in fetch proxyExternalRequest

### DIFF
--- a/.changeset/cool-tools-add.md
+++ b/.changeset/cool-tools-add.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: handle multiple same-name headers as array in fetch proxyExternalRequest

--- a/packages/open-next/src/overrides/proxyExternalRequest/fetch.ts
+++ b/packages/open-next/src/overrides/proxyExternalRequest/fetch.ts
@@ -20,7 +20,14 @@ const fetchProxy: ProxyExternalRequest = {
     });
     const responseHeaders: Record<string, string | string[]> = {};
     response.headers.forEach((value, key) => {
-      responseHeaders[key] = value;
+      const cur = responseHeaders[key];
+      if (cur === undefined) {
+        responseHeaders[key] = value;
+      } else if (Array.isArray(cur)) {
+        cur.push(value);
+      } else {
+        responseHeaders[key] = [cur, value];
+      }
     });
     return {
       type: "core",

--- a/packages/tests-unit/tests/overrides/proxyExternalRequest/fetch.test.ts
+++ b/packages/tests-unit/tests/overrides/proxyExternalRequest/fetch.test.ts
@@ -1,7 +1,16 @@
 import fetchProxy from "@opennextjs/aws/overrides/proxyExternalRequest/fetch.js";
-import { vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 
 describe("proxyExternalRequest/fetch", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
   // Note: if the url is hosted on the Cloudflare network we want to make sure that a `cf-connecting-ip` header is not being sent as that causes a DNS error
   //       (see: https://developers.cloudflare.com/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-1xxx-errors/#error-1000-dns-points-to-prohibited-ip)
   it("the proxy should remove any cf-connecting-ip headers (with any casing) before passing it to fetch", async () => {

--- a/packages/tests-unit/tests/overrides/proxyExternalRequest/fetch.test.ts
+++ b/packages/tests-unit/tests/overrides/proxyExternalRequest/fetch.test.ts
@@ -36,4 +36,28 @@ describe("proxyExternalRequest/fetch", () => {
     expect(headersPassedToFetch).not.toContain("CF-CONNECTING-IP");
     expect(headersPassedToFetch).toContain("header-4");
   });
+  it("the proxy should save multiple set-cookie response headers as an array", async () => {
+    const responseHeaders = new Headers();
+    responseHeaders.append("set-cookie", "foo=value1");
+    responseHeaders.append("set-cookie", "bar=value2");
+    responseHeaders.append("Set-Cookie", "cookie=value3");
+    const fetchMock = vi.fn<typeof global.fetch>(
+      async () =>
+        new Response(null, {
+          headers: responseHeaders,
+        }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const { proxy } = fetchProxy;
+
+    const { headers } = await proxy({ headers: {} });
+
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(headers["set-cookie"]).toEqual([
+      "foo=value1",
+      "bar=value2",
+      "cookie=value3",
+    ]);
+  });
 });


### PR DESCRIPTION
resolve: https://github.com/opennextjs/opennextjs-aws/issues/1134

