### PR TITLE
fix(aws): copy server/instrumentation.js into standalone dir on Next.js 16

### DIFF
--- a/.changeset/next16-standalone-instrumentation.md
+++ b/.changeset/next16-standalone-instrumentation.md
@@ -1,0 +1,13 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix `server/instrumentation.js does not exist` build failure on Next.js 16
+
+On Next.js 16 the standalone output no longer copies `server/instrumentation.js`
+into the standalone directory, but `copyTracedFiles` copies the instrumentation
+`.nft.json` trace and then asserts the `.js` file exists in the standalone dir,
+throwing `File server/instrumentation.js does not exist` during the server
+bundle. The instrumentation file is now copied from the build dir into the
+standalone dir (mirroring the existing `.nft.json` copy) so the assertion passes
+and the file ships in the bundle.

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -243,6 +243,20 @@ File ${serverPath} does not exist
       path.join(dotNextDir, INSTRUMENTATION_TRACE_FILE),
       path.join(standaloneNextDir, INSTRUMENTATION_TRACE_FILE),
     );
+    // Next 16's standalone output no longer includes `server/instrumentation.js`
+    // in the standalone dir, but `computeCopyFilesForPage` asserts it exists
+    // there. Copy it from the build dir (mirroring the .nft.json copy above) so
+    // the assertion passes and the instrumentation file ships in the bundle.
+    const instrumentationServerFile = path.join("server", "instrumentation.js");
+    if (
+      existsSync(path.join(dotNextDir, instrumentationServerFile)) &&
+      !existsSync(path.join(standaloneNextDir, instrumentationServerFile))
+    ) {
+      copyFileAndMakeOwnerWritable(
+        path.join(dotNextDir, instrumentationServerFile),
+        path.join(standaloneNextDir, instrumentationServerFile),
+      );
+    }
     computeCopyFilesForPage("instrumentation");
     logger.debug("Adding instrumentation trace files");
   }


### PR DESCRIPTION
## Problem

On **Next.js 16**, `open-next build` fails during the server-function bundle:

```
Error: This error should only happen for static 404 and 500 page from page router. Report this if that's not the case.,
        File server/instrumentation.js does not exist
    at computeCopyFilesForPage (.../build/copyTracedFiles.js)
    at copyTracedFiles (...)
    at createServerBundle (...)
```

## Root cause

Next 16's `output: "standalone"` no longer copies `server/instrumentation.js` into the standalone output dir (it remains only in `.next/server/`). In `copyTracedFiles`, the instrumentation block copies the instrumentation **`.nft.json` trace** into `standaloneNextDir` and then calls `computeCopyFilesForPage("instrumentation")`, which asserts that `server/instrumentation.js` exists in `standaloneNextDir` — so it throws. (Middleware is unaffected because its `.js` is emitted into the standalone dir.)

## Fix

Before the assertion, copy `server/instrumentation.js` from the build dir into the standalone dir — mirroring the existing `.nft.json` copy right above it — guarded so it only runs when the file exists in the build dir and isn't already present in the standalone dir. Pre-16 behavior is unchanged, and the instrumentation file ships in the bundle.

## Validation

Reproduced on a real **pnpm monorepo** app: **Next.js 16.1.6**, App Router, `next-intl` middleware, `@opennextjs/aws@4.0.3`, monorepo config (`packageJsonPath` / `appPath` / `buildOutputPath`) + `output: "standalone"` + `outputFileTracingRoot`.

- **Before:** build fails at `copyTracedFiles` with the error above.
- **After** (this change applied as a patch to 4.0.3): `open-next build` completes; the full bundle is produced (`server-functions/default`, `assets`, `cache`, `dynamodb-provider`, `revalidation-function`, `image-optimization-function`, `warmer-function`); the server-function bundle loads and exports `handler`; `server/instrumentation.js` is present in the server-function output.

A patch changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
