### PR TITLE
Replace NEXT_BUILD_ID with OPEN_NEXT_BUILD_ID for consistency

### DIFF
--- a/.changeset/smooth-parts-march.md
+++ b/.changeset/smooth-parts-march.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Deprecate NEXT_BUILD_ID env variable, and replace it with OPEN_NEXT_BUILD_ID

--- a/packages/open-next/src/adapters/config/index.ts
+++ b/packages/open-next/src/adapters/config/index.ts
@@ -41,5 +41,10 @@ export const AppPathRoutesManifest =
 export const FunctionsConfigManifest =
   /* @__PURE__ */ loadFunctionsConfigManifest(NEXT_DIR);
 
+/**
+ * @deprecated Do not use NEXT_BUILD_ID above Next 16.2, as it could be a fixed value if used in conjonction with deploymentId
+ * We keep it for backward compatibility
+ */
 process.env.NEXT_BUILD_ID = BuildId;
+process.env.OPEN_NEXT_BUILD_ID = NextConfig.deploymentId ?? BuildId;
 process.env.NEXT_PREVIEW_MODE_ID = PrerenderManifest?.preview?.previewModeId;

--- a/packages/open-next/src/overrides/cdnInvalidation/cloudfront.ts
+++ b/packages/open-next/src/overrides/cdnInvalidation/cloudfront.ts
@@ -19,7 +19,7 @@ export default {
           ? [`/${path}`, `/${path}?_rsc=*`]
           : [
               `/${path}`,
-              `/_next/data/${process.env.NEXT_BUILD_ID}${path === "/" ? "/index" : `/${path}`}.json*`,
+              `/_next/data/${process.env.OPEN_NEXT_BUILD_ID}${path === "/" ? "/index" : `/${path}`}.json*`,
             ];
       },
     );

--- a/packages/open-next/src/overrides/incrementalCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/incrementalCache/fs-dev.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import type { IncrementalCache } from "types/overrides.js";
 import { getMonorepoRelativePath } from "utils/normalize-path";
 
