### PR TITLE
fix: include `package.json#imports` re-maps in traced files

### DIFF
--- a/.changeset/copytracedfiles-imports-remap.md
+++ b/.changeset/copytracedfiles-imports-remap.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: include `package.json#imports` subpath remap targets in traced files.
+
+Next's NFT tracer does not follow the `imports` field, so packages only reachable via remaps (e.g. `@mathjax/src`'s `#mhchem/*` → `mhchemparser/esm/*`) were missing from the server bundle. `copyTracedFiles` now scans traced package.json files for an `imports` field and pulls in any bare-specifier remap targets from source.

--- a/.changeset/copytracedfiles-imports-remap.md
+++ b/.changeset/copytracedfiles-imports-remap.md
@@ -5,3 +5,5 @@
 fix: include `package.json#imports` subpath remap targets in traced files.
 
 Next's NFT tracer does not follow the `imports` field, so packages only reachable via remaps (e.g. `@mathjax/src`'s `#mhchem/*` → `mhchemparser/esm/*`) were missing from the server bundle. `copyTracedFiles` now scans traced package.json files for an `imports` field and pulls in any bare-specifier remap targets from source.
+
+Workaround for upstream issue https://github.com/vercel/next.js/issues/93295.

--- a/packages/open-next/src/build/augmentWithImportsRemaps.ts
+++ b/packages/open-next/src/build/augmentWithImportsRemaps.ts
@@ -1,0 +1,211 @@
+/**
+ * Workaround for Next.js NFT tracing missing `package.json#imports` remap targets.
+ *
+ * Next's NFT tracer does not follow the `imports` field, so packages only
+ * reachable via a subpath remap (e.g. `@mathjax/src`'s `"#mhchem/*"` ->
+ * `"mhchemparser/esm/*"`) are missing from the trace and the runtime fails
+ * to resolve them.
+ *
+ * This file augments the traced file set by walking each traced
+ * `package.json` and following its `imports` remaps to source.
+ *
+ * Tracking issue: https://github.com/vercel/next.js/issues/93295
+ */
+
+import { type Dirent, readFileSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { getCrossPlatformPathRegex } from "utils/regex.js";
+
+export const packageJsonPathRegex = getCrossPlatformPathRegex(
+  String.raw`/package\.json$`,
+  { escape: false },
+);
+
+/**
+ * Recursively flatten the value side of a `package.json#imports` entry into
+ * a list of remap targets.
+ *
+ * Values can be a string, a conditional-exports object, or an array of either.
+ *
+ * @param value - The raw value from a single `imports` entry.
+ * @param out - Array that the leaf string targets are appended to (mutated in place).
+ */
+function collectImportTargets(value: unknown, out: string[]): void {
+  if (typeof value === "string") {
+    out.push(value);
+  } else if (Array.isArray(value)) {
+    value.forEach((v) => collectImportTargets(v, out));
+  } else if (value && typeof value === "object") {
+    Object.values(value).forEach((v) => collectImportTargets(v, out));
+  }
+}
+
+/**
+ * Resolve a package's directory using a require instance.
+ *
+ * @param name - Bare package specifier to resolve (e.g. `"foo"` or `"@scope/foo"`).
+ * @param require_ - `NodeRequire` rooted at the location to resolve from.
+ * @returns The package's directory, or `null` when `name` is empty or not resolvable.
+ */
+function resolveConsumerDir(
+  name: string,
+  require_: NodeRequire,
+): string | null {
+  if (!name) return null;
+  try {
+    return path.dirname(require_.resolve(`${name}/package.json`));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Recursively register every file in a source directory as candidates to copy
+ * to a target directory, skipping nested `node_modules` and files tracked via
+ * NFT manifests.
+ *
+ * Discovered `package.json` files are tracked so that `imports` can be resolved.
+ *
+ * @param targetSrcDir - Source directory to walk.
+ * @param targetDstDir - Destination directory for source files to be copied to.
+ * @param filesToCopy - Source-to-destination map; mutated with newly-found files.
+ * Existing entries are preserved (never overwritten).
+ * @param pending - Queue of `[src, dst]` `package.json` pairs to revisit so the
+ * caller can follow transitive `imports` remaps; mutated.
+ */
+function walkTargetPackage(
+  targetSrcDir: string,
+  targetDstDir: string,
+  filesToCopy: Map<string, string>,
+  pending: Array<[string, string]>,
+): void {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(targetSrcDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const srcEntry = path.join(targetSrcDir, entry.name);
+    const dstEntry = path.join(targetDstDir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules") continue;
+      walkTargetPackage(srcEntry, dstEntry, filesToCopy, pending);
+    } else if (entry.isFile()) {
+      if (filesToCopy.has(srcEntry)) continue;
+      filesToCopy.set(srcEntry, dstEntry);
+      if (packageJsonPathRegex.test(srcEntry))
+        pending.push([srcEntry, dstEntry]);
+    }
+  }
+}
+
+/**
+ * Augment `filesToCopy` with targets of `package.json#imports` subpath remaps.
+ *
+ * Workaround for https://github.com/vercel/next.js/issues/93295: Next's NFT
+ * tracer does not follow the `imports` field, so packages that are only
+ * reachable via a remap (e.g. `@mathjax/src`'s `"#mhchem/*"` ->
+ * `"mhchemparser/esm/*"`) are missing from the trace and the runtime fails
+ * to resolve them.
+ *
+ * For every traced `package.json` with an `imports` field, this scans the
+ * remap values for bare-specifier targets, resolves each target package
+ * from the consumer's real location, and walks its source files into
+ * `filesToCopy`. Newly-discovered `package.json` files are re-queued so
+ * transitive remaps are followed. Existing entries in `filesToCopy` are
+ * never overwritten.
+ *
+ * @param filesToCopy - Map from source path to destination path; mutated in place
+ * with files of every discovered remap target.
+ * @param buildOutputPath - Project root used to seed the resolver for traced
+ * consumers.
+ */
+export function augmentWithImportsRemaps(
+  filesToCopy: Map<string, string>,
+  buildOutputPath: string,
+): void {
+  const visitedConsumers = new Set<string>();
+  const visitedTargets = new Set<string>();
+  const requireCache = new Map<string, NodeRequire>();
+
+  const projectRequire = createRequire(
+    path.join(buildOutputPath, "package.json"),
+  );
+
+  const pending: Array<[string, string]> = [];
+  for (const [src, dst] of filesToCopy) {
+    if (packageJsonPathRegex.test(src)) pending.push([src, dst]);
+  }
+
+  while (pending.length) {
+    const [pkgSrc, pkgDst] = pending.pop()!;
+    if (visitedConsumers.has(pkgSrc)) continue;
+    visitedConsumers.add(pkgSrc);
+
+    let pkg: { name?: unknown; imports?: unknown };
+    try {
+      pkg = JSON.parse(readFileSync(pkgSrc, "utf-8"));
+    } catch {
+      continue;
+    }
+    if (!pkg.imports || typeof pkg.imports !== "object") continue;
+
+    const consumerName = typeof pkg.name === "string" ? pkg.name : "";
+    const consumerSrcDir = path.dirname(pkgSrc);
+    const consumerDstDir = path.dirname(pkgDst);
+    const dstNodeModules = path.resolve(
+      consumerDstDir,
+      // traverse up from `node_modules/<name>` or `node_modules/@scope/<name>`
+      path.basename(path.dirname(consumerDstDir)).startsWith("@")
+        ? "../.."
+        : "..",
+    );
+
+    // Consumer resolves deps via its own source location in the real project.
+    const realConsumerDir =
+      resolveConsumerDir(consumerName, projectRequire) ?? consumerSrcDir;
+    let consumerRequire = requireCache.get(realConsumerDir);
+    if (!consumerRequire) {
+      consumerRequire = createRequire(
+        path.join(realConsumerDir, "package.json"),
+      );
+      requireCache.set(realConsumerDir, consumerRequire);
+    }
+
+    const targets: string[] = [];
+    for (const v of Object.values(pkg.imports)) {
+      collectImportTargets(v, targets);
+    }
+
+    for (const target of targets) {
+      if (
+        !target ||
+        target.startsWith("./") ||
+        target.startsWith("../") ||
+        target.startsWith("/") ||
+        target.startsWith("#")
+      ) {
+        continue;
+      }
+
+      const parts = target.split("/");
+
+      const isScoped = parts[0].startsWith("@");
+      if (isScoped && parts.length < 2) continue;
+      const targetPkg = isScoped ? `${parts[0]}/${parts[1]}` : parts[0];
+      if (!targetPkg) continue;
+
+      const targetSrcDir = resolveConsumerDir(targetPkg, consumerRequire);
+      if (!targetSrcDir || visitedTargets.has(targetSrcDir)) continue;
+      visitedTargets.add(targetSrcDir);
+
+      const targetDstDir = path.join(dstNodeModules, targetPkg);
+      walkTargetPackage(targetSrcDir, targetDstDir, filesToCopy, pending);
+    }
+  }
+}

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -1,6 +1,7 @@
 import url from "node:url";
 
 import {
+  type Dirent,
   chmodSync,
   copyFileSync,
   cpSync,
@@ -13,6 +14,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 
 import {
@@ -85,6 +87,152 @@ export function isNonLinuxPlatformPackage(srcPath: string): boolean {
   return nonLinuxPlatformRegex.test(srcPath);
 }
 
+const packageJsonPathRegex = getCrossPlatformPathRegex(
+  String.raw`/package\.json$`,
+  { escape: false },
+);
+
+function collectImportTargets(value: unknown, out: string[]): void {
+  if (typeof value === "string") {
+    out.push(value);
+  } else if (Array.isArray(value)) {
+    value.forEach((v) => collectImportTargets(v, out));
+  } else if (value && typeof value === "object") {
+    Object.values(value).forEach((v) => collectImportTargets(v, out));
+  }
+}
+
+function resolveConsumerDir(
+  name: string,
+  require_: NodeRequire,
+): string | null {
+  if (!name) return null;
+  try {
+    return path.dirname(require_.resolve(`${name}/package.json`));
+  } catch {
+    return null;
+  }
+}
+
+function walkTargetPackage(
+  targetSrcDir: string,
+  targetDstDir: string,
+  filesToCopy: Map<string, string>,
+  pending: Array<[string, string]>,
+): void {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(targetSrcDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const srcEntry = path.join(targetSrcDir, entry.name);
+    const dstEntry = path.join(targetDstDir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules") continue;
+      walkTargetPackage(srcEntry, dstEntry, filesToCopy, pending);
+    } else if (entry.isFile()) {
+      if (filesToCopy.has(srcEntry)) continue;
+      filesToCopy.set(srcEntry, dstEntry);
+      if (packageJsonPathRegex.test(srcEntry))
+        pending.push([srcEntry, dstEntry]);
+    }
+  }
+}
+
+// Augment traced files with targets of `package.json#imports` subpath remaps.
+// Next's NFT tracer does not follow the `imports` field, so packages that are
+// only reachable via remaps (e.g. @mathjax/src's "#mhchem/*" → "mhchemparser/esm/*")
+// are missing from the trace. Scan every traced package.json for an `imports`
+// field and pull in any bare-specifier remap targets from source.
+function augmentWithImportsRemaps(
+  filesToCopy: Map<string, string>,
+  buildOutputPath: string,
+): void {
+  const visitedConsumers = new Set<string>();
+  const visitedTargets = new Set<string>();
+  const requireCache = new Map<string, NodeRequire>();
+
+  const projectRequire = createRequire(
+    path.join(buildOutputPath, "package.json"),
+  );
+
+  const pending: Array<[string, string]> = [];
+  for (const [src, dst] of filesToCopy) {
+    if (packageJsonPathRegex.test(src)) pending.push([src, dst]);
+  }
+
+  while (pending.length) {
+    const [pkgSrc, pkgDst] = pending.pop()!;
+    if (visitedConsumers.has(pkgSrc)) continue;
+    visitedConsumers.add(pkgSrc);
+
+    let pkg: { name?: unknown; imports?: unknown };
+    try {
+      pkg = JSON.parse(readFileSync(pkgSrc, "utf-8"));
+    } catch {
+      continue;
+    }
+    if (!pkg.imports || typeof pkg.imports !== "object") continue;
+
+    const consumerName = typeof pkg.name === "string" ? pkg.name : "";
+    const consumerSrcDir = path.dirname(pkgSrc);
+    const consumerDstDir = path.dirname(pkgDst);
+    const dstNodeModules = path.resolve(
+      consumerDstDir,
+      // traverse up from `node_modules/<name>` or `node_modules/@scope/<name>`
+      path.basename(path.dirname(consumerDstDir)).startsWith("@")
+        ? "../.."
+        : "..",
+    );
+
+    // Consumer resolves deps via its own source location in the real project.
+    const realConsumerDir =
+      resolveConsumerDir(consumerName, projectRequire) ?? consumerSrcDir;
+    let consumerRequire = requireCache.get(realConsumerDir);
+    if (!consumerRequire) {
+      consumerRequire = createRequire(
+        path.join(realConsumerDir, "package.json"),
+      );
+      requireCache.set(realConsumerDir, consumerRequire);
+    }
+
+    const targets: string[] = [];
+    for (const v of Object.values(pkg.imports)) {
+      collectImportTargets(v, targets);
+    }
+
+    for (const target of targets) {
+      if (
+        !target ||
+        target.startsWith("./") ||
+        target.startsWith("../") ||
+        target.startsWith("/") ||
+        target.startsWith("#")
+      ) {
+        continue;
+      }
+
+      const parts = target.split("/");
+
+      const isScoped = parts[0].startsWith("@");
+      if (isScoped && parts.length < 2) continue;
+      const targetPkg = isScoped ? `${parts[0]}/${parts[1]}` : parts[0];
+      if (!targetPkg) continue;
+
+      const targetSrcDir = resolveConsumerDir(targetPkg, consumerRequire);
+      if (!targetSrcDir || visitedTargets.has(targetSrcDir)) continue;
+      visitedTargets.add(targetSrcDir);
+
+      const targetDstDir = path.join(dstNodeModules, targetPkg);
+      walkTargetPackage(targetSrcDir, targetDstDir, filesToCopy, pending);
+    }
+  }
+}
+
 function copyPatchFile(outputDir: string) {
   const patchFile = path.join(__dirname, "patch", "patchedAsyncStorage.js");
   const outputPatchFile = path.join(outputDir, "patchedAsyncStorage.cjs");
@@ -153,7 +301,7 @@ export async function copyTracedFiles({
       filesToCopy.set(src, dst);
 
       const module = path.join(dotNextDir, subDir, tracedPath);
-      if (module.endsWith("package.json")) {
+      if (packageJsonPathRegex.test(module)) {
         nodePackages.set(path.dirname(module), path.dirname(dst));
       }
     });
@@ -190,7 +338,7 @@ export async function copyTracedFiles({
 
     try {
       processNftFile(`${serverPath}.nft.json`);
-    } catch (e) {
+    } catch {
       if (existsSync(path.join(dotNextDir, serverPath))) {
         //TODO: add a link to the docs
         throw new Error(
@@ -229,7 +377,7 @@ File ${serverPath} does not exist
   ) => {
     try {
       computeCopyFilesForPage(pagePath);
-    } catch (e) {
+    } catch {
       if (alternativePath) {
         safeComputeCopyFilesForPage(alternativePath);
       }
@@ -286,6 +434,8 @@ File ${serverPath} does not exist
     computeCopyFilesForPage(route);
   });
 
+  augmentWithImportsRemaps(filesToCopy, buildOutputPath);
+
   // Only files that are actually copied
   const tracedFiles: string[] = [];
   const erroredFiles: string[] = [];
@@ -317,7 +467,7 @@ File ${serverPath} does not exist
     // see https://github.com/vercel/next.js/blob/498f342b3552d6fc6f1566a1cc5acea324ce0dec/packages/next/src/build/utils.ts#L1932
     try {
       symlink = readlinkSync(from);
-    } catch (e) {
+    } catch {
       //Ignore
     }
     if (symlink) {

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -1,7 +1,6 @@
 import url from "node:url";
 
 import {
-  type Dirent,
   chmodSync,
   copyFileSync,
   cpSync,
@@ -14,7 +13,6 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
 
 import {
@@ -28,6 +26,10 @@ import {
 } from "config/util.js";
 import { getCrossPlatformPathRegex } from "utils/regex.js";
 import logger from "../logger.js";
+import {
+  augmentWithImportsRemaps,
+  packageJsonPathRegex,
+} from "./augmentWithImportsRemaps.js";
 import {
   INSTRUMENTATION_TRACE_FILE,
   MIDDLEWARE_TRACE_FILE,
@@ -85,197 +87,6 @@ const nonLinuxPlatformRegex = getCrossPlatformPathRegex(
 
 export function isNonLinuxPlatformPackage(srcPath: string): boolean {
   return nonLinuxPlatformRegex.test(srcPath);
-}
-
-const packageJsonPathRegex = getCrossPlatformPathRegex(
-  String.raw`/package\.json$`,
-  { escape: false },
-);
-
-/**
- * Recursively flatten the value side of a `package.json#imports` entry into
- * a list of remap targets.
- *
- * Values can be a string, a conditional-exports object, or an array of either.
- *
- * @param value - The raw value from a single `imports` entry.
- * @param out - Array that the leaf string targets are appended to (mutated in place).
- */
-function collectImportTargets(value: unknown, out: string[]): void {
-  if (typeof value === "string") {
-    out.push(value);
-  } else if (Array.isArray(value)) {
-    value.forEach((v) => collectImportTargets(v, out));
-  } else if (value && typeof value === "object") {
-    Object.values(value).forEach((v) => collectImportTargets(v, out));
-  }
-}
-
-/**
- * Resolve a package's directory using a require instance.
- *
- * @param name - Bare package specifier to resolve (e.g. `"foo"` or `"@scope/foo"`).
- * @param require_ - `NodeRequire` rooted at the location to resolve from.
- * @returns The package's directory, or `null` when `name` is empty or not resolvable.
- */
-function resolveConsumerDir(
-  name: string,
-  require_: NodeRequire,
-): string | null {
-  if (!name) return null;
-  try {
-    return path.dirname(require_.resolve(`${name}/package.json`));
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Recursively register every file in a source directory as candidates to copy
- * to a target directory, skipping nested `node_modules` and files tracked via
- * NFT manifests.
- *
- * Discovered `package.json` files are tracked so that `imports` can be resolved.
- *
- * @param targetSrcDir - Source directory to walk.
- * @param targetDstDir - Destination directory for source files to be copied to.
- * @param filesToCopy - Source-to-destination map; mutated with newly-found files.
- * Existing entries are preserved (never overwritten).
- * @param pending - Queue of `[src, dst]` `package.json` pairs to revisit so the
- * caller can follow transitive `imports` remaps; mutated.
- */
-function walkTargetPackage(
-  targetSrcDir: string,
-  targetDstDir: string,
-  filesToCopy: Map<string, string>,
-  pending: Array<[string, string]>,
-): void {
-  let entries: Dirent[];
-  try {
-    entries = readdirSync(targetSrcDir, { withFileTypes: true });
-  } catch {
-    return;
-  }
-
-  for (const entry of entries) {
-    const srcEntry = path.join(targetSrcDir, entry.name);
-    const dstEntry = path.join(targetDstDir, entry.name);
-
-    if (entry.isDirectory()) {
-      if (entry.name === "node_modules") continue;
-      walkTargetPackage(srcEntry, dstEntry, filesToCopy, pending);
-    } else if (entry.isFile()) {
-      if (filesToCopy.has(srcEntry)) continue;
-      filesToCopy.set(srcEntry, dstEntry);
-      if (packageJsonPathRegex.test(srcEntry))
-        pending.push([srcEntry, dstEntry]);
-    }
-  }
-}
-
-/**
- * Augment `filesToCopy` with targets of `package.json#imports` subpath remaps.
- *
- * Next's NFT tracer does not follow the `imports` field, so packages that
- * are only reachable via a remap (e.g. `@mathjax/src`'s `"#mhchem/*"` ->
- * `"mhchemparser/esm/*"`) are missing from the trace and the runtime fails
- * to resolve them.
- *
- * For every traced `package.json` with an `imports` field, this scans the
- * remap values for bare-specifier targets, resolves each target package
- * from the consumer's real location, and walks its source files into
- * `filesToCopy`. Newly-discovered `package.json` files are re-queued so
- * transitive remaps are followed. Existing entries in `filesToCopy` are
- * never overwritten.
- *
- * @param filesToCopy - Map from source path to destination path; mutated in place
- * with files of every discovered remap target.
- * @param buildOutputPath - Project root used to seed the resolver for traced
- * consumers.
- */
-export function augmentWithImportsRemaps(
-  filesToCopy: Map<string, string>,
-  buildOutputPath: string,
-): void {
-  const visitedConsumers = new Set<string>();
-  const visitedTargets = new Set<string>();
-  const requireCache = new Map<string, NodeRequire>();
-
-  const projectRequire = createRequire(
-    path.join(buildOutputPath, "package.json"),
-  );
-
-  const pending: Array<[string, string]> = [];
-  for (const [src, dst] of filesToCopy) {
-    if (packageJsonPathRegex.test(src)) pending.push([src, dst]);
-  }
-
-  while (pending.length) {
-    const [pkgSrc, pkgDst] = pending.pop()!;
-    if (visitedConsumers.has(pkgSrc)) continue;
-    visitedConsumers.add(pkgSrc);
-
-    let pkg: { name?: unknown; imports?: unknown };
-    try {
-      pkg = JSON.parse(readFileSync(pkgSrc, "utf-8"));
-    } catch {
-      continue;
-    }
-    if (!pkg.imports || typeof pkg.imports !== "object") continue;
-
-    const consumerName = typeof pkg.name === "string" ? pkg.name : "";
-    const consumerSrcDir = path.dirname(pkgSrc);
-    const consumerDstDir = path.dirname(pkgDst);
-    const dstNodeModules = path.resolve(
-      consumerDstDir,
-      // traverse up from `node_modules/<name>` or `node_modules/@scope/<name>`
-      path.basename(path.dirname(consumerDstDir)).startsWith("@")
-        ? "../.."
-        : "..",
-    );
-
-    // Consumer resolves deps via its own source location in the real project.
-    const realConsumerDir =
-      resolveConsumerDir(consumerName, projectRequire) ?? consumerSrcDir;
-    let consumerRequire = requireCache.get(realConsumerDir);
-    if (!consumerRequire) {
-      consumerRequire = createRequire(
-        path.join(realConsumerDir, "package.json"),
-      );
-      requireCache.set(realConsumerDir, consumerRequire);
-    }
-
-    const targets: string[] = [];
-    for (const v of Object.values(pkg.imports)) {
-      collectImportTargets(v, targets);
-    }
-
-    for (const target of targets) {
-      if (
-        !target ||
-        target.startsWith("./") ||
-        target.startsWith("../") ||
-        target.startsWith("/") ||
-        target.startsWith("#")
-      ) {
-        continue;
-      }
-
-      const parts = target.split("/");
-
-      const isScoped = parts[0].startsWith("@");
-      if (isScoped && parts.length < 2) continue;
-      const targetPkg = isScoped ? `${parts[0]}/${parts[1]}` : parts[0];
-      if (!targetPkg) continue;
-
-      const targetSrcDir = resolveConsumerDir(targetPkg, consumerRequire);
-      if (!targetSrcDir || visitedTargets.has(targetSrcDir)) continue;
-      visitedTargets.add(targetSrcDir);
-
-      const targetDstDir = path.join(dstNodeModules, targetPkg);
-      walkTargetPackage(targetSrcDir, targetDstDir, filesToCopy, pending);
-    }
-  }
 }
 
 function copyPatchFile(outputDir: string) {

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -92,6 +92,15 @@ const packageJsonPathRegex = getCrossPlatformPathRegex(
   { escape: false },
 );
 
+/**
+ * Recursively flatten the value side of a `package.json#imports` entry into
+ * a list of remap targets.
+ *
+ * Values can be a string, a conditional-exports object, or an array of either.
+ *
+ * @param value - The raw value from a single `imports` entry.
+ * @param out - Array that the leaf string targets are appended to (mutated in place).
+ */
 function collectImportTargets(value: unknown, out: string[]): void {
   if (typeof value === "string") {
     out.push(value);
@@ -102,6 +111,13 @@ function collectImportTargets(value: unknown, out: string[]): void {
   }
 }
 
+/**
+ * Resolve a package's directory using a require instance.
+ *
+ * @param name - Bare package specifier to resolve (e.g. `"foo"` or `"@scope/foo"`).
+ * @param require_ - `NodeRequire` rooted at the location to resolve from.
+ * @returns The package's directory, or `null` when `name` is empty or not resolvable.
+ */
 function resolveConsumerDir(
   name: string,
   require_: NodeRequire,
@@ -114,6 +130,20 @@ function resolveConsumerDir(
   }
 }
 
+/**
+ * Recursively register every file in a source directory as candidates to copy
+ * to a target directory, skipping nested `node_modules` and files tracked via
+ * NFT manifests.
+ *
+ * Discovered `package.json` files are tracked so that `imports` can be resolved.
+ *
+ * @param targetSrcDir - Source directory to walk.
+ * @param targetDstDir - Destination directory for source files to be copied to.
+ * @param filesToCopy - Source-to-destination map; mutated with newly-found files.
+ * Existing entries are preserved (never overwritten).
+ * @param pending - Queue of `[src, dst]` `package.json` pairs to revisit so the
+ * caller can follow transitive `imports` remaps; mutated.
+ */
 function walkTargetPackage(
   targetSrcDir: string,
   targetDstDir: string,
@@ -143,12 +173,27 @@ function walkTargetPackage(
   }
 }
 
-// Augment traced files with targets of `package.json#imports` subpath remaps.
-// Next's NFT tracer does not follow the `imports` field, so packages that are
-// only reachable via remaps (e.g. @mathjax/src's "#mhchem/*" → "mhchemparser/esm/*")
-// are missing from the trace. Scan every traced package.json for an `imports`
-// field and pull in any bare-specifier remap targets from source.
-function augmentWithImportsRemaps(
+/**
+ * Augment `filesToCopy` with targets of `package.json#imports` subpath remaps.
+ *
+ * Next's NFT tracer does not follow the `imports` field, so packages that
+ * are only reachable via a remap (e.g. `@mathjax/src`'s `"#mhchem/*"` ->
+ * `"mhchemparser/esm/*"`) are missing from the trace and the runtime fails
+ * to resolve them.
+ *
+ * For every traced `package.json` with an `imports` field, this scans the
+ * remap values for bare-specifier targets, resolves each target package
+ * from the consumer's real location, and walks its source files into
+ * `filesToCopy`. Newly-discovered `package.json` files are re-queued so
+ * transitive remaps are followed. Existing entries in `filesToCopy` are
+ * never overwritten.
+ *
+ * @param filesToCopy - Map from source path to destination path; mutated in place
+ * with files of every discovered remap target.
+ * @param buildOutputPath - Project root used to seed the resolver for traced
+ * consumers.
+ */
+export function augmentWithImportsRemaps(
   filesToCopy: Map<string, string>,
   buildOutputPath: string,
 ): void {

--- a/packages/tests-unit/tests/build/augmentWithImportsRemaps.test.ts
+++ b/packages/tests-unit/tests/build/augmentWithImportsRemaps.test.ts
@@ -8,7 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { augmentWithImportsRemaps } from "@opennextjs/aws/build/copyTracedFiles.js";
+import { augmentWithImportsRemaps } from "@opennextjs/aws/build/augmentWithImportsRemaps.js";
 
 function ensureDir(...parts: string[]): string {
   const dir = path.join(...parts);

--- a/packages/tests-unit/tests/build/augmentWithImportsRemaps.test.ts
+++ b/packages/tests-unit/tests/build/augmentWithImportsRemaps.test.ts
@@ -1,0 +1,216 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { augmentWithImportsRemaps } from "@opennextjs/aws/build/copyTracedFiles.js";
+
+function ensureDir(...parts: string[]): string {
+  const dir = path.join(...parts);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeJson(file: string, value: unknown): void {
+  ensureDir(path.dirname(file));
+  writeFileSync(file, JSON.stringify(value));
+}
+
+function writeSource(file: string, content = "// noop\n"): void {
+  ensureDir(path.dirname(file));
+  writeFileSync(file, content);
+}
+
+describe("augmentWithImportsRemaps", () => {
+  let projectRoot: string;
+  // Bogus prefix used only as `filesToCopy` Map values - never read or written
+  // by the function under test, just compared as strings.
+  const fakeOutRoot = "/__never-written__";
+
+  beforeEach(() => {
+    // realpath because on macOS `tmpdir()` is a symlink (`/var/...` →
+    // `/private/var/...`) but `require.resolve` returns the realpath form;
+    // we need both sides of the test to agree.
+    projectRoot = realpathSync(
+      mkdtempSync(path.join(tmpdir(), "augment-imports-")),
+    );
+    writeJson(path.join(projectRoot, "package.json"), {
+      name: "test-app",
+      version: "0.0.0",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  test.each([
+    {
+      label: "unscoped consumer",
+      consumerRelPath: "node_modules/consumer/package.json",
+      consumerName: "consumer",
+    },
+    {
+      label: "scoped consumer (dst hops up two levels)",
+      consumerRelPath: "node_modules/@scope/consumer/package.json",
+      consumerName: "@scope/consumer",
+    },
+  ])(
+    "places remap target next to $label",
+    ({ consumerRelPath, consumerName }) => {
+      const consumerPkg = path.join(projectRoot, consumerRelPath);
+      writeJson(consumerPkg, {
+        name: consumerName,
+        imports: { "#foo/*": "target-pkg/sub/*" },
+      });
+
+      const targetDir = ensureDir(projectRoot, "node_modules/target-pkg");
+      writeJson(path.join(targetDir, "package.json"), { name: "target-pkg" });
+      writeSource(path.join(targetDir, "sub/file.js"));
+      writeSource(path.join(targetDir, "other.js"));
+
+      const filesToCopy = new Map<string, string>([
+        [consumerPkg, path.join(fakeOutRoot, consumerRelPath)],
+      ]);
+
+      augmentWithImportsRemaps(filesToCopy, projectRoot);
+
+      // target-pkg files land under `<fakeOutRoot>/node_modules/target-pkg/...`
+      // regardless of whether the consumer was scoped.
+      expect(filesToCopy.get(path.join(targetDir, "sub/file.js"))).toBe(
+        path.join(fakeOutRoot, "node_modules/target-pkg/sub/file.js"),
+      );
+      expect(filesToCopy.get(path.join(targetDir, "other.js"))).toBe(
+        path.join(fakeOutRoot, "node_modules/target-pkg/other.js"),
+      );
+      expect(filesToCopy.get(path.join(targetDir, "package.json"))).toBe(
+        path.join(fakeOutRoot, "node_modules/target-pkg/package.json"),
+      );
+    },
+  );
+
+  test("follows transitive remaps via newly-discovered package.json files", () => {
+    // consumer -> target-a (via imports), target-a -> target-b (via imports).
+    const consumerPkg = path.join(
+      projectRoot,
+      "node_modules/consumer/package.json",
+    );
+    writeJson(consumerPkg, {
+      name: "consumer",
+      imports: { "#a/*": "target-a/*" },
+    });
+
+    const targetA = ensureDir(projectRoot, "node_modules/target-a");
+    writeJson(path.join(targetA, "package.json"), {
+      name: "target-a",
+      imports: { "#b/*": "target-b/*" },
+    });
+    writeSource(path.join(targetA, "a.js"));
+
+    const targetB = ensureDir(projectRoot, "node_modules/target-b");
+    writeJson(path.join(targetB, "package.json"), { name: "target-b" });
+    writeSource(path.join(targetB, "b.js"));
+
+    const filesToCopy = new Map<string, string>([
+      [
+        consumerPkg,
+        path.join(fakeOutRoot, "node_modules/consumer/package.json"),
+      ],
+    ]);
+
+    augmentWithImportsRemaps(filesToCopy, projectRoot);
+
+    expect(filesToCopy.get(path.join(targetA, "a.js"))).toBe(
+      path.join(fakeOutRoot, "node_modules/target-a/a.js"),
+    );
+    expect(filesToCopy.get(path.join(targetB, "b.js"))).toBe(
+      path.join(fakeOutRoot, "node_modules/target-b/b.js"),
+    );
+  });
+
+  test("ignores non-resolvable targets without polluting the map", () => {
+    const consumerPkg = path.join(
+      projectRoot,
+      "node_modules/consumer/package.json",
+    );
+    writeJson(consumerPkg, {
+      name: "consumer",
+      imports: {
+        "#local/*": "./internal/*",
+        "#parent/*": "../sibling/*",
+        "#abs/*": "/etc/passwd",
+        "#chained": "#other",
+        "#bareScope": "@scope", // scoped specifier with no package segment
+      },
+    });
+
+    const filesToCopy = new Map<string, string>([
+      [
+        consumerPkg,
+        path.join(fakeOutRoot, "node_modules/consumer/package.json"),
+      ],
+    ]);
+    const sizeBefore = filesToCopy.size;
+
+    expect(() =>
+      augmentWithImportsRemaps(filesToCopy, projectRoot),
+    ).not.toThrow();
+    // No resolvable bare-specifier targets -> no new files.
+    expect(filesToCopy.size).toBe(sizeBefore);
+  });
+
+  test("does not overwrite existing dst entries already in filesToCopy", () => {
+    const consumerPkg = path.join(
+      projectRoot,
+      "node_modules/consumer/package.json",
+    );
+    writeJson(consumerPkg, {
+      name: "consumer",
+      imports: { "#foo": "target-pkg/file.js" },
+    });
+
+    const targetDir = ensureDir(projectRoot, "node_modules/target-pkg");
+    writeJson(path.join(targetDir, "package.json"), { name: "target-pkg" });
+    writeSource(path.join(targetDir, "file.js"));
+
+    // Pretend NFT already mapped target-pkg/file.js to a different destination.
+    const nftDst = path.join(fakeOutRoot, "nft-mapped/target-pkg/file.js");
+    const filesToCopy = new Map<string, string>([
+      [
+        consumerPkg,
+        path.join(fakeOutRoot, "node_modules/consumer/package.json"),
+      ],
+      [path.join(targetDir, "file.js"), nftDst],
+    ]);
+
+    augmentWithImportsRemaps(filesToCopy, projectRoot);
+
+    // The pre-existing mapping wins.
+    expect(filesToCopy.get(path.join(targetDir, "file.js"))).toBe(nftDst);
+  });
+
+  test("is a no-op for consumers with no `imports` field", () => {
+    const consumerPkg = path.join(
+      projectRoot,
+      "node_modules/consumer/package.json",
+    );
+    writeJson(consumerPkg, { name: "consumer" });
+
+    const filesToCopy = new Map<string, string>([
+      [
+        consumerPkg,
+        path.join(fakeOutRoot, "node_modules/consumer/package.json"),
+      ],
+    ]);
+    const snapshot = new Map(filesToCopy);
+
+    augmentWithImportsRemaps(filesToCopy, projectRoot);
+
+    expect(filesToCopy).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
Next's NFT tracer does not appear to follow the `imports` field in `package.json`, so packages only reachable via subpath remaps (e.g. `@mathjax/src`'s `"#mhchem/*"` -> `"mhchemparser/esm/*"`) are missing from the traced server bundle, and built-time and runtime fails to resolve them in the Cloudflare adapter.

`copyTracedFiles` now scans every traced `package.json` for an `imports` field and, for any bare-specifier remap target, resolves the target package from the consumer's real location and pulls its source files in.

This is tested via https://github.com/opennextjs/opennextjs-cloudflare/pull/1231 with a reproduction for https://github.com/opennextjs/opennextjs-cloudflare/issues/1229 (would be a good candidate for monorepo!)

The root cause of the issue seems to be a bug in Next.js, see https://github.com/vercel/next.js/issues/93295