### PR TITLE
feat: add aws-apigw-streaming wrapper for API Gateway response streaming

### DIFF
--- a/.changeset/apigw-streaming-wrapper.md
+++ b/.changeset/apigw-streaming-wrapper.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/aws": minor
+---
+
+Add `aws-apigw-streaming` wrapper for API Gateway response streaming
+
+A new built-in streaming wrapper for fronting the server function with an API Gateway REST API in `ResponseTransferMode: STREAM` (now [supported by AWS](https://aws.amazon.com/about-aws/whats-new/2025/11/api-gateway-response-streaming-rest-apis/)), rather than a Lambda Function URL. Unlike `aws-lambda-streaming`, it omits the Function-URL-only `application/vnd.awslambda.http-integration-response` content type and never compresses the body (API Gateway streaming does not support content encoding). Pairs with `aws-apigw-v1` (REST) or `aws-apigw-v2` (HTTP) converters.

--- a/packages/open-next/src/build/generateOutput.ts
+++ b/packages/open-next/src/build/generateOutput.ts
@@ -98,7 +98,10 @@ async function canStream(opts: FunctionOptions) {
     return false;
   }
   if (typeof opts.override.wrapper === "string") {
-    return opts.override.wrapper === "aws-lambda-streaming";
+    return (
+      opts.override.wrapper === "aws-lambda-streaming" ||
+      opts.override.wrapper === "aws-apigw-streaming"
+    );
   }
   const wrapper = await opts.override.wrapper();
   return wrapper.supportStreaming;

--- a/packages/open-next/src/build/validateConfig.ts
+++ b/packages/open-next/src/build/validateConfig.ts
@@ -17,6 +17,7 @@ const compatibilityMatrix: Record<IncludedWrapper, IncludedConverter[]> = {
   ],
   "aws-lambda-compressed": ["aws-apigw-v2"],
   "aws-lambda-streaming": ["aws-apigw-v2"],
+  "aws-apigw-streaming": ["aws-apigw-v1", "aws-apigw-v2"],
   cloudflare: ["edge"],
   "cloudflare-edge": ["edge"],
   "cloudflare-node": ["edge"],

--- a/packages/open-next/src/overrides/wrappers/aws-apigw-streaming.ts
+++ b/packages/open-next/src/overrides/wrappers/aws-apigw-streaming.ts
@@ -1,0 +1,112 @@
+import { Readable, type Writable } from "node:stream";
+
+import type { APIGatewayProxyEvent, APIGatewayProxyEventV2 } from "aws-lambda";
+import type { Wrapper, WrapperHandler } from "types/overrides";
+
+import type { StreamCreator } from "types/open-next";
+import { debug } from "../../adapters/logger";
+import type {
+  WarmerEvent,
+  WarmerResponse,
+} from "../../adapters/warmer-function";
+
+// Accepts either API Gateway payload format (v1/REST or v2/HTTP). The paired
+// converter (`aws-apigw-v1` or `aws-apigw-v2`) is responsible for parsing the
+// event shape; the wrapper only handles the response transport.
+type AwsLambdaEvent =
+  | APIGatewayProxyEventV2
+  | APIGatewayProxyEvent
+  | WarmerEvent;
+
+type AwsLambdaReturn = void;
+
+function formatWarmerResponse(event: WarmerEvent) {
+  const result = new Promise<WarmerResponse>((resolve) => {
+    setTimeout(() => {
+      resolve({ serverId, type: "warmer" } satisfies WarmerResponse);
+    }, event.delay);
+  });
+  return result;
+}
+
+/**
+ * Streaming wrapper for an API Gateway proxy integration in
+ * `ResponseTransferMode: STREAM`.
+ *
+ * Differs from `aws-lambda-streaming` (the Lambda **Function URL** wrapper) in
+ * two ways, both mandated by API Gateway response streaming
+ * (https://aws.amazon.com/blogs/compute/building-responsive-apis-with-amazon-api-gateway-response-streaming/):
+ *
+ *  1. It does NOT set the
+ *     `application/vnd.awslambda.http-integration-response` content type. That
+ *     marker is Function-URL-specific metadata; API Gateway forwards it onto
+ *     the wire, corrupting HTTP framing.
+ *  2. It does NOT compress the response. API Gateway streaming explicitly does
+ *     not support content encoding, so the body is always emitted as
+ *     `identity`. Compression, if desired, is handled by the CDN in front
+ *     (e.g. CloudFront).
+ *
+ * The response framing itself — a JSON metadata prelude followed by an
+ * 8-null-byte delimiter, then the payload — is identical to the Function URL
+ * format and is what API Gateway expects in STREAM mode.
+ */
+const handler: WrapperHandler = async (handler, converter) =>
+  awslambda.streamifyResponse(
+    async (
+      event: AwsLambdaEvent,
+      responseStream,
+      context,
+    ): Promise<AwsLambdaReturn> => {
+      context.callbackWaitsForEmptyEventLoop = false;
+      if ("type" in event) {
+        const result = await formatWarmerResponse(event);
+        responseStream.end(Buffer.from(JSON.stringify(result)), "utf-8");
+        await globalThis.__next_route_preloader("warmerEvent");
+        return;
+      }
+
+      const internalEvent = await converter.convertFrom(event);
+
+      responseStream.on("error", (err) => {
+        debug(err);
+        responseStream.end();
+      });
+
+      const streamCreator: StreamCreator = {
+        writeHeaders: (_prelude) => {
+          // No content-encoding header — API Gateway streaming does not
+          // support content encoding; the body is emitted as identity.
+          _prelude.headers["content-encoding"] = "identity";
+
+          const prelude = JSON.stringify(_prelude);
+
+          responseStream.write(prelude);
+
+          // 8-null-byte delimiter separating the JSON metadata prelude from
+          // the response payload. Same framing API Gateway STREAM expects.
+          responseStream.write(new Uint8Array(8));
+
+          return responseStream;
+        },
+      };
+
+      const response = await handler(internalEvent, { streamCreator });
+
+      const isUsingEdge = globalThis.isEdgeRuntime ?? false;
+      if (isUsingEdge) {
+        debug("Headers has not been set, we must be in the edge runtime");
+        const stream = streamCreator.writeHeaders({
+          statusCode: response.statusCode,
+          headers: response.headers as Record<string, string>,
+          cookies: [],
+        });
+        Readable.fromWeb(response.body).pipe(stream as Writable);
+      }
+    },
+  );
+
+export default {
+  wrapper: handler,
+  name: "aws-apigw-streaming",
+  supportStreaming: true,
+} satisfies Wrapper;

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -126,6 +126,7 @@ export interface Origin {
 export type IncludedWrapper =
   | "aws-lambda"
   | "aws-lambda-streaming"
+  | "aws-apigw-streaming"
   | "aws-lambda-compressed"
   | "node"
   // @deprecated - use "cloudflare-edge" instead.


### PR DESCRIPTION
## Motivation

OpenNext's only streaming wrapper, `aws-lambda-streaming`, targets the Lambda **Function URL** streaming wire format. There was no streaming wrapper for **API Gateway**, even though:

1. **API Gateway REST APIs now support response streaming** (announced Nov 2025): https://aws.amazon.com/about-aws/whats-new/2025/11/api-gateway-response-streaming-rest-apis/ — via `ResponseTransferMode: STREAM` on a Lambda proxy integration (`InvokeWithResponseStreaming`).

2. **Lambda Function URLs are unusable behind CloudFront + OAC for `POST`/`PUT`.** OAC signs the request with SigV4 (including a body hash); the Function URL re-hashes the received body and the two diverge, returning `403 InvalidSignatureException` on every non-empty body: https://repost.aws/questions/QUbHCI9AfyRdaUPCCo_3XKMQ/lambda-function-url-behind-cloudfront-invalidsignatureexception-only-on-post . API Gateway REST uses `lambda:InvokeFunction` (no body re-hash), so `POST`/`PUT` bodies — including binary uploads — pass through intact.

So the natural transport for a CloudFront-fronted SSR Lambda that must accept `POST` bodies **and** stream responses is **API Gateway REST in STREAM mode**. But the existing streaming wrapper can't be used there: it emits a Function-URL-only content-type marker and compresses the body, both of which break API Gateway streaming.

This is also what #1090 ("Clarify streaming support with apigateway-v2") is about — the wrapper/converter compatibility matrix implies streaming pairs with API Gateway, but the only streaming wrapper actually 500s behind a gateway. This PR adds the missing piece and addresses #1090.

Related: #1127 — origin-level compression in `aws-lambda-streaming` causes periodic 502s behind a Function URL, and the proposed fix is to fall back to `identity`. This new wrapper sidesteps that class of issue entirely: it never compresses and always emits `identity`, consistent with AWS's note that API Gateway streaming does not support content encoding (CloudFront compresses downstream).

## What this PR changes

A new built-in wrapper, **`aws-apigw-streaming`** — 4 files, +118 lines. It keeps the framing that API Gateway STREAM shares with Function URLs (a JSON metadata prelude + 8-null-byte delimiter, then the body) but omits the two things that break API Gateway:

1. **No `application/vnd.awslambda.http-integration-response` content type.** That marker is Function-URL-specific metadata for the Lambda runtime; API Gateway forwards it onto the wire and corrupts HTTP framing.
2. **No content encoding.** API Gateway streaming does not support content encoding (per the AWS announcement above), so the body is emitted as `identity`. Compression, if desired, is handled by the CDN in front (e.g. CloudFront).

| File | Change |
|---|---|
| `src/overrides/wrappers/aws-apigw-streaming.ts` | **New** wrapper. `streamifyResponse`, omits the FURL content-type marker, forces `identity` encoding. Works with either API Gateway payload format via its paired converter. |
| `src/types/open-next.ts` | Add `"aws-apigw-streaming"` to the `IncludedWrapper` union. |
| `src/build/validateConfig.ts` | Compatibility matrix: `"aws-apigw-streaming": ["aws-apigw-v1", "aws-apigw-v2"]`. |
| `src/build/generateOutput.ts` | `canStream()` recognizes the new wrapper so `open-next.output.json` reports `streaming: true`. |

It does not alter `aws-lambda-streaming` or any existing behavior — it's purely additive, following the existing precedent of transport-specific wrapper variants (`cloudflare-edge`, `cloudflare-node`, `aws-lambda-compressed`).

Usage:

```ts
// open-next.config.ts
export default {
  default: {
    override: {
      wrapper: "aws-apigw-streaming",
      converter: "aws-apigw-v1", // REST API payload format (v1); use aws-apigw-v2 for HTTP API
    },
  },
};
```

## Verification

Deployed a Next.js app built with this wrapper behind **API Gateway REST in `ResponseTransferMode: STREAM`** using hand-written AWS CDK (no SST, no framework), to prove the wrapper stands on its own.

**Live demo: https://d376d74ff6kodo.cloudfront.net/streaming-demo**

**Source (sample app + CDK stack, public): https://github.com/osama-rizk/opennext-apigw-streaming-demo**

Verified end to end on the live deployment:

| Check | Result |
|---|---|
| `GET /streaming` | 10 chunks delivered progressively over ~2.7&nbsp;s (not buffered) |
| Streaming RSC (`<Suspense>`) | shell paints first; sections stream in at 1&nbsp;s / 2&nbsp;s / 3&nbsp;s (9 network flushes) |
| `POST` with a 1&nbsp;MB binary body | round-trips byte-for-byte (sha256 match) — the case that 403s on a Function URL behind OAC |
| SSG / ISR (time + on-demand) / RSC / server actions / API routes | all pass |
| Bundle inspection | zero `http-integration-response` markers; `open-next.output.json` reports `streaming: true` |