-const buildId = process.env.NEXT_BUILD_ID;
+const buildId = process.env.OPEN_NEXT_BUILD_ID;
 const basePath = path.join(getMonorepoRelativePath(), `cache/${buildId}`);
 
 const getCacheKey = (key: string) => {

--- a/packages/open-next/src/overrides/incrementalCache/multi-tier-ddb-s3.ts
+++ b/packages/open-next/src/overrides/incrementalCache/multi-tier-ddb-s3.ts
@@ -41,8 +41,8 @@ const awsFetch = (body: RequestInit["body"], type: "get" | "set" = "get") => {
 };
 
 const buildDynamoKey = (key: string) => {
-  const { NEXT_BUILD_ID } = process.env;
-  return `__meta_${NEXT_BUILD_ID}_${key}`;
+  const { OPEN_NEXT_BUILD_ID } = process.env;
+  return `__meta_${OPEN_NEXT_BUILD_ID}_${key}`;
 };
 
 /**

--- a/packages/open-next/src/overrides/incrementalCache/s3-lite.ts
+++ b/packages/open-next/src/overrides/incrementalCache/s3-lite.ts
@@ -34,11 +34,11 @@ const awsFetch = async (key: string, options: RequestInit) => {
 };
 
 function buildS3Key(key: string, extension: Extension) {
-  const { CACHE_BUCKET_KEY_PREFIX, NEXT_BUILD_ID } = process.env;
+  const { CACHE_BUCKET_KEY_PREFIX, OPEN_NEXT_BUILD_ID } = process.env;
   return path.posix.join(
     CACHE_BUCKET_KEY_PREFIX ?? "",
     extension === "fetch" ? "__fetch" : "",
-    NEXT_BUILD_ID ?? "",
+    OPEN_NEXT_BUILD_ID ?? "",
     extension === "fetch" ? key : `${key}.${extension}`,
   );
 }

--- a/packages/open-next/src/overrides/incrementalCache/s3.ts
+++ b/packages/open-next/src/overrides/incrementalCache/s3.ts
@@ -16,7 +16,7 @@ import { parseNumberFromEnv } from "../../adapters/util";
 const {
   CACHE_BUCKET_REGION,
   CACHE_BUCKET_KEY_PREFIX,
-  NEXT_BUILD_ID,
+  OPEN_NEXT_BUILD_ID,
   CACHE_BUCKET_NAME,
 } = process.env;
 
@@ -34,7 +34,7 @@ function buildS3Key(key: string, extension: Extension) {
   return path.posix.join(
     CACHE_BUCKET_KEY_PREFIX ?? "",
     extension === "fetch" ? "__fetch" : "",
-    NEXT_BUILD_ID ?? "",
+    OPEN_NEXT_BUILD_ID ?? "",
     extension === "fetch" ? key : `${key}.${extension}`,
   );
 }

--- a/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-lite.ts
@@ -51,10 +51,10 @@ const awsFetch = (
 };
 
 function buildDynamoKey(key: string) {
-  const { NEXT_BUILD_ID } = process.env;
+  const { OPEN_NEXT_BUILD_ID } = process.env;
   // FIXME: We should probably use something else than path.join here
   // this could transform some fetch cache key into a valid path
-  return path.posix.join(NEXT_BUILD_ID ?? "", key);
+  return path.posix.join(OPEN_NEXT_BUILD_ID ?? "", key);
 }
 
 function buildDynamoObject(
@@ -81,7 +81,7 @@ const tagCache: TagCache = {
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {
         return [];
       }
-      const { CACHE_DYNAMO_TABLE, NEXT_BUILD_ID } = process.env;
+      const { CACHE_DYNAMO_TABLE, OPEN_NEXT_BUILD_ID } = process.env;
       const store = globalThis.__openNextAls.getStore();
       const cache = store?.requestCache.getOrCreate<string, string[]>(
         "dynamoDb:getByPath",
@@ -113,7 +113,7 @@ const tagCache: TagCache = {
       debug("tags for path", path, tags);
       // We need to remove the buildId from the path
       const resultTags = tags.map((tag: string) =>
-        tag.replace(`${NEXT_BUILD_ID}/`, ""),
+        tag.replace(`${OPEN_NEXT_BUILD_ID}/`, ""),
       );
       cache?.set(path, resultTags);
       return resultTags;
@@ -127,7 +127,7 @@ const tagCache: TagCache = {
       if (globalThis.openNextConfig.dangerous?.disableTagCache) {
         return [];
       }
-      const { CACHE_DYNAMO_TABLE, NEXT_BUILD_ID } = process.env;
+      const { CACHE_DYNAMO_TABLE, OPEN_NEXT_BUILD_ID } = process.env;
       const store = globalThis.__openNextAls.getStore();
       const cache = store?.requestCache.getOrCreate<string, string[]>(
         "dynamoDb:getByTag",
@@ -155,7 +155,7 @@ const tagCache: TagCache = {
       const paths =
         Items?.map(
           ({ path: { S: key } }: any) =>
-            key?.replace(`${NEXT_BUILD_ID}/`, "") ?? "",
+            key?.replace(`${OPEN_NEXT_BUILD_ID}/`, "") ?? "",
         ) ?? [];
       cache?.set(tag, paths);
       return paths;

--- a/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb-nextMode.ts
@@ -50,10 +50,10 @@ const awsFetch = (
 };
 
 function buildDynamoKey(key: string) {
-  const { NEXT_BUILD_ID } = process.env;
+  const { OPEN_NEXT_BUILD_ID } = process.env;
   // FIXME: We should probably use something else than path.join here
   // this could transform some fetch cache key into a valid path
-  return path.posix.join(NEXT_BUILD_ID ?? "", "_tag", key);
+  return path.posix.join(OPEN_NEXT_BUILD_ID ?? "", "_tag", key);
 }
 
 // We use the same key for both path and tag

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -15,7 +15,7 @@ import {
   getDynamoBatchWriteCommandConcurrency,
 } from "./constants";
 
-const { CACHE_BUCKET_REGION, CACHE_DYNAMO_TABLE, NEXT_BUILD_ID } = process.env;
+const { CACHE_BUCKET_REGION, CACHE_DYNAMO_TABLE, OPEN_NEXT_BUILD_ID } = process.env;
 
 function parseDynamoClientConfigFromEnv(): DynamoDBClientConfig {
   return {
@@ -30,7 +30,7 @@ const dynamoClient = new DynamoDBClient(parseDynamoClientConfigFromEnv());
 function buildDynamoKey(key: string) {
   // FIXME: We should probably use something else than path.join here
   // this could transform some fetch cache key into a valid path
-  return path.posix.join(NEXT_BUILD_ID ?? "", key);
+  return path.posix.join(OPEN_NEXT_BUILD_ID ?? "", key);
 }
 
 function buildDynamoObject(
@@ -81,7 +81,7 @@ const tagCache: TagCache = {
       debug("tags for path", path, tags);
       // We need to remove the buildId from the path
       const resultTags = tags.map((tag) =>
-        tag.replace(`${NEXT_BUILD_ID}/`, ""),
+        tag.replace(`${OPEN_NEXT_BUILD_ID}/`, ""),
       );
       cache?.set(path, resultTags);
       return resultTags;
@@ -117,7 +117,7 @@ const tagCache: TagCache = {
       // We need to remove the buildId from the path
       const paths =
         Items?.map(
-          ({ path: { S: key } }) => key?.replace(`${NEXT_BUILD_ID}/`, "") ?? "",
+          ({ path: { S: key } }) => key?.replace(`${OPEN_NEXT_BUILD_ID}/`, "") ?? "",
         ) ?? [];
       cache?.set(tag, paths);
       return paths;

--- a/packages/open-next/src/overrides/tagCache/dynamodb.ts
+++ b/packages/open-next/src/overrides/tagCache/dynamodb.ts
@@ -15,7 +15,8 @@ import {
   getDynamoBatchWriteCommandConcurrency,
 } from "./constants";
 
-const { CACHE_BUCKET_REGION, CACHE_DYNAMO_TABLE, OPEN_NEXT_BUILD_ID } = process.env;
+const { CACHE_BUCKET_REGION, CACHE_DYNAMO_TABLE, OPEN_NEXT_BUILD_ID } =
+  process.env;
 
 function parseDynamoClientConfigFromEnv(): DynamoDBClientConfig {
   return {
@@ -117,7 +118,8 @@ const tagCache: TagCache = {
       // We need to remove the buildId from the path
       const paths =
         Items?.map(
-          ({ path: { S: key } }) => key?.replace(`${OPEN_NEXT_BUILD_ID}/`, "") ?? "",
+          ({ path: { S: key } }) =>
+            key?.replace(`${OPEN_NEXT_BUILD_ID}/`, "") ?? "",
         ) ?? [];
       cache?.set(tag, paths);
       return paths;

--- a/packages/open-next/src/overrides/tagCache/fs-dev.ts
+++ b/packages/open-next/src/overrides/tagCache/fs-dev.ts
@@ -19,10 +19,10 @@ let tags = JSON.parse(tagContent) as {
   expire?: { N: string };
 }[];
 
-const { NEXT_BUILD_ID } = process.env;
+const { OPEN_NEXT_BUILD_ID } = process.env;
 
 function buildKey(key: string) {
-  return path.posix.join(NEXT_BUILD_ID ?? "", key);
+  return path.posix.join(OPEN_NEXT_BUILD_ID ?? "", key);
 }
 
 const tagCache: TagCache = {
@@ -31,12 +31,12 @@ const tagCache: TagCache = {
   getByPath: async (path: string) => {
     return tags
       .filter((tagPathMapping) => tagPathMapping.path.S === buildKey(path))
-      .map((tag) => tag.tag.S.replace(`${NEXT_BUILD_ID}/`, ""));
+      .map((tag) => tag.tag.S.replace(`${OPEN_NEXT_BUILD_ID}/`, ""));
   },
   getByTag: async (tag: string) => {
     return tags
       .filter((tagPathMapping) => tagPathMapping.tag.S === buildKey(tag))
-      .map((tagEntry) => tagEntry.path.S.replace(`${NEXT_BUILD_ID}/`, ""));
+      .map((tagEntry) => tagEntry.path.S.replace(`${OPEN_NEXT_BUILD_ID}/`, ""));
   },
   getLastModified: async (path: string, lastModified?: number) => {
     // Check if any tag has expired

--- a/packages/open-next/src/plugins/edge.ts
+++ b/packages/open-next/src/plugins/edge.ts
@@ -195,6 +195,7 @@ ${contents}
   export const PagesManifest = ${JSON.stringify(PagesManifest)};
 
   process.env.NEXT_BUILD_ID = BuildId;
+  process.env.OPEN_NEXT_BUILD_ID = NextConfig.deploymentId ?? BuildId;
   process.env.NEXT_PREVIEW_MODE_ID = PrerenderManifest?.preview?.previewModeId;
 `;
           return { contents };

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb-lite.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb-lite.test.ts
@@ -42,7 +42,7 @@ function makeJsonResponse(body: unknown, status = 200) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  process.env.NEXT_BUILD_ID = BUILD_ID;
+  process.env.OPEN_NEXT_BUILD_ID = BUILD_ID;
   process.env.CACHE_DYNAMO_TABLE = TABLE_NAME;
   process.env.CACHE_BUCKET_REGION = "us-east-1";
   process.env.AWS_ACCESS_KEY_ID = "test-key";

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb-nextMode.test.ts
@@ -43,7 +43,7 @@ function makeJsonResponse(body: unknown, status = 200) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  process.env.NEXT_BUILD_ID = BUILD_ID;
+  process.env.OPEN_NEXT_BUILD_ID = BUILD_ID;
   process.env.CACHE_DYNAMO_TABLE = TABLE_NAME;
   process.env.CACHE_BUCKET_REGION = "us-east-1";
   process.env.AWS_ACCESS_KEY_ID = "test-key";

--- a/packages/tests-unit/tests/overrides/tagCache/dynamodb.test.ts
+++ b/packages/tests-unit/tests/overrides/tagCache/dynamodb.test.ts
@@ -8,10 +8,10 @@ vi.mock("@opennextjs/aws/adapters/logger.js", () => ({
   error: vi.fn(),
 }));
 
-// dynamodb.ts captures NEXT_BUILD_ID, CACHE_DYNAMO_TABLE, and CACHE_BUCKET_REGION
+// dynamodb.ts captures OPEN_NEXT_BUILD_ID, CACHE_DYNAMO_TABLE, and CACHE_BUCKET_REGION
 // from process.env at module load time, so they must be set before the import.
 const mockSend = vi.hoisted(() => {
-  process.env.NEXT_BUILD_ID = "test-build-id";
+  process.env.OPEN_NEXT_BUILD_ID = "test-build-id";
   process.env.CACHE_DYNAMO_TABLE = "test-table";
   process.env.CACHE_BUCKET_REGION = "us-east-1";
   return vi.fn();
@@ -41,7 +41,7 @@ function makeStore() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  process.env.NEXT_BUILD_ID = BUILD_ID;
+  process.env.OPEN_NEXT_BUILD_ID = BUILD_ID;
   process.env.CACHE_DYNAMO_TABLE = TABLE_NAME;
   process.env.CACHE_BUCKET_REGION = "us-east-1";
   globalThis.openNextConfig = { dangerous: { disableTagCache: false } };


### PR DESCRIPTION
Deprecate the NEXT_BUILD_ID environment variable in favor of OPEN_NEXT_BUILD_ID to enhance consistency and maintain backward compatibility. 