### PR TITLE
Implement getTagCacheResult for cache validation tracking

### DIFF
--- a/.changeset/thin-oranges-serve.md
+++ b/.changeset/thin-oranges-serve.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": minor
+---
+
+Add a getTagCacheResult method for the incremental cache

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -75,7 +75,14 @@ export default class Cache {
         ? false
         : await hasBeenRevalidated(key, _tags, cachedEntry);
 
-      if (_hasBeenRevalidated) return null;
+      if (_hasBeenRevalidated) {
+        await globalThis.incrementalCache.getTagCacheResult?.({
+          key,
+          hasBeenRevalidated: true,
+          isStaleFromTag: false,
+        });
+        return null;
+      }
 
       // For cases where we don't have tags, we need to ensure that the soft tags are not being revalidated
       // We only need to check for the path as it should already contain all the tags
@@ -106,6 +113,12 @@ export default class Cache {
         ? false
         : await isStale(key, _tags, _lastModified);
 
+      await globalThis.incrementalCache.getTagCacheResult?.({
+        key,
+        hasBeenRevalidated: false,
+        isStaleFromTag: _isStale,
+      });
+
       return {
         lastModified: _isStale ? 1 : _lastModified,
         value: cachedEntry.value,
@@ -133,11 +146,24 @@ export default class Cache {
       const _hasBeenRevalidated = cachedEntry.shouldBypassTagCache
         ? false
         : await hasBeenRevalidated(key, tags, cachedEntry);
-      if (_hasBeenRevalidated) return null;
+      if (_hasBeenRevalidated) {
+        await globalThis.incrementalCache.getTagCacheResult?.({
+          key,
+          hasBeenRevalidated: true,
+          isStaleFromTag: false,
+        });
+        return null;
+      }
 
       const _isStale = cachedEntry.shouldBypassTagCache
         ? false
         : await isStale(key, tags, _lastModified);
+
+      await globalThis.incrementalCache.getTagCacheResult?.({
+        key,
+        hasBeenRevalidated: false,
+        isStaleFromTag: _isStale,
+      });
 
       const store = globalThis.__openNextAls.getStore();
       if (store) {

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -39,18 +39,27 @@ export default {
         result.value.tags.length > 0
       ) {
         // We need to check if the tags associated with this entry has been revalidated
-        const hasBeenRevalidated = result.shouldBypassTagCache
+        const _hasBeenRevalidated = result.shouldBypassTagCache
           ? false
           : await globalThis.tagCache.hasBeenRevalidated(
               result.value.tags,
               result.lastModified,
             );
-        if (hasBeenRevalidated) return undefined;
 
         // Check if tags are stale – entry is valid but needs background revalidation
-        const isCacheStale = result.shouldBypassTagCache
+        const isCacheStale = _hasBeenRevalidated
           ? false
-          : await isStale(cacheKey, result.value.tags, result.lastModified);
+          : result.shouldBypassTagCache
+            ? false
+            : await isStale(cacheKey, result.value.tags, result.lastModified);
+
+        await globalThis.incrementalCache.getTagCacheResult?.({
+          key: cacheKey,
+          hasBeenRevalidated: _hasBeenRevalidated,
+          isStaleFromTag: isCacheStale,
+        });
+
+        if (_hasBeenRevalidated) return undefined;
         if (isCacheStale) {
           revalidate = -1;
         }
@@ -58,18 +67,27 @@ export default {
         globalThis.tagCache.mode === "original" ||
         globalThis.tagCache.mode === undefined
       ) {
-        const hasBeenRevalidated = result.shouldBypassTagCache
+        const _hasBeenRevalidated = result.shouldBypassTagCache
           ? false
           : (await globalThis.tagCache.getLastModified(
               cacheKey,
               result.lastModified,
             )) === -1;
-        if (hasBeenRevalidated) return undefined;
 
         // Check if tags are stale – entry is valid but needs background revalidation
-        const isCacheStale = result.shouldBypassTagCache
+        const isCacheStale = _hasBeenRevalidated
           ? false
-          : await isStale(cacheKey, result.value.tags, result.lastModified);
+          : result.shouldBypassTagCache
+            ? false
+            : await isStale(cacheKey, result.value.tags, result.lastModified);
+
+        await globalThis.incrementalCache.getTagCacheResult?.({
+          key: cacheKey,
+          hasBeenRevalidated: _hasBeenRevalidated,
+          isStaleFromTag: isCacheStale,
+        });
+
+        if (_hasBeenRevalidated) return undefined;
         if (isCacheStale) {
           revalidate = -1;
         }

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -18,6 +18,47 @@ import { generateMessageGroupId } from "./queue";
 const CACHE_ONE_YEAR = 60 * 60 * 24 * 365;
 const CACHE_ONE_MONTH = 60 * 60 * 24 * 30;
 
+/**
+ * Determines the effective revalidate duration for a given path/value combination,
+ * consulting the prerender manifest when `revalidate` is not explicitly set.
+ */
+function computeFinalRevalidate(
+  path: string,
+  revalidate?: number | false,
+): number {
+  let finalRevalidate = CACHE_ONE_YEAR;
+  const existingRoute = Object.entries(PrerenderManifest?.routes ?? {}).find(
+    (p) => p[0] === path,
+  )?.[1];
+  if (revalidate === undefined && existingRoute) {
+    finalRevalidate =
+      existingRoute.initialRevalidateSeconds === false
+        ? CACHE_ONE_YEAR
+        : existingRoute.initialRevalidateSeconds;
+    // eslint-disable-next-line sonarjs/elseif-without-else
+  } else if (revalidate !== undefined) {
+    finalRevalidate = revalidate === false ? CACHE_ONE_YEAR : revalidate;
+  }
+  return finalRevalidate;
+}
+
+/**
+ * Returns whether a cache entry is stale purely due to time (TTL expiry),
+ * independent of any tag-based revalidation.
+ */
+function computeIsStaleFromTime(
+  path: string,
+  revalidate: number | false | undefined,
+  lastModified: number | undefined,
+): boolean {
+  const finalRevalidate = computeFinalRevalidate(path, revalidate);
+  const isSSG = finalRevalidate === CACHE_ONE_YEAR;
+  if (isSSG) return false;
+  const age = Math.round((Date.now() - (lastModified ?? 0)) / 1000);
+  const remainingTtl = Math.max(finalRevalidate - age, 1);
+  return remainingTtl === 1;
+}
+
 /*
  * We use this header to prevent Firefox (and possibly some CDNs) from incorrectly reusing the RSC responses during caching.
  * This can especially happen when there's a redirect in the middleware as the `_rsc` query parameter is not visible there.
@@ -41,20 +82,7 @@ async function computeCacheControl(
   lastModified?: number,
   isStaleFromTagCache = false,
 ) {
-  let finalRevalidate = CACHE_ONE_YEAR;
-
-  const existingRoute = Object.entries(PrerenderManifest?.routes ?? {}).find(
-    (p) => p[0] === path,
-  )?.[1];
-  if (revalidate === undefined && existingRoute) {
-    finalRevalidate =
-      existingRoute.initialRevalidateSeconds === false
-        ? CACHE_ONE_YEAR
-        : existingRoute.initialRevalidateSeconds;
-    // eslint-disable-next-line sonarjs/elseif-without-else
-  } else if (revalidate !== undefined) {
-    finalRevalidate = revalidate === false ? CACHE_ONE_YEAR : revalidate;
-  }
+  const finalRevalidate = computeFinalRevalidate(path, revalidate);
   // calculate age
   const age = Math.round((Date.now() - (lastModified ?? 0)) / 1000);
   const hash = (str: string) => createHash("md5").update(str).digest("hex");
@@ -298,6 +326,17 @@ export async function cacheInterceptor(
           : await hasBeenRevalidated(cacheKey, tags, cachedData);
 
         if (_hasBeenRevalidated) {
+          const isStaleFromTime = computeIsStaleFromTime(
+            localizedPath,
+            cachedData.value.revalidate,
+            cachedData.lastModified,
+          );
+          await globalThis.incrementalCache.getTagCacheResult?.({
+            key: cacheKey,
+            hasBeenRevalidated: true,
+            isStaleFromTag: false,
+            isStaleFromTime,
+          });
           return event;
         }
       }
@@ -306,6 +345,19 @@ export async function cacheInterceptor(
       const _isStale = cachedData.shouldBypassTagCache
         ? false
         : await isStale(cacheKey, tags, cachedData.lastModified ?? Date.now());
+
+      const isStaleFromTime = computeIsStaleFromTime(
+        localizedPath,
+        cachedData.value.revalidate,
+        cachedData.lastModified,
+      );
+
+      await globalThis.incrementalCache.getTagCacheResult?.({
+        key: cacheKey,
+        hasBeenRevalidated: false,
+        isStaleFromTag: _isStale,
+        isStaleFromTime,
+      });
 
       const host = event.headers.host;
       switch (cachedData?.value?.type) {

--- a/packages/open-next/src/types/overrides.ts
+++ b/packages/open-next/src/types/overrides.ts
@@ -127,6 +127,17 @@ export type IncrementalCache = {
   ): Promise<void>;
   delete(key: string): Promise<void>;
   name: string;
+  /**
+   * Optional observer hook called after the tag cache has been consulted.
+   * Receives the combined tag-cache verdict for the given cache key.
+   * `isStaleFromTime` is only provided by the cache interceptor.
+   */
+  getTagCacheResult?: (params: {
+    key: string;
+    hasBeenRevalidated: boolean;
+    isStaleFromTag: boolean;
+    isStaleFromTime?: boolean;
+  }) => Promise<void>;
 };
 
 // Tag cache

--- a/packages/open-next/src/utils/cache.ts
+++ b/packages/open-next/src/utils/cache.ts
@@ -83,7 +83,6 @@ export function getTagsFromValue(value?: CacheValue<"cache">) {
   try {
     const cacheTags =
       value.meta?.headers?.["x-next-cache-tags"]?.split(",") ?? [];
-    delete value.meta?.headers?.["x-next-cache-tags"];
     return cacheTags;
   } catch (e) {
     return [];

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -28,6 +28,7 @@ describe("CacheHandler", () => {
     }),
     set: vi.fn(),
     delete: vi.fn(),
+    getTagCacheResult: vi.fn().mockResolvedValue(undefined),
   };
   globalThis.incrementalCache = incrementalCache;
 
@@ -253,6 +254,57 @@ describe("CacheHandler", () => {
           await cache.get("key", { kind: "FETCH", tags: ["tag1"] });
 
           expect(tagCache.isStale).not.toHaveBeenCalled();
+        });
+      });
+
+      describe("getTagCacheResult", () => {
+        it("Should call getTagCacheResult with hasBeenRevalidated: false and isStaleFromTag: false on cache hit", async () => {
+          await cache.get("key", { fetchCache: true });
+
+          expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+            key: "key",
+            hasBeenRevalidated: false,
+            isStaleFromTag: false,
+          });
+        });
+
+        it("Should call getTagCacheResult with hasBeenRevalidated: true when fetch cache is expired", async () => {
+          tagCache.getLastModified.mockResolvedValueOnce(-1);
+
+          await cache.get("key", { fetchCache: true });
+
+          expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+            key: "key",
+            hasBeenRevalidated: true,
+            isStaleFromTag: false,
+          });
+        });
+
+        it("Should call getTagCacheResult with isStaleFromTag: true when fetch cache tag is stale (next16)", async () => {
+          globalThis.nextVersion = "16.0.0";
+          tagCache.mode = "nextMode";
+          tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
+          tagCache.isStale.mockResolvedValueOnce(true);
+          incrementalCache.get.mockResolvedValueOnce({
+            value: {
+              kind: "FETCH",
+              data: {
+                headers: {},
+                body: "{}",
+                url: "https://example.com",
+                status: 200,
+              },
+            },
+            lastModified: Date.now(),
+          });
+
+          await cache.get("key", { kind: "FETCH", tags: ["tag1"] });
+
+          expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+            key: "key",
+            hasBeenRevalidated: false,
+            isStaleFromTag: true,
+          });
         });
       });
     });
