### PR TITLE
fix(cache): use the Open Next Build Id for the cache assets folder

### DIFF
--- a/.changeset/floppy-owls-travel.md
+++ b/.changeset/floppy-owls-travel.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(cache): use the Open Next Build Id for the cache assets folder

--- a/packages/open-next/src/build/createAssets.ts
+++ b/packages/open-next/src/build/createAssets.ts
@@ -24,8 +24,8 @@ export function createStaticAssets(
 
   const { appBuildOutputPath, appPublicPath, outputDir, appPath } = options;
 
-  const NextConfig = loadConfig(path.join(appBuildOutputPath, ".next"));
-  const basePath = useBasePath ? (NextConfig.basePath ?? "") : "";
+  const nextConfig = loadConfig(path.join(appBuildOutputPath, ".next"));
+  const basePath = useBasePath ? (nextConfig.basePath ?? "") : "";
 
   // Create output folder
   const outputPath = path.join(outputDir, "assets", basePath);
@@ -88,6 +88,9 @@ export function createCacheAssets(options: buildHelper.BuildOptions) {
   const { appBuildOutputPath, outputDir } = options;
   const packagePath = buildHelper.getPackagePath(options);
   const buildId = buildHelper.getBuildId(options);
+  const nextConfig = loadConfig(path.join(appBuildOutputPath, ".next"));
+  const openNextBuildId = nextConfig.deploymentId ?? buildId;
+
   let useTagCache = false;
 
   const dotNextPath = path.join(
@@ -96,7 +99,7 @@ export function createCacheAssets(options: buildHelper.BuildOptions) {
     packagePath,
   );
 
-  const outputCachePath = path.join(outputDir, "cache", buildId);
+  const outputCachePath = path.join(outputDir, "cache", openNextBuildId);
   fs.mkdirSync(outputCachePath, { recursive: true });
 
   const sourceDirs = [".next/server/pages", ".next/server/app"]


### PR DESCRIPTION
The build id should be the Open Next Build Id introduced in #1144

The current code is causing troubles in the Cloudflare adapter which retrieves the build id from the path.
I can confirm that the fix here solve the issue in the Cloudflare adapter.