### PR TITLE
fix(build): use basename to detect package.json in copyTracedFiles

### DIFF
--- a/.changeset/fix-copytraced-package-json-suffix.md
+++ b/.changeset/fix-copytraced-package-json-suffix.md
@@ -1,0 +1,10 @@
+---
+"@opennextjs/aws": patch
+---
+
+`copyTracedFiles`: only register a traced file as a node package when its
+basename is exactly `package.json`, not when its filename merely ends with
+`package.json` (e.g. `care-package.json`). The previous suffix-only check
+caused harmless but noisy `Failed to copy <dir>` errors in the Cloudflare
+adapter's workerd-package copy step whenever a project traced a JSON data
+file whose name happened to end in `-package.json`.

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -85,6 +85,16 @@ export function isNonLinuxPlatformPackage(srcPath: string): boolean {
   return nonLinuxPlatformRegex.test(srcPath);
 }
 
+// `path.basename` only splits on the OS-native separator, so we explicitly
+// look at both `/` and `\` to handle paths produced under either platform.
+export function isPackageJson(modulePath: string): boolean {
+  const lastSep = Math.max(
+    modulePath.lastIndexOf("/"),
+    modulePath.lastIndexOf("\\"),
+  );
+  return modulePath.slice(lastSep + 1) === "package.json";
+}
+
 function copyPatchFile(outputDir: string) {
   const patchFile = path.join(__dirname, "patch", "patchedAsyncStorage.js");
   const outputPatchFile = path.join(outputDir, "patchedAsyncStorage.cjs");
@@ -153,7 +163,7 @@ export async function copyTracedFiles({
       filesToCopy.set(src, dst);
 
       const module = path.join(dotNextDir, subDir, tracedPath);
-      if (module.endsWith("package.json")) {
+      if (isPackageJson(module)) {
         nodePackages.set(path.dirname(module), path.dirname(dst));
       }
     });

--- a/packages/tests-unit/tests/build/copyTracedFiles.test.ts
+++ b/packages/tests-unit/tests/build/copyTracedFiles.test.ts
@@ -1,6 +1,7 @@
 import {
   isExcluded,
   isNonLinuxPlatformPackage,
+  isPackageJson,
 } from "@opennextjs/aws/build/copyTracedFiles.js";
 
 describe("isExcluded", () => {
@@ -127,5 +128,29 @@ describe("isNonLinuxPlatformPackage", () => {
         "/project/node_modules/turbo-linux-x64/bin/turbo",
       ),
     ).toBe(false);
+  });
+});
+
+describe("isPackageJson", () => {
+  test("should detect package.json", () => {
+    expect(isPackageJson("/project/node_modules/next/package.json")).toBe(true);
+    expect(isPackageJson("package.json")).toBe(true);
+  });
+
+  test("should not treat files whose names end with 'package.json' as package.json", () => {
+    // Regression: traced JSON data files in user code can have names like
+    // `care-package.json` that share the "package.json" suffix without being
+    // real package manifests. The previous `endsWith("package.json")` check
+    // mis-classified them, causing `Failed to copy <dir>` errors in the
+    // Cloudflare adapter's workerd-package copy step.
+    expect(isPackageJson("/project/data/tables/care-package.json")).toBe(false);
+    expect(isPackageJson("/project/fixtures/my-package.json")).toBe(false);
+  });
+
+  test("should handle Windows-style path separators", () => {
+    expect(isPackageJson("C:\\project\\node_modules\\next\\package.json")).toBe(
+      true,
+    );
+    expect(isPackageJson("C:\\project\\data\\care-package.json")).toBe(false);
   });
 });


### PR DESCRIPTION
## What

`copyTracedFiles` decides whether a traced file is a node-package manifest with

```ts
if (module.endsWith("package.json")) {
  nodePackages.set(path.dirname(module), path.dirname(dst));
}
```

`endsWith` matches any filename whose tail is `package.json`, so files like `care-package.json` or `my-package.json` get registered as if their parent directory were a node package. The map is then handed to the Cloudflare adapter's `copyWorkerdPackages`, which tries to read `<parent-dir>/package.json` and surfaces:

```
ERROR Failed to copy /path/to/data/tables
```

The actual file copy is unaffected — that goes through `filesToCopy`, which is keyed by full paths — so the error is purely cosmetic. But it's misleading enough that someone hitting it usually has to dig into OpenNext's source to convince themselves the deploy is fine, which is what motivated this patch.

## Repro

In a Next.js app, statically import a JSON data file whose name ends in `-package.json`:

```ts
// src/lib/foo.ts
import careData from '@@/data/tables/care-package.json' assert { type: 'json' };
```

Next traces that file, OpenNext walks the `.nft.json`, and the inline `endsWith` check fires on `care-package.json`. Cloudflare adapter's deploy log then prints `Failed to copy <dir>` for each affected directory.

## Fix

Switch the inline check to a real basename comparison. The helper is exported so the regression is covered by a unit test alongside `isExcluded` / `isNonLinuxPlatformPackage`.

```ts
export function isPackageJson(modulePath: string): boolean {
  const lastSep = Math.max(
    modulePath.lastIndexOf("/"),
    modulePath.lastIndexOf("\\"),
  );
  return modulePath.slice(lastSep + 1) === "package.json";
}
```

`path.basename` was avoided because traced paths can come from either platform after `path.join`, and `path.basename` only splits on the OS-native separator. The manual scan handles both.

## Tests

Added three cases in `packages/tests-unit/tests/build/copyTracedFiles.test.ts`:

- positive: `…/next/package.json` and bare `package.json` → `true`
- regression: `…/care-package.json`, `…/my-package.json` → `false`
- cross-platform: Windows-style `\` separators behave the same

```
✓ packages/tests-unit/tests/build/copyTracedFiles.test.ts (12 tests) 3ms
```

## Risk

Behavior only changes for filenames that share the `package.json` suffix but aren't actually package manifests. Real `package.json` traces continue to be picked up identically.

## Changeset

Included a `patch` changeset under `.changeset/fix-copytraced-package-json-suffix.md`.