### PR TITLE
fix(cloudflare-node): use native IdentityTransformStream to prevent intermittent mid-stream response stalls

### DIFF
--- a/.changeset/cloudflare-node-native-stream.md
+++ b/.changeset/cloudflare-node-native-stream.md
@@ -1,0 +1,18 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix(cloudflare-node): use native IdentityTransformStream for the response body
+
+The `cloudflare-node` wrapper built the streamed response body from a JS-backed
+`ReadableStream` with a manually captured controller, acknowledging writes
+without backpressure. On deployed Workers this intermittently (20-35% of
+requests in our reproduction) stalled mid-stream: the final flush(es) of
+SSR/RSC responses were never delivered, the terminating chunk was never sent,
+and the client connection stayed open indefinitely — browsers eventually
+exhaust their per-origin connection pool and the whole site appears frozen.
+
+Switching to the Workers-native `IdentityTransformStream` and awaiting
+`writer.write()` provides runtime-managed pumping with real backpressure and
+eliminates the stall (0 hangs in 80 requests after the change, measured on the
+same production deployment).

--- a/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
+++ b/packages/open-next/src/overrides/wrappers/cloudflare-node.ts
@@ -7,6 +7,14 @@ import type { Wrapper, WrapperHandler } from "types/overrides";
 
 import { Writable } from "node:stream";
 
+// `IdentityTransformStream` is a Cloudflare Workers specific, C++-backed
+// identity TransformStream optimized for byte streams.
+// https://developers.cloudflare.com/workers/runtime-apis/streams/transformstream/#identitytransformstream
+declare class IdentityTransformStream extends TransformStream<
+  Uint8Array,
+  Uint8Array
+> {}
+
 // Response with null body status (101, 204, 205, or 304) cannot have a body.
 const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
 
@@ -68,12 +76,21 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
           });
         }
 
-        let controller: ReadableStreamDefaultController<Uint8Array>;
-        const readable = new ReadableStream({
-          start(c) {
-            controller = c;
-          },
-        });
+        // Use the native (C++-backed) `IdentityTransformStream` instead of a
+        // JS-backed `ReadableStream` with a manually captured controller.
+        //
+        // With the JS-backed stream, the runtime's pump of the response body
+        // has been observed to intermittently stall mid-stream on deployed
+        // Workers: the last enqueued flush(es) are never delivered and the
+        // terminating chunk is never sent, leaving the client connection open
+        // indefinitely. Because `Writable.write` acknowledged chunks without
+        // waiting for the consumer, nothing in the worker ever noticed the
+        // stall (the invocation simply never completed).
+        //
+        // The native stream is pumped by the runtime itself and
+        // `writer.write()` resolves only once the chunk is accepted, giving
+        // real backpressure end-to-end and avoiding the stall entirely.
+        const { readable, writable } = new IdentityTransformStream();
 
         const response = new Response(readable, {
           status: statusCode,
@@ -81,30 +98,35 @@ const handler: WrapperHandler<InternalEvent, InternalResult> =
         });
         resolveResponse(response);
 
+        const writer = writable.getWriter();
+
         return new Writable({
           write(chunk, encoding, callback) {
-            try {
-              controller.enqueue(chunk);
-            } catch (e: any) {
-              return callback(e);
-            }
-            callback();
+            const bytes =
+              chunk instanceof Uint8Array
+                ? chunk
+                : Buffer.from(chunk, encoding);
+            writer.write(bytes).then(
+              () => callback(),
+              (e) => callback(e),
+            );
           },
           final(callback) {
-            controller.close();
-            callback();
+            writer.close().then(
+              () => callback(),
+              (e) => callback(e),
+            );
           },
           destroy(error, callback) {
-            if (error) {
-              controller.error(error);
-            } else {
-              try {
-                controller.close();
-              } catch {
-                // Ignore "This ReadableStream is closed" error
-              }
-            }
-            callback(error);
+            const done = error
+              ? writer.abort(error)
+              : writer.close().catch(() => {
+                  // Ignore "already closed" errors
+                });
+            done.then(
+              () => callback(error),
+              () => callback(error),
+            );
           },
         });
       },


