### PR TITLE
Fix/next image external fetch parameters

### DIFF
--- a/.changeset/common-animals-drive.md
+++ b/.changeset/common-animals-drive.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix next 15.5.18 usage of fetchExternalImage

--- a/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
+++ b/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
@@ -27,12 +27,24 @@ export async function optimizeImage(
 ) {
   const { isAbsolute, href } = imageParams;
 
-  // Signature for the fetch Image functions have changed in Next.js 15.5.16 and 16.2.5, so we need to check the version to determine how to call them.
-  const isAfter1625 = compareSemver(globalThis.nextVersion, ">=", "16.2.5");
-  const isAfter15516 =
-    compareSemver(globalThis.nextVersion, ">=", "15.5.16") &&
+  const isVersion15 =
+    compareSemver(globalThis.nextVersion, ">=", "15") &&
     compareSemver(globalThis.nextVersion, "<", "16");
-  const isNewArgsForInternalFetch = isAfter1625 || isAfter15516;
+  const isV16Plus = compareSemver(globalThis.nextVersion, ">=", "16");
+
+  // fetchExternalImage signature varies across Next.js versions:
+  //   <=v15.5.9:       fetchExternalImage(href)
+  //   v15.5.10–v15.x:  fetchExternalImage(href, maximumResponseBody)
+  //   v16.0.0–v16.1.4: fetchExternalImage(href, dangerouslyAllowLocalIP)
+  //   v16.1.5+:        fetchExternalImage(href, dangerouslyAllowLocalIP, maximumResponseBody)
+  const externalNeedsDangerouslyAllowLocalIP = isV16Plus;
+  const externalNeedsMaxBody =
+    (isVersion15 && compareSemver(globalThis.nextVersion, ">=", "15.5.10")) ||
+    compareSemver(globalThis.nextVersion, ">=", "16.1.5");
+
+  // fetchInternalImage added maximumResponseBody in all v15 and v16.2.5+.
+  const internalNeedsMaxBody =
+    isVersion15 || compareSemver(globalThis.nextVersion, ">=", "16.2.5");
 
   // The default value for maximumResponseBody is 50KB in Next code
   // https://github.com/vercel/next.js/blob/0f38c522/packages/next/src/shared/lib/image-config.ts#L164
@@ -41,11 +53,15 @@ export async function optimizeImage(
 
   const imageUpstream = isAbsolute
     ? // https://github.com/vercel/next.js/blob/bfe2ab4/packages/next/src/server/image-optimizer.ts#L711
-      await (isNewArgsForInternalFetch
-        ? fetchExternalImage(href, false, maximumResponseBody)
-        : //@ts-expect-error - fetchExternalImage signature has changed in Next.js 16, it has an extra boolean parameter.
-          fetchExternalImage(href))
-    : await (isNewArgsForInternalFetch
+      // @ts-ignore - fetchExternalImage signature varies across Next.js versions
+      await (externalNeedsDangerouslyAllowLocalIP
+        ? externalNeedsMaxBody
+          ? fetchExternalImage(href, false, maximumResponseBody)
+          : fetchExternalImage(href, false)
+        : externalNeedsMaxBody
+          ? fetchExternalImage(href, maximumResponseBody)
+          : fetchExternalImage(href))
+    : await (internalNeedsMaxBody
         ? fetchInternalImage(
             href,
             // @ts-expect-error - It is supposed to be an IncomingMessage object, but only the headers are used.

--- a/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
+++ b/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
@@ -56,14 +56,16 @@ export async function optimizeImage(
 
   const imageUpstream = isAbsolute
     ? // https://github.com/vercel/next.js/blob/bfe2ab4/packages/next/src/server/image-optimizer.ts#L711
-      // @ts-ignore - fetchExternalImage signature varies across Next.js versions
       await (isAfter1615
         ? fetchExternalImage(href, false, maximumResponseBody)
         : isV16Plus
-          ? fetchExternalImage(href, false)
+          ? // @ts-expect-error - fetchExternalImage signature varies across Next.js versions
+            fetchExternalImage(href, false)
           : isV15After15510
-            ? fetchExternalImage(href, maximumResponseBody)
-            : fetchExternalImage(href))
+            ? // @ts-expect-error - fetchExternalImage signature varies across Next.js versions
+              fetchExternalImage(href, maximumResponseBody)
+            : // @ts-expect-error - fetchExternalImage signature varies across Next.js versions
+              fetchExternalImage(href))
     : await (isNewArgsForInternalFetch
         ? fetchInternalImage(
             href,

--- a/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
+++ b/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
@@ -31,7 +31,7 @@ export async function optimizeImage(
   const isV15After15510 =
     compareSemver(globalThis.nextVersion, ">=", "15.5.10") &&
     compareSemver(globalThis.nextVersion, "<", "16");
-  const isV15After15516 =
+  const isV15After15515 =
     compareSemver(globalThis.nextVersion, ">=", "15.5.16") &&
     compareSemver(globalThis.nextVersion, "<", "16");
   const isV16Plus = compareSemver(globalThis.nextVersion, ">=", "16");
@@ -41,7 +41,7 @@ export async function optimizeImage(
   // fetchInternalImage signature varies across Next.js versions:
   //   <=v15.5.15, v16.0.0–v16.2.4: fetchInternalImage(href, req, res, handleRequest)
   //   v15.5.16–v15.x, v16.2.5+:    fetchInternalImage(href, req, res, maximumResponseBody, handleRequest)
-  const isNewArgsForInternalFetch = isAfter1625 || isV15After15516;
+  const isNewArgsForInternalFetch = isAfter1625 || isV15After15515;
 
   // fetchExternalImage signature varies across Next.js versions:
   //   <=v15.5.9:       fetchExternalImage(href)

--- a/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
+++ b/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
@@ -27,24 +27,22 @@ export async function optimizeImage(
 ) {
   const { isAbsolute, href } = imageParams;
 
-  const isVersion15 =
-    compareSemver(globalThis.nextVersion, ">=", "15") &&
+  // Signature for the fetch Image functions have changed across Next.js versions.
+  const isV15After15510 =
+    compareSemver(globalThis.nextVersion, ">=", "15.5.10") &&
     compareSemver(globalThis.nextVersion, "<", "16");
   const isV16Plus = compareSemver(globalThis.nextVersion, ">=", "16");
+  const isAfter1615 = compareSemver(globalThis.nextVersion, ">=", "16.1.5");
+  const isAfter1625 = compareSemver(globalThis.nextVersion, ">=", "16.2.5");
+
+  // fetchInternalImage: maximumResponseBody added in v15.5.10 and v16.2.5.
+  const isNewArgsForInternalFetch = isAfter1625 || isV15After15510;
 
   // fetchExternalImage signature varies across Next.js versions:
   //   <=v15.5.9:       fetchExternalImage(href)
   //   v15.5.10–v15.x:  fetchExternalImage(href, maximumResponseBody)
   //   v16.0.0–v16.1.4: fetchExternalImage(href, dangerouslyAllowLocalIP)
   //   v16.1.5+:        fetchExternalImage(href, dangerouslyAllowLocalIP, maximumResponseBody)
-  const externalNeedsDangerouslyAllowLocalIP = isV16Plus;
-  const externalNeedsMaxBody =
-    (isVersion15 && compareSemver(globalThis.nextVersion, ">=", "15.5.10")) ||
-    compareSemver(globalThis.nextVersion, ">=", "16.1.5");
-
-  // fetchInternalImage added maximumResponseBody in all v15 and v16.2.5+.
-  const internalNeedsMaxBody =
-    isVersion15 || compareSemver(globalThis.nextVersion, ">=", "16.2.5");
 
   // The default value for maximumResponseBody is 50KB in Next code
   // https://github.com/vercel/next.js/blob/0f38c522/packages/next/src/shared/lib/image-config.ts#L164
@@ -54,14 +52,14 @@ export async function optimizeImage(
   const imageUpstream = isAbsolute
     ? // https://github.com/vercel/next.js/blob/bfe2ab4/packages/next/src/server/image-optimizer.ts#L711
       // @ts-ignore - fetchExternalImage signature varies across Next.js versions
-      await (externalNeedsDangerouslyAllowLocalIP
-        ? externalNeedsMaxBody
-          ? fetchExternalImage(href, false, maximumResponseBody)
-          : fetchExternalImage(href, false)
-        : externalNeedsMaxBody
-          ? fetchExternalImage(href, maximumResponseBody)
-          : fetchExternalImage(href))
-    : await (internalNeedsMaxBody
+      await (isAfter1615
+        ? fetchExternalImage(href, false, maximumResponseBody)
+        : isV16Plus
+          ? fetchExternalImage(href, false)
+          : isV15After15510
+            ? fetchExternalImage(href, maximumResponseBody)
+            : fetchExternalImage(href))
+    : await (isNewArgsForInternalFetch
         ? fetchInternalImage(
             href,
             // @ts-expect-error - It is supposed to be an IncomingMessage object, but only the headers are used.
@@ -70,7 +68,7 @@ export async function optimizeImage(
             maximumResponseBody,
             handleRequest,
           )
-        : // @ts-expect-error - fetchInternalImage signature has changed in Next.js 15.5.16 and 16.2.5
+        : // @ts-expect-error - fetchInternalImage signature has changed in Next.js 15.5.10 and 16.2.5
           fetchInternalImage(
             href,
             { headers },

--- a/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
+++ b/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
@@ -31,12 +31,17 @@ export async function optimizeImage(
   const isV15After15510 =
     compareSemver(globalThis.nextVersion, ">=", "15.5.10") &&
     compareSemver(globalThis.nextVersion, "<", "16");
+  const isV15After15516 =
+    compareSemver(globalThis.nextVersion, ">=", "15.5.16") &&
+    compareSemver(globalThis.nextVersion, "<", "16");
   const isV16Plus = compareSemver(globalThis.nextVersion, ">=", "16");
   const isAfter1615 = compareSemver(globalThis.nextVersion, ">=", "16.1.5");
   const isAfter1625 = compareSemver(globalThis.nextVersion, ">=", "16.2.5");
 
-  // fetchInternalImage: maximumResponseBody added in v15.5.10 and v16.2.5.
-  const isNewArgsForInternalFetch = isAfter1625 || isV15After15510;
+  // fetchInternalImage signature varies across Next.js versions:
+  //   <=v15.5.15, v16.0.0–v16.2.4: fetchInternalImage(href, req, res, handleRequest)
+  //   v15.5.16–v15.x, v16.2.5+:    fetchInternalImage(href, req, res, maximumResponseBody, handleRequest)
+  const isNewArgsForInternalFetch = isAfter1625 || isV15After15516;
 
   // fetchExternalImage signature varies across Next.js versions:
   //   <=v15.5.9:       fetchExternalImage(href)
@@ -68,7 +73,7 @@ export async function optimizeImage(
             maximumResponseBody,
             handleRequest,
           )
-        : // @ts-expect-error - fetchInternalImage signature has changed in Next.js 15.5.10 and 16.2.5
+        : // @ts-expect-error - fetchInternalImage signature has changed in Next.js 15.5.16 and 16.2.5
           fetchInternalImage(
             href,
             { headers },


### PR DESCRIPTION
## Summary
 
 `fetchExternalImage` usage is all over the place in Next.js but in summary:
 - <= 15.5.9 requires `fetchExternalImage(href)` - https://github.com/vercel/next.js/blob/v15.5.9/packages/next/src/server/image-optimizer.ts#L697
 - \>= 15.5.10 - v15.5.x requires `fetchExternalImage(href, maximumResponseBody)` - https://github.com/vercel/next.js/blob/v15.5.10/packages/next/src/server/image-optimizer.ts#L697-L700 & https://github.com/vercel/next.js/blob/v15.5.18/packages/next/src/server/image-optimizer.ts#L787-L790
 - \> 16.0.0 - < 16.1.4 requires `fetchExternalImage(href, dangerouslyAllowLocalIP)` because `maximumResponseBody` was dropped. - https://github.com/vercel/next.js/blob/v16.1.4/packages/next/src/server/image-optimizer.ts#L711-L715
 - \>= 16.1.5 requires `fetchExternalImage(href, dangerouslyAllowLocalIP, maximumResponseBody)` https://github.com/vercel/next.js/blob/v16.1.5/packages/next/src/server/image-optimizer.ts#L711-L715 & https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/image-optimizer.ts#L862-L867

Fixes an error on the `15.5.18` next.js branch + OpenNext `4.0.1` where maximumResponseBody becomes false producing this error:

```
START RequestId: - Version: $LATEST
2026-05-08T13:44:00.401Z    -    ERROR     ⨯ upstream image response exceeded maximum size for [some-url] 2347
2026-05-08T13:44:00.401Z    -    ERROR    Failed to optimize image Br [Error]: "url" parameter is valid but upstream response is invalid
    at aEe (file:///var/task/index.mjs:44:53498)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async R3e (file:///var/task/index.mjs:105:71685)
    at async I3e (file:///var/task/index.mjs:105:72655)
    at async BufferedInvokeProcessor.handler (file:///var/task/index.mjs:44:70794)
    at async BufferedInvokeProcessor.processInvoke (file:///var/runtime/index.mjs:1092:22)
    at async _Runtime.processSingleConcurrent (file:///var/runtime/index.mjs:1178:7)
    at async _Runtime.start (file:///var/runtime/index.mjs:1165:7)
    at async ignition (file:///var/runtime/index.mjs:1634:5) {
  statusCode: 413
}
END RequestId: -
REPORT RequestId: -    Duration: 43.41 ms    Billed Duration: 44 ms    Memory Size: 6144 MB    Max Memory Used: 134 MB    
XRAY TraceId: -SegmentId: -    Sampled: true 
```

### Additional context:
`fetchInternalImage` didn't introduce `maximumResponseBody` at the same time as `fetchExternalImage` so added conditions for that - >=15.5.16 <16 requires `maximumResponseBody`, 16.1.5 re-introduces it for both.