### PR TITLE
reproduction: middleware rewrite breaks client-side navigation on SSG target (#1170)

### DIFF
--- a/.changeset/quiet-rivers-bend.md
+++ b/.changeset/quiet-rivers-bend.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: middleware rewrites breaking client-side navigation

--- a/examples/pages-router/src/components/home.tsx
+++ b/examples/pages-router/src/components/home.tsx
@@ -18,6 +18,13 @@ export default function Home() {
           <Nav href="/ssr" title="/SSR" icon="/static/frank.webp">
             SSR on each load
           </Nav>
+          <Nav
+            href="/rewrite-client-path/foo"
+            title="/rewrite-client-path/foo"
+            icon="/static/frank.webp"
+          >
+            Middleware rewrite to /rewrite-code-path
+          </Nav>
         </div>
       </main>
     </>

--- a/examples/pages-router/src/middleware.ts
+++ b/examples/pages-router/src/middleware.ts
@@ -5,15 +5,25 @@ export function middleware(request: NextRequest) {
   if (request.headers.get("x-throw")) {
     throw new Error("Middleware error");
   }
+
+  const { pathname } = request.nextUrl;
+  if (pathname.startsWith("/rewrite-client-path")) {
+    const url = request.nextUrl.clone();
+    url.pathname = pathname.replace(
+      /^\/rewrite-client-path/,
+      "/rewrite-code-path",
+    );
+    return NextResponse.rewrite(url);
+  }
+
   return NextResponse.next({
     headers: {
       "x-from-middleware": "true",
-      // We need to disable caching in cloudfront to ensure we always hit the origin for this test
       "cache-control": "private, no-store",
     },
   });
 }
 
 export const config = {
-  matcher: ["/"],
+  matcher: ["/", "/rewrite-client-path/:path*"],
 };

--- a/examples/pages-router/src/middleware.ts
+++ b/examples/pages-router/src/middleware.ts
@@ -19,6 +19,7 @@ export function middleware(request: NextRequest) {
   return NextResponse.next({
     headers: {
       "x-from-middleware": "true",
+      // We need to disable caching in cloudfront to ensure we always hit the origin for this test
       "cache-control": "private, no-store",
     },
   });

--- a/examples/pages-router/src/pages/rewrite-code-path/[[...slug]].tsx
+++ b/examples/pages-router/src/pages/rewrite-code-path/[[...slug]].tsx
@@ -1,0 +1,35 @@
+import type {
+  GetStaticPaths,
+  GetStaticProps,
+  InferGetStaticPropsType,
+} from "next";
+
+export const getStaticPaths: GetStaticPaths = () => {
+  return {
+    paths: [],
+    fallback: "blocking",
+  };
+};
+
+export const getStaticProps: GetStaticProps = async (context) => {
+  const slug = (context.params?.slug as string[] | undefined) ?? [];
+  return {
+    props: {
+      slug,
+      renderedAt: new Date().toISOString(),
+    },
+  };
+};
+
+export default function RewriteCodePath({
+  slug,
+  renderedAt,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  return (
+    <>
+      <h1>Rewrite Code Path</h1>
+      <div>Slug: {slug.join("/") || "(empty)"}</div>
+      <div>Rendered at: {renderedAt}</div>
+    </>
+  );
+}

--- a/packages/open-next/src/core/routing/matcher.ts
+++ b/packages/open-next/src/core/routing/matcher.ts
@@ -411,6 +411,10 @@ export function fixDataPage(
       ...internalEvent,
       rawPath: newPath,
       query,
+      headers: {
+        ...internalEvent.headers,
+        "x-nextjs-data": "1",
+      },
       url: new URL(
         `${newPath}${convertToQueryString(query)}`,
         internalEvent.url,

--- a/packages/tests-e2e/tests/pagesRouter/middleware.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/middleware.test.ts
@@ -10,3 +10,23 @@ test("should return 500 on middleware error", async ({ request }) => {
   expect(response.status()).toBe(500);
   expect(body).toContain("Internal Server Error");
 });
+
+test("middleware rewrite — direct navigation renders the rewritten page", async ({
+  page,
+}) => {
+  await page.goto("/rewrite-client-path/foo");
+  await expect(
+    page.getByRole("heading", { name: "Rewrite Code Path" }),
+  ).toBeVisible();
+});
+
+test("middleware rewrite — client-side navigation renders the rewritten page", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.locator('a[href="/rewrite-client-path/foo/"]').click();
+  await page.waitForURL("**/rewrite-client-path/foo/");
+  await expect(
+    page.getByRole("heading", { name: "Rewrite Code Path" }),
+  ).toBeVisible();
+});

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -594,6 +594,7 @@ describe("fixDataPage", () => {
       ...event,
       rawPath: "/test/file",
       url: "https://on/test/file?hello=world&__nextDataReq=1",
+      headers: { "x-nextjs-data": "1" },
     });
   });
 
@@ -611,6 +612,7 @@ describe("fixDataPage", () => {
       ...event,
       rawPath: `${mockBasePath}/test/file`,
       url: `https://on${mockBasePath}/test/file?hello=world&__nextDataReq=1`,
+      headers: { "x-nextjs-data": "1" },
     });
 
     NextConfig.basePath = undefined;


### PR DESCRIPTION
Extends e2e tests and page router example with a currently broken handling of rewrites as per issue #1170