### PR DESCRIPTION
## Summary

The `cloudflare-node` wrapper builds the streamed response body from a JS-backed `ReadableStream` with a manually captured controller, and `Writable.write` acknowledges chunks immediately without backpressure (`controller.desiredSize` is never consulted).

On deployed Workers (production runtime, not reproducible with `wrangler dev`/local workerd) we observed this **intermittently stalling mid-stream**: the final flush(es) of chunked SSR/RSC responses are never delivered to the client and the terminating chunk is never sent, so the connection stays open indefinitely. Browsers keep waiting on the incomplete response, gradually exhaust their per-origin connection pool, and the whole site eventually freezes for that browser profile (every request stuck in "Stalled", even sign-out).

This PR switches the response body to the Workers-native (C++-backed) [`IdentityTransformStream`](https://developers.cloudflare.com/workers/runtime-apis/streams/transformstream/#identitytransformstream) and awaits `writer.write()`, so the runtime pumps the stream itself with real end-to-end backpressure.

## Reproduction / evidence

Observed on a production app (Next.js `16.2.10`, `@opennextjs/cloudflare` `1.20.1`, `wrangler` `4.107.0`, `compatibility_date` `2025-12-01`, free plan, custom domain). No auth required — a plain RSC request to the login page reproduces it:

```
$ for i in $(seq 1 20); do curl --http1.1 -s -o /dev/null -m 8 \
    -w "%{time_total}s %{size_download}B\n" -H "RSC:1" https://<app>/login; done
0.14s 8599B      # ok — complete flight payload, stream closed
8.00s 6934B      # HUNG — stalls at the same byte offset every time,
...              #        terminating chunk never arrives (7/20 in this run)
```

- Hangs affect **both** HTML documents and RSC payloads (any streamed SSR response); hang rate was 20–35% across runs.
- The stall point is deterministic (always the same byte offset for a given page) — the tail that never arrives corresponds to the last flush(es).
- A hung response stays open **at least 180s** (test timeout) — the terminating chunk never comes.
- `wrangler tail` shows **no event at all** for hung requests (the invocation never completes); completed requests log `outcome: ok` with 8–22ms CPU, so this is not `exceededCpu`.
- Static assets (ASSETS binding) never hang (0/30).
- Not reproducible locally via `wrangler dev`/miniflare (0/30 with the same build), so it appears to be an interaction between the JS-backed stream pump and the production runtime — possibly related to recent workerd stream regressions (e.g. cloudflare/workerd#6832, cloudflare/workerd#6818), but the wrapper-side pattern makes it invisible: writes are acked without backpressure, so nothing ever notices the pump stalled.

## Validation

Measured on the same production deployment, patched adapter only (no other changes):

| | JS ReadableStream (current) | IdentityTransformStream (this PR) |
|---|---|---|
| RSC response hangs | 4–7 / 20 | **0 / 60** |
| HTML document hangs | 2 / 15 | **0 / 20** |
| Real-browser SPA navigation (Playwright) | froze at the 5th navigation | **300 navigations, no freeze, no lingering pending requests** |

- `pnpm build` (tsc) passes, `pnpm lint` (biome) clean, `tests-unit` 600/600 pass.
- `IdentityTransformStream` is declared locally in the file (it is a Workers-specific global); this wrapper only runs on the Workers runtime.

## Notes

- `writer.write()` resolving only when the chunk is accepted also gives the wrapper real backpressure, which the previous implementation lacked (unbounded queue growth in the JS stream).
- Non-`Uint8Array` chunks are converted with `Buffer.from(chunk, encoding)` since `IdentityTransformStream` only accepts bytes.
- The null-body-status fast path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
