### PR TITLE
fix: Cloudflare streaming response backpressure

### DIFF
--- a/.changeset/cloudflare-stream-backpressure.md
+++ b/.changeset/cloudflare-stream-backpressure.md
@@ -2,4 +2,4 @@
 "@opennextjs/aws": patch
 ---
 
-Bound Cloudflare Node response streaming with backpressure and stop retaining an unused duplicate response body.
+Bound Cloudflare Node response streaming with backpressure.

--- a/.changeset/cloudflare-stream-backpressure.md
+++ b/.changeset/cloudflare-stream-backpressure.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Bound Cloudflare Node response streaming with backpressure and stop retaining an unused duplicate response body.

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -162,6 +162,8 @@ export async function openNextHandler(
           response.statusCode = routingResult.statusCode;
           response.flushHeaders();
           const [bodyToConsume, bodyToReturn] = routingResult.body.tee();
+          // Use pipeline so the streamCreator Writable can apply backpressure
+          // instead of eagerly consuming the whole Web stream.
           await pipeline(Readable.fromWeb(bodyToConsume), response);
           routingResult.body = bodyToReturn;
         }

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -161,13 +161,9 @@ export async function openNextHandler(
           );
           response.statusCode = routingResult.statusCode;
           response.flushHeaders();
-          let bodyToConsume = routingResult.body;
-          if (options.streamCreator.retainChunks !== false) {
-            const [bodyToStream, bodyToReturn] = routingResult.body.tee();
-            bodyToConsume = bodyToStream;
-            routingResult.body = bodyToReturn;
-          }
+          const [bodyToConsume, bodyToReturn] = routingResult.body.tee();
           await pipeline(Readable.fromWeb(bodyToConsume), response);
+          routingResult.body = bodyToReturn;
         }
         return routingResult;
       }

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -1,4 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 
 import type { OpenNextNodeResponse } from "http/index.js";
 import { IncomingMessage } from "http/index.js";
@@ -159,12 +161,13 @@ export async function openNextHandler(
           );
           response.statusCode = routingResult.statusCode;
           response.flushHeaders();
-          const [bodyToConsume, bodyToReturn] = routingResult.body.tee();
-          for await (const chunk of bodyToConsume) {
-            response.write(chunk);
+          let bodyToConsume = routingResult.body;
+          if (options.streamCreator.retainChunks !== false) {
+            const [bodyToStream, bodyToReturn] = routingResult.body.tee();
+            bodyToConsume = bodyToStream;
+            routingResult.body = bodyToReturn;
           }
-          response.end();
-          routingResult.body = bodyToReturn;
+          await pipeline(Readable.fromWeb(bodyToConsume), response);
         }
         return routingResult;
       }

--- a/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
@@ -5,7 +5,7 @@ import type {
 } from "types/open-next";
 import type { Wrapper, WrapperHandler } from "types/overrides";
 
-import { Writable } from "node:stream";
+import { type Readable, Writable } from "node:stream";
 
 // Response with null body status (101, 204, 205, or 304) cannot have a body.
 const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
@@ -69,9 +69,69 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
         }
 
         let controller: ReadableStreamDefaultController<Uint8Array>;
+        let controllerClosed = false;
+        let producer: Readable | undefined;
+        let completed = false;
+        let destructionError: Error | undefined;
+        let parkedWriteCallback:
+          | ((error?: Error | null | undefined) => void)
+          | undefined;
+
+        const settleParkedWrite = (error?: Error | null) => {
+          const callback = parkedWriteCallback;
+          parkedWriteCallback = undefined;
+          callback?.(error);
+        };
+
+        const destroyProducer = () => {
+          if (!completed && producer && !producer.destroyed) {
+            producer.destroy();
+          }
+        };
+
+        const closeController = () => {
+          if (controllerClosed) {
+            return;
+          }
+          controllerClosed = true;
+          try {
+            controller.close();
+          } catch {
+            // The Web stream may already have been closed by its consumer.
+          }
+        };
+
+        const errorController = (error: Error) => {
+          if (controllerClosed) {
+            return;
+          }
+          controllerClosed = true;
+          try {
+            controller.error(error);
+          } catch {
+            // The Web stream may already have been closed by its consumer.
+          }
+        };
+
+        const normalizeError = (reason: unknown) =>
+          reason == null
+            ? undefined
+            : reason instanceof Error
+              ? reason
+              : new Error(String(reason));
+
         const readable = new ReadableStream({
           start(c) {
             controller = c;
+          },
+          pull() {
+            settleParkedWrite();
+          },
+          cancel(reason) {
+            controllerClosed = true;
+            destructionError = normalizeError(reason);
+            destroyProducer();
+            bridge.destroy();
           },
         });
 
