### PR TITLE
fix: recreate pnpm symlinks as junctions on Windows in copyTracedFiles

### DIFF
--- a/.changeset/windows-pnpm-symlink-junction.md
+++ b/.changeset/windows-pnpm-symlink-junction.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix broken symlink recreation in `copyTracedFiles` on Windows
+
+On Windows, recreating pnpm directory symlinks from the raw `readlinkSync` value produced file-type symlinks pointing at directories (Node falls back to `type: "file"` when the target does not exist yet), which esbuild could not traverse ("Cannot read directory ...: Access is denied"). Directory links are now recreated as junctions whose target is resolved against the destination's parent directory, matching the semantics of the relative symlink on Linux.

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -322,7 +322,29 @@ File ${serverPath} does not exist
     }
     if (symlink) {
       try {
-        symlinkSync(symlink, to);
+        if (process.platform === "win32") {
+          // On Windows, recreating the link from the raw readlink value breaks:
+          // `symlinkSync` without a `type` autodetects from the target, and when
+          // the target does not exist yet (common here, since entries are copied
+          // in traversal order) it falls back to a *file*-type symlink pointing
+          // at a directory, which Windows cannot traverse (esbuild later fails
+          // with "Cannot read directory ...: Access is denied").
+          // Instead, create a junction whose target is the raw value resolved
+          // against the destination's parent directory — semantically identical
+          // to what the relative symlink means on Linux (it points into the
+          // mirrored output structure). Junctions only apply to directories
+          // (every pnpm link recreated here is one), need no admin rights or
+          // Developer Mode, and resolve lazily once the target is populated.
+          const rawTarget = symlink.startsWith("\\\\?\\")
+            ? symlink.slice(4)
+            : symlink;
+          const target = path.isAbsolute(rawTarget)
+            ? rawTarget
+            : path.resolve(path.dirname(to), rawTarget);
+          symlinkSync(target, to, "junction");
+        } else {
+          symlinkSync(symlink, to);
+        }
       } catch (e: any) {
         if (e.code !== "EEXIST") {
           throw e;


### PR DESCRIPTION
## Summary

Fixes #1184

On Windows, `copyTracedFiles` recreates pnpm directory symlinks from the raw `readlinkSync` value. Per the Node docs, `symlinkSync` without a `type` autodetects from the target — and **falls back to `'file'` when the target does not exist**. Since entries are copied in traversal order, the relative target inside the output mirror frequently does not exist yet at link-creation time, producing a file-type symlink pointing at a directory. Windows cannot traverse those, so esbuild later fails with `Cannot read directory ...: Access is denied` / `Could not resolve "styled-jsx"`.

## Change

On `win32`, recreate the link as a **junction** whose target is the raw symlink value resolved against the destination's parent directory — semantically identical to what the relative symlink means on Linux (it points into the mirrored output structure):

- junctions only apply to directories (every pnpm link recreated here is one)
- no admin rights / Developer Mode required
- resolve lazily, so the link is valid once the target directory is populated later in the copy
- `\\?\` -prefixed absolute targets (as returned by `readlinkSync` for junctions) are handled

Non-Windows behavior is unchanged.

## Validation

- `packages/tests-unit/tests/build/copyTracedFiles.test.ts` — 9/9 passing
- `pnpm --filter @opennextjs/aws build` (tsc) and `biome check` pass
- Verified as a patch against `@opennextjs/aws` 4.0.2 on three real Next.js 16 apps on Windows 11 (pnpm `nodeLinker: isolated` ×2, `hoisted` ×1): builds reach "Worker saved" with no esbuild errors, and all three are deployed to Cloudflare Workers serving HTTP 200 in production.

A changeset (patch) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