@@ -534,6 +586,65 @@ describe("CacheHandler", () => {
           await cache.get("key", { kindHint: "app" });
 
           expect(tagCache.isStale).not.toHaveBeenCalled();
+        });
+      });
+
+      describe("getTagCacheResult", () => {
+        it("Should call getTagCacheResult with hasBeenRevalidated: false and isStaleFromTag: false on cache hit", async () => {
+          await cache.get("key", { kindHint: "app" });
+
+          expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+            key: "key",
+            hasBeenRevalidated: false,
+            isStaleFromTag: false,
+          });
+        });
+
+        it("Should call getTagCacheResult with hasBeenRevalidated: true when cache is expired", async () => {
+          tagCache.getLastModified.mockResolvedValueOnce(-1);
+          incrementalCache.get.mockResolvedValueOnce({
+            value: { type: "route", body: "{}" },
+            lastModified: Date.now(),
+          });
+
+          await cache.get("key", { kindHint: "app" });
+
+          expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+            key: "key",
+            hasBeenRevalidated: true,
+            isStaleFromTag: false,
+          });
+        });
+
+        it("Should call getTagCacheResult with isStaleFromTag: true when cache tag is stale (next16)", async () => {
+          globalThis.nextVersion = "16.0.0";
+          tagCache.isStale.mockResolvedValueOnce(true);
+          incrementalCache.get.mockResolvedValueOnce({
+            value: { type: "route", body: "{}" },
+            lastModified: Date.now(),
+          });
+
+          await cache.get("key", { kindHint: "app" });
+
+          expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+            key: "key",
+            hasBeenRevalidated: false,
+            isStaleFromTag: true,
+          });
+        });
+
+        it("Should not throw when getTagCacheResult is not defined", async () => {
+          const prevIncrementalCache = globalThis.incrementalCache;
+          globalThis.incrementalCache = {
+            ...prevIncrementalCache,
+            getTagCacheResult: undefined,
+          };
+
+          await expect(
+            cache.get("key", { kindHint: "app" }),
+          ).resolves.not.toThrow();
+
+          globalThis.incrementalCache = prevIncrementalCache;
         });
       });
     });