@@ -81,32 +141,50 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
         });
         resolveResponse(response);
 
-        return new Writable({
+        const bridge = new Writable({
+          // Keep Node-side buffering minimal; write callbacks are released from pull().
+          highWaterMark: 1,
           write(chunk, encoding, callback) {
+            if (controllerClosed) {
+              callback(
+                destructionError ?? new Error("Response stream is closed"),
+              );
+              return;
+            }
             try {
               controller.enqueue(chunk);
             } catch (e: any) {
-              return callback(e);
+              callback(e);
+              return;
             }
-            callback();
+            parkedWriteCallback = callback;
           },
           final(callback) {
-            controller.close();
+            completed = true;
+            closeController();
             callback();
           },
           destroy(error, callback) {
+            destroyProducer();
+            settleParkedWrite(error);
             if (error) {
-              controller.error(error);
+              destructionError = error;
+              errorController(error);
             } else {
-              try {
-                controller.close();
-              } catch {
-                // Ignore "This ReadableStream is closed" error
-              }
+              closeController();
             }
             callback(error);
           },
         });
+
+        bridge.on("pipe", (source: Readable) => {
+          producer = source;
+          if (bridge.destroyed) {
+            destroyProducer();
+          }
+        });
+
+        return bridge;
       },
       // This is for passing along the original abort signal from the initial Request you retrieve in your worker
       // Ensures that the response we pass to NextServer is aborted if the request is aborted

--- a/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
@@ -30,8 +30,10 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
     const internalEvent = await converter.convertFrom(request);
     const url = new URL(request.url);
 
-    const { promise: promiseResponse, resolve: resolveResponse } =
-      Promise.withResolvers<Response>();
+    let resolveResponse!: (response: Response) => void;
+    const promiseResponse = new Promise<Response>((resolve) => {
+      resolveResponse = resolve;
+    });
 
     const streamCreator: StreamCreator = {
       writeHeaders(prelude: {

--- a/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
@@ -30,6 +30,8 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
     const internalEvent = await converter.convertFrom(request);
     const url = new URL(request.url);
 
+    // writeHeaders resolves this once Next has chosen status/headers; the body is
+    // streamed later through the Writable returned from streamCreator.
     let resolveResponse!: (response: Response) => void;
     const promiseResponse = new Promise<Response>((resolve) => {
       resolveResponse = resolve;
@@ -70,6 +72,11 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
           });
         }
 
+        // Bridge Next's Node stream into Cloudflare's Web stream:
+        // - Next writes chunks to the Writable below.
+        // - Cloudflare reads chunks from the Response's ReadableStream.
+        // - Each Node write callback is held until the Web stream pulls again,
+        //   which propagates reader backpressure to the Node producer.
         let controller: ReadableStreamDefaultController<Uint8Array>;
         let controllerClosed = false;
         let producer: Readable | undefined;
@@ -79,6 +86,8 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
           | ((error?: Error | null | undefined) => void)
           | undefined;
 
+        // Completing the parked callback tells Node the previous write finished,
+        // allowing a piped source to produce the next chunk.
         const settleParkedWrite = (error?: Error | null) => {
           const callback = parkedWriteCallback;
           parkedWriteCallback = undefined;
@@ -122,6 +131,8 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
               ? reason
               : new Error(String(reason));
 
+        // pull() means the Response consumer has capacity for more data; use that
+        // signal to release exactly one pending Node write.
         const readable = new ReadableStream({
           start(c) {
             controller = c;
@@ -130,6 +141,8 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
             settleParkedWrite();
           },
           cancel(reason) {
+            // The response reader went away. Destroy the original producer too,
+            // otherwise it may keep generating chunks into a closed bridge.
             controllerClosed = true;
             destructionError = normalizeError(reason);
             destroyProducer();
@@ -144,7 +157,8 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
         resolveResponse(response);
 
         const bridge = new Writable({
-          // Keep Node-side buffering minimal; write callbacks are released from pull().
+          // Keep the Writable queue small; backpressure is enforced by delaying
+          // each write callback until the Web stream pulls again.
           highWaterMark: 1,
           write(chunk, encoding, callback) {
             if (controllerClosed) {
@@ -159,6 +173,8 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
               callback(e);
               return;
             }
+            // Do not call the callback yet: parking it pauses the Node producer
+            // until pull() shows the Web stream wants another chunk.
             parkedWriteCallback = callback;
           },
           final(callback) {
@@ -179,6 +195,8 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
           },
         });
 
+        // The source Readable is only exposed through the pipe event; keep it so
+        // Web stream cancellation can tear down upstream work.
         bridge.on("pipe", (source: Readable) => {
           producer = source;
           if (bridge.destroyed) {

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -61,7 +61,8 @@ export interface StreamCreator {
    *
    * However some implementations use a fake `StreamCreator` and expect the chunks to be retained.
    * When your stream controller implementation doesn't need to retain the chunk, you can set this
-   * to `false` to reduce memory usage.
+   * to `false` to reduce memory usage. This also permits the handler to consume the returned response
+   * body directly instead of retaining an unused duplicate with `ReadableStream.tee()`.
    *
    * @see https://github.com/opennextjs/opennextjs-aws/blob/main/packages/open-next/src/overrides/wrappers/aws-lambda.ts
    *

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -61,8 +61,7 @@ export interface StreamCreator {
    *
    * However some implementations use a fake `StreamCreator` and expect the chunks to be retained.
    * When your stream controller implementation doesn't need to retain the chunk, you can set this
-   * to `false` to reduce memory usage. This also permits the handler to consume the returned response
-   * body directly instead of retaining an unused duplicate with `ReadableStream.tee()`.
+   * to `false` to reduce memory usage.
    *
    * @see https://github.com/opennextjs/opennextjs-aws/blob/main/packages/open-next/src/overrides/wrappers/aws-lambda.ts
    *

--- a/packages/tests-unit/tests/core/requestHandler.test.ts
+++ b/packages/tests-unit/tests/core/requestHandler.test.ts
@@ -1,0 +1,166 @@
+import { Writable } from "node:stream";
+import { ReadableStream } from "node:stream/web";
+
+import { openNextHandler } from "@opennextjs/aws/core/requestHandler.js";
+import routingHandler from "@opennextjs/aws/core/routingHandler.js";
+import type {
+  InternalEvent,
+  InternalResult,
+  StreamCreator,
+} from "@opennextjs/aws/types/open-next.js";
+import { beforeEach, vi } from "vitest";
+
+vi.mock("@opennextjs/aws/adapters/config/index.js", () => ({
+  BuildId: "build-id",
+  HtmlPages: [],
+  NextConfig: {},
+}));
+
+vi.mock("@opennextjs/aws/core/routingHandler.js", () => ({
+  default: vi.fn(),
+  INTERNAL_EVENT_REQUEST_ID: "x-opennext-request-id",
+  INTERNAL_HEADER_INITIAL_URL: "x-opennext-initial-url",
+  INTERNAL_HEADER_RESOLVED_ROUTES: "x-opennext-resolved-routes",
+  INTERNAL_HEADER_REWRITE_STATUS_CODE: "x-opennext-rewrite-status-code",
+  MIDDLEWARE_HEADER_PREFIX: "x-middleware-response-",
+  MIDDLEWARE_HEADER_PREFIX_LEN: "x-middleware-response-".length,
+}));
+
+vi.mock("@opennextjs/aws/core/util.js", () => ({
+  requestHandler: vi.fn(),
+  setNextjsPrebundledReact: vi.fn(),
+}));
+
+const mockedRoutingHandler = vi.mocked(routingHandler);
+const event: InternalEvent = {
+  type: "core",
+  method: "GET",
+  rawPath: "/",
+  url: "https://example.com/",
+  body: Buffer.alloc(0),
+  headers: {},
+  query: {},
+  cookies: {},
+  remoteAddress: "::1",
+};
+
+function nextTurn() {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function waitFor(predicate: () => boolean) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) {
+      return;
+    }
+    await nextTurn();
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+function createBody(total: number) {
+  let produced = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (produced >= total) {
+        controller.close();
+        return;
+      }
+      const chunk = new Uint8Array(64 * 1024);
+      chunk[0] = produced++;
+      controller.enqueue(chunk);
+    },
+  });
+
+  return {
+    body,
+    get produced() {
+      return produced;
+    },
+  };
+}
+
+function createResult(body: ReadableStream<Uint8Array>): InternalResult {
+  return {
+    type: "core",
+    statusCode: 200,
+    headers: {},
+    body,
+    isBase64Encoded: false,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  globalThis.openNextConfig = {};
+  globalThis.__next_route_preloader = vi.fn(async () => {});
+});
+
+describe("requestHandler streaming", () => {
+  it("skips tee and remains bounded when chunks do not need retaining", async () => {
+    const source = createBody(20);
+    const tee = vi.spyOn(source.body, "tee");
+    const result = createResult(source.body);
+    mockedRoutingHandler.mockResolvedValue(result);
+
+    const writeCallbacks: Array<() => void> = [];
+    const received: number[] = [];
+    const streamCreator: StreamCreator = {
+      retainChunks: false,
+      writeHeaders: () =>
+        new Writable({
+          highWaterMark: 1,
+          write(chunk: Buffer, _encoding, callback) {
+            received.push(chunk[0]);
+            writeCallbacks.push(callback);
+          },
+        }),
+    };
+
+    const handlerPromise = openNextHandler(event, { streamCreator });
+    await waitFor(() => writeCallbacks.length > 0);
+    await nextTurn();
+    const producedWhileStalled = source.produced;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(source.produced).toBe(producedWhileStalled);
+    expect(source.produced).toBeLessThan(20);
+    expect(tee).not.toHaveBeenCalled();
+
+    while (received.length < 20) {
+      await waitFor(() => writeCallbacks.length > 0);
+      writeCallbacks.shift()!();
+    }
+
+    await expect(handlerPromise).resolves.toBe(result);
+    expect(received).toEqual(Array.from({ length: 20 }, (_, index) => index));
+    expect(source.body.locked).toBe(true);
+  });
+
+  it("retains a tee branch by default", async () => {
+    const source = createBody(3);
+    const tee = vi.spyOn(source.body, "tee");
+    const result = createResult(source.body);
+    mockedRoutingHandler.mockResolvedValue(result);
+
+    const streamed: Buffer[] = [];
+    const streamCreator: StreamCreator = {
+      writeHeaders: () =>
+        new Writable({
+          write(chunk, _encoding, callback) {
+            streamed.push(chunk);
+            callback();
+          },
+        }),
+    };
+
+    const returned = await openNextHandler(event, { streamCreator });
+
+    expect(tee).toHaveBeenCalledOnce();
+    expect(returned.body).not.toBe(source.body);
+    expect(Buffer.concat(streamed).length).toBe(3 * 64 * 1024);
+    expect((await new Response(returned.body).arrayBuffer()).byteLength).toBe(
+      3 * 64 * 1024,
+    );
+  });
+});

--- a/packages/tests-unit/tests/core/requestHandler.test.ts
+++ b/packages/tests-unit/tests/core/requestHandler.test.ts
@@ -97,7 +97,7 @@ beforeEach(() => {
 });
 
 describe("requestHandler streaming", () => {
-  it("skips tee and remains bounded when chunks do not need retaining", async () => {
+  it("retains a tee branch and remains bounded when chunks do not need retaining", async () => {
     const source = createBody(20);
     const tee = vi.spyOn(source.body, "tee");
     const result = createResult(source.body);
@@ -127,15 +127,20 @@ describe("requestHandler streaming", () => {
 
     expect(source.produced).toBe(producedWhileStalled);
     expect(source.produced).toBeLessThan(20);
-    expect(tee).not.toHaveBeenCalled();
+    expect(tee).toHaveBeenCalledOnce();
 
     while (received.length < 20) {
       await waitFor(() => writeCallbacks.length > 0);
       writeCallbacks.shift()!();
     }
 
-    await expect(handlerPromise).resolves.toBe(result);
+    const returned = await handlerPromise;
+    expect(returned).toBe(result);
     expect(received).toEqual(Array.from({ length: 20 }, (_, index) => index));
+    expect(returned.body).not.toBe(source.body);
+    expect((await new Response(returned.body).arrayBuffer()).byteLength).toBe(
+      20 * 64 * 1024,
+    );
     expect(source.body.locked).toBe(true);
   });
 

--- a/packages/tests-unit/tests/core/requestHandler.test.ts
+++ b/packages/tests-unit/tests/core/requestHandler.test.ts
@@ -121,7 +121,9 @@ describe("requestHandler streaming", () => {
     await waitFor(() => writeCallbacks.length > 0);
     await nextTurn();
     const producedWhileStalled = source.produced;
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    for (let i = 0; i < 25; i++) {
+      await nextTurn();
+    }
 
     expect(source.produced).toBe(producedWhileStalled);
     expect(source.produced).toBeLessThan(20);

--- a/packages/tests-unit/tests/overrides/wrappers/cloudflare-node.test.ts
+++ b/packages/tests-unit/tests/overrides/wrappers/cloudflare-node.test.ts
@@ -125,7 +125,9 @@ describe("cloudflare-node wrapper streaming", () => {
     await waitFor(() => source.produced > 0);
     await nextTurn();
     const producedWhileIdle = source.produced;
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    for (let i = 0; i < 25; i++) {
+      await nextTurn();
+    }
 
     expect(source.produced).toBe(producedWhileIdle);
     expect(source.produced).toBeLessThan(32);

--- a/packages/tests-unit/tests/overrides/wrappers/cloudflare-node.test.ts
+++ b/packages/tests-unit/tests/overrides/wrappers/cloudflare-node.test.ts
@@ -1,0 +1,182 @@
+import { Readable, type Writable } from "node:stream";
+import { finished } from "node:stream/promises";
+
+import cloudflareNode from "@opennextjs/aws/overrides/wrappers/cloudflare-node.js";
+import type {
+  InternalEvent,
+  InternalResult,
+} from "@opennextjs/aws/types/open-next.js";
+import type {
+  Converter,
+  OpenNextHandler,
+} from "@opennextjs/aws/types/overrides.js";
+
+const event: InternalEvent = {
+  type: "core",
+  method: "GET",
+  rawPath: "/",
+  url: "https://example.com/",
+  body: Buffer.alloc(0),
+  headers: {},
+  query: {},
+  cookies: {},
+  remoteAddress: "::1",
+};
+
+const emptyResult: InternalResult = {
+  type: "core",
+  statusCode: 200,
+  headers: {},
+  body: new ReadableStream(),
+  isBase64Encoded: false,
+};
+
+const converter = {
+  name: "test",
+  convertFrom: async () => event,
+  convertTo: async () => undefined,
+} satisfies Converter;
+
+function nextTurn() {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function waitFor(predicate: () => boolean) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) {
+      return;
+    }
+    await nextTurn();
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+function createProducer(total = Number.POSITIVE_INFINITY) {
+  let produced = 0;
+  let destroyedWith: Error | null | undefined;
+  const producer = new Readable({
+    highWaterMark: 1,
+    read() {
+      if (produced >= total) {
+        this.push(null);
+        return;
+      }
+      this.push(Buffer.from([produced++]));
+    },
+    destroy(error, callback) {
+      destroyedWith = error;
+      callback(error);
+    },
+  });
+
+  return {
+    producer,
+    get produced() {
+      return produced;
+    },
+    get destroyedWith() {
+      return destroyedWith;
+    },
+  };
+}
+
+async function startResponse(producer: Readable) {
+  let destination: Writable | undefined;
+  let handlerPromise: Promise<InternalResult> | undefined;
+  const handler: OpenNextHandler = async (_event, options) => {
+    destination = options?.streamCreator?.writeHeaders({
+      statusCode: 200,
+      cookies: [],
+      headers: {},
+    });
+    if (!destination) {
+      throw new Error("Missing stream destination");
+    }
+    producer.pipe(destination);
+    await finished(destination);
+    return emptyResult;
+  };
+
+  const wrapped = await cloudflareNode.wrapper(handler, converter);
+  const response = await wrapped(
+    new Request("https://example.com/"),
+    {},
+    {
+      waitUntil(promise: Promise<InternalResult>) {
+        handlerPromise = promise;
+        promise.catch(() => {});
+      },
+    },
+    new AbortController().signal,
+  );
+
+  if (!destination || !handlerPromise) {
+    throw new Error("Wrapper did not start streaming");
+  }
+
+  return { destination, handlerPromise, response };
+}
+
+describe("cloudflare-node wrapper streaming", () => {
+  it("bounds production and delivers chunks in order to a slow consumer", async () => {
+    const source = createProducer(32);
+    const { handlerPromise, response } = await startResponse(source.producer);
+
+    await waitFor(() => source.produced > 0);
+    await nextTurn();
+    const producedWhileIdle = source.produced;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(source.produced).toBe(producedWhileIdle);
+    expect(source.produced).toBeLessThan(32);
+
+    const reader = response.body!.getReader();
+    const received: number[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      received.push(value[0]);
+      expect(source.produced).toBeLessThanOrEqual(received.length + 3);
+      await nextTurn();
+    }
+
+    await expect(handlerPromise).resolves.toBe(emptyResult);
+    expect(received).toEqual(Array.from({ length: 32 }, (_, index) => index));
+  });
+
+  it("cancels the bridge and its producer while settling the handler", async () => {
+    const source = createProducer();
+    const { destination, handlerPromise, response } = await startResponse(
+      source.producer,
+    );
+    const reader = response.body!.getReader();
+
+    await reader.read();
+    const cancellation = new Error("consumer cancelled");
+    await reader.cancel(cancellation);
+
+    await expect(handlerPromise).rejects.toMatchObject({
+      code: "ERR_STREAM_PREMATURE_CLOSE",
+    });
+    expect(destination.destroyed).toBe(true);
+    expect(source.producer.destroyed).toBe(true);
+    expect(source.destroyedWith).toBeNull();
+  });
+
+  it("destroys the producer and errors the Web response when destroyed", async () => {
+    const source = createProducer();
+    const { destination, handlerPromise, response } = await startResponse(
+      source.producer,
+    );
+    const destruction = new Error("bridge destroyed");
+
+    destination.destroy(destruction);
+
+    await expect(handlerPromise).rejects.toThrow("bridge destroyed");
+    await expect(response.text()).rejects.toThrow("bridge destroyed");
+    expect(source.producer.destroyed).toBe(true);
+    expect(source.destroyedWith).toBeNull();
+  });
+});


### PR DESCRIPTION
Prevents excessive memory usage when streaming large responses. Previously, writes did not account for consumer backpressure, so a fast producer could buffer large amounts of data when the consumer was slow. This PR pauses pulling from the producer until the consumer is ready for more data.

~~Also skips `ReadableStream.tee()` when chunks do not need to be retained, avoiding an unused duplicate response body during direct streaming.~~