--- a/packages/tests-unit/tests/adapters/composable-cache.test.ts
+++ b/packages/tests-unit/tests/adapters/composable-cache.test.ts
@@ -25,6 +25,7 @@ describe("Composable cache handler", () => {
     }),
     set: vi.fn(),
     delete: vi.fn(),
+    getTagCacheResult: vi.fn().mockResolvedValue(undefined),
   };
   globalThis.incrementalCache = incrementalCache;
 
@@ -244,6 +245,76 @@ describe("Composable cache handler", () => {
 
       expect(result).toBeUndefined();
       expect(tagCache.isStale).not.toHaveBeenCalled();
+    });
+
+    describe("getTagCacheResult", () => {
+      it("should call getTagCacheResult with hasBeenRevalidated: false and isStaleFromTag: false in nextMode", async () => {
+        tagCache.mode = "nextMode";
+        tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
+        tagCache.isStale.mockResolvedValueOnce(false);
+
+        await ComposableCache.get("test-key");
+
+        expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+          key: "test-key",
+          hasBeenRevalidated: false,
+          isStaleFromTag: false,
+        });
+      });
+
+      it("should call getTagCacheResult with hasBeenRevalidated: true in nextMode when cache is expired", async () => {
+        tagCache.mode = "nextMode";
+        tagCache.hasBeenRevalidated.mockResolvedValueOnce(true);
+
+        await ComposableCache.get("test-key");
+
+        expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+          key: "test-key",
+          hasBeenRevalidated: true,
+          isStaleFromTag: false,
+        });
+      });
+
+      it("should call getTagCacheResult with isStaleFromTag: true in nextMode when cache is stale", async () => {
+        tagCache.mode = "nextMode";
+        tagCache.hasBeenRevalidated.mockResolvedValueOnce(false);
+        tagCache.isStale.mockResolvedValueOnce(true);
+
+        await ComposableCache.get("test-key");
+
+        expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+          key: "test-key",
+          hasBeenRevalidated: false,
+          isStaleFromTag: true,
+        });
+      });
+
+      it("should call getTagCacheResult with hasBeenRevalidated: false and isStaleFromTag: false in original mode", async () => {
+        tagCache.mode = "original";
+        tagCache.getLastModified.mockResolvedValueOnce(Date.now());
+        tagCache.isStale.mockResolvedValueOnce(false);
+
+        await ComposableCache.get("test-key");
+
+        expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+          key: "test-key",
+          hasBeenRevalidated: false,
+          isStaleFromTag: false,
+        });
+      });
+
+      it("should call getTagCacheResult with hasBeenRevalidated: true in original mode when cache is expired", async () => {
+        tagCache.mode = "original";
+        tagCache.getLastModified.mockResolvedValueOnce(-1);
+
+        await ComposableCache.get("test-key");
+
+        expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+          key: "test-key",
+          hasBeenRevalidated: true,
+          isStaleFromTag: false,
+        });
+      });
     });
 
     it("should return pending write promise if available", async () => {

--- a/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
+++ b/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
@@ -60,6 +60,7 @@ const incrementalCache = {
   get: vi.fn(),
   set: vi.fn(),
   delete: vi.fn(),
+  getTagCacheResult: vi.fn().mockResolvedValue(undefined),
 };
 
 const tagCache = {
@@ -848,6 +849,104 @@ describe("cacheInterceptor", () => {
         }),
       );
       expect(queue.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getTagCacheResult", () => {
+    it("should call getTagCacheResult with isStaleFromTime: false on a fresh SSG cache hit", async () => {
+      const event = createEvent({ url: "/albums" });
+      incrementalCache.get.mockResolvedValueOnce({
+        value: {
+          type: "app",
+          html: "Hello, world!",
+          revalidate: false,
+        },
+        lastModified: new Date("2024-01-02T00:00:00Z").getTime(),
+      });
+
+      await cacheInterceptor(event);
+
+      expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+        key: "/albums",
+        hasBeenRevalidated: false,
+        isStaleFromTag: false,
+        isStaleFromTime: false,
+      });
+    });
+
+    it("should call getTagCacheResult with isStaleFromTime: true when entry is time-stale", async () => {
+      const event = createEvent({ url: "/revalidate" });
+      // /revalidate has initialRevalidateSeconds: 60; lastModified is 2 minutes ago
+      incrementalCache.get.mockResolvedValueOnce({
+        value: {
+          type: "app",
+          html: "Hello, world!",
+          revalidate: 60,
+        },
+        lastModified: new Date("2024-01-01T23:58:00Z").getTime(),
+      });
+
+      await cacheInterceptor(event);
+
+      expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith({
+        key: "/revalidate",
+        hasBeenRevalidated: false,
+        isStaleFromTag: false,
+        isStaleFromTime: true,
+      });
+    });
+
+    it("should call getTagCacheResult with isStaleFromTag: true when tag cache reports stale", async () => {
+      const event = createEvent({ url: "/albums" });
+      incrementalCache.get.mockResolvedValueOnce({
+        value: {
+          type: "app",
+          html: "Hello, world!",
+          revalidate: false,
+        },
+        lastModified: new Date("2024-01-02T00:00:00Z").getTime(),
+      });
+      tagCache.isStale.mockResolvedValueOnce(true);
+
+      await cacheInterceptor(event);
+
+      expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: "/albums",
+          isStaleFromTag: true,
+        }),
+      );
+    });
+
+    it("should call getTagCacheResult with hasBeenRevalidated: true when app cache has been revalidated", async () => {
+      const event = createEvent({ url: "/albums" });
+      incrementalCache.get.mockResolvedValueOnce({
+        value: {
+          type: "app",
+          html: "Hello, world!",
+        },
+      });
+      tagCache.getLastModified.mockResolvedValueOnce(-1);
+
+      await cacheInterceptor(event);
+
+      expect(incrementalCache.getTagCacheResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: "/albums",
+          hasBeenRevalidated: true,
+          isStaleFromTag: false,
+        }),
+      );
+    });
+
+    it("should not call getTagCacheResult when request is bypassed by next-action header", async () => {
+      const event = createEvent({
+        headers: { "next-action": "something" },
+      });
+
+      await cacheInterceptor(event);
+
+      expect(incrementalCache.getTagCacheResult).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Introduce a new method, `getTagCacheResult`, to enhance cache validation and revalidation tracking. 

This addition allows for better monitoring of cache states and is especially useful for things like a regional cache that depending on options should not be populated.