### PR TITLE
fix(converters): preserve query param encoding in getQueryFromSearchParams

### DIFF
--- a/.changeset/preserve-query-param-encoding.md
+++ b/.changeset/preserve-query-param-encoding.md
@@ -2,8 +2,10 @@
 "@opennextjs/aws": patch
 ---
 
-Preserve percent-encoding of query parameters in `getQueryFromSearchParams`
+Preserve percent-encoding of query parameters in `getQueryFromSearchParams` and `convertToQuery`
 
-`getQueryFromSearchParams` iterated over `URLSearchParams.entries()`, which decodes the values. Since `convertToQueryString` does not re-encode them (by design, see #817), any query value containing reserved characters (`&`, `=`, `+`, spaces, ...) was corrupted when the query string was rebuilt for `req.url`. The parser now keeps the values encoded so they round-trip correctly through `convertToQueryString`.
+Both query parsers read values through `URLSearchParams`, which decodes them. Since `convertToQueryString` does not re-encode them (by design, see #817), any query value containing reserved characters (`&`, `=`, `+`, spaces, ...) was corrupted when the query string was rebuilt — for `req.url` in the request handler, and for the origin `querystring` in the CloudFront converter. The parsers now keep the values encoded so they round-trip correctly through `convertToQueryString`.
+
+`getQueryFromSearchParams` covers the `node` and `edge` converters; `convertToQuery` covers the `aws-apigw-v2` and `aws-cloudfront` converters.
 
 Fixes opennextjs/opennextjs-cloudflare#1134.

--- a/.changeset/preserve-query-param-encoding.md
+++ b/.changeset/preserve-query-param-encoding.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/aws": patch
+---
+
+Preserve percent-encoding of query parameters in `getQueryFromSearchParams`
+
+`getQueryFromSearchParams` iterated over `URLSearchParams.entries()`, which decodes the values. Since `convertToQueryString` does not re-encode them (by design, see #817), any query value containing reserved characters (`&`, `=`, `+`, spaces, ...) was corrupted when the query string was rebuilt for `req.url`. The parser now keeps the values encoded so they round-trip correctly through `convertToQueryString`.
+
+Fixes opennextjs/opennextjs-cloudflare#1134.

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -155,19 +155,26 @@ export function convertToQueryString(query: Record<string, string | string[]>) {
 /**
  * Given a raw query string, returns a record with key value-array pairs
  * similar to how multiValueQueryStringParameters are structured
+ *
+ * The values are kept percent-encoded so that they can be reused as-is by
+ * `convertToQueryString` (which does not re-encode). Reading the values
+ * through `URLSearchParams` getters would decode them, and values containing
+ * reserved characters (`&`, `=`, `+`, spaces, ...) would corrupt the rebuilt
+ * query string.
  * @__PURE__
  */
 export function convertToQuery(querystring: string) {
   if (!querystring) return {};
-  const query = new URLSearchParams(querystring);
-  const queryObject: Record<string, string[] | string> = {};
-
-  for (const key of query.keys()) {
-    const queries = query.getAll(key);
-    queryObject[key] = queries.length > 1 ? queries : queries[0];
-  }
-
-  return queryObject;
+  // URLSearchParams normalizes the string to a fully percent-encoded form
+  // (and strips a leading "?"), so splitting on "&" and "=" is safe.
+  const normalized = new URLSearchParams(querystring).toString();
+  if (normalized === "") return {};
+  return getQueryFromIterator(
+    normalized.split("&").map((part) => {
+      const [key, value] = part.split("=");
+      return [key, value] as const;
+    }),
+  );
 }
 
 /**

--- a/packages/open-next/src/overrides/converters/utils.ts
+++ b/packages/open-next/src/overrides/converters/utils.ts
@@ -27,9 +27,23 @@ export function extractHostFromHeaders(
 /**
  * Get the query object from an URLSearchParams
  *
+ * The values are kept percent-encoded so that they can be reused as-is by
+ * `convertToQueryString` (which does not re-encode). Iterating over
+ * `searchParams.entries()` would decode the values, and since
+ * `convertToQueryString` does not re-encode them, values containing
+ * reserved characters (`&`, `=`, `+`, spaces, ...) would corrupt the
+ * rebuilt query string.
+ *
  * @param searchParams
  * @returns
  */
 export function getQueryFromSearchParams(searchParams: URLSearchParams) {
-  return getQueryFromIterator(searchParams.entries());
+  const querystring = searchParams.toString();
+  if (querystring === "") return {};
+  return getQueryFromIterator(
+    querystring.split("&").map((part) => {
+      const [key, value] = part.split("=");
+      return [key, value] as const;
+    }),
+  );
 }

--- a/packages/tests-unit/tests/converters/utils.test.ts
+++ b/packages/tests-unit/tests/converters/utils.test.ts
@@ -1,4 +1,7 @@
-import { removeUndefinedFromQuery } from "@opennextjs/aws/overrides/converters/utils.js";
+import {
+  getQueryFromSearchParams,
+  removeUndefinedFromQuery,
+} from "@opennextjs/aws/overrides/converters/utils.js";
 
 describe("removeUndefinedFromQuery", () => {
   it("should remove undefined from query", () => {
@@ -27,5 +30,45 @@ describe("removeUndefinedFromQuery", () => {
     });
 
     expect(result).toEqual({});
+  });
+});
+
+describe("getQueryFromSearchParams", () => {
+  it("returns an empty object when there are no params", () => {
+    expect(getQueryFromSearchParams(new URLSearchParams(""))).toEqual({});
+  });
+
+  it("returns a single param", () => {
+    expect(getQueryFromSearchParams(new URLSearchParams("key=value"))).toEqual({
+      key: "value",
+    });
+  });
+
+  it("groups repeated keys into an array", () => {
+    expect(
+      getQueryFromSearchParams(new URLSearchParams("key=value1&key=value2")),
+    ).toEqual({
+      key: ["value1", "value2"],
+    });
+  });
+
+  // https://github.com/opennextjs/opennextjs-cloudflare/issues/1134
+  it("keeps reserved characters percent-encoded so the value survives convertToQueryString", () => {
+    const raw =
+      "authorizationURL=https%3A%2F%2Fexample.com%2Fauth%3Fresponse_type%3Dcode%2Bid_token%26state%3Dabc&oauthState=xyz";
+    const query = getQueryFromSearchParams(new URLSearchParams(raw));
+
+    // The encoded value must be preserved (not decoded), otherwise the nested
+    // "&"/"="/"+"/space would break the rebuilt query string.
+    expect(query).toEqual({
+      authorizationURL:
+        "https%3A%2F%2Fexample.com%2Fauth%3Fresponse_type%3Dcode%2Bid_token%26state%3Dabc",
+      oauthState: "xyz",
+    });
+
+    // The value round-trips back to the original once decoded.
+    expect(decodeURIComponent(query.authorizationURL as string)).toBe(
+      "https://example.com/auth?response_type=code+id_token&state=abc",
+    );
   });
 });

--- a/packages/tests-unit/tests/core/routing/util.test.ts
+++ b/packages/tests-unit/tests/core/routing/util.test.ts
@@ -373,6 +373,34 @@ describe("convertToQuery", () => {
       another: "value2",
     });
   });
+
+  it("ignores a leading question mark", () => {
+    const querystring = "?key=value";
+    expect(convertToQuery(querystring)).toEqual({ key: "value" });
+  });
+
+  // https://github.com/opennextjs/opennextjs-cloudflare/issues/1134
+  it("keeps reserved characters percent-encoded so the value survives convertToQueryString", () => {
+    const querystring =
+      "returnUrl=https%3A%2F%2Fexample.com%2Fauth%3Fresponse_type%3Dcode%2Bid_token%26state%3Dabc&other=xyz";
+    const query = convertToQuery(querystring);
+
+    // The encoded value must be preserved (not decoded), otherwise the nested
+    // "&"/"="/"+"/space would break the rebuilt query string.
+    expect(query).toEqual({
+      returnUrl:
+        "https%3A%2F%2Fexample.com%2Fauth%3Fresponse_type%3Dcode%2Bid_token%26state%3Dabc",
+      other: "xyz",
+    });
+
+    // The value round-trips through convertToQueryString unchanged.
+    expect(convertToQueryString(query)).toBe(`?${querystring}`);
+
+    // The value decodes back to the original URL.
+    expect(decodeURIComponent(query.returnUrl as string)).toBe(
+      "https://example.com/auth?response_type=code+id_token&state=abc",
+    );
+  });
 });
 
 describe("getMiddlewareMatch", () => {


### PR DESCRIPTION
## What

`getQueryFromSearchParams` parsed query values by iterating over `URLSearchParams.entries()`, which **decodes** each value. However, since #817, `convertToQueryString` intentionally does **not** re-encode values (it concatenates them raw to preserve their original encoding). This leaves the two sides of the round-trip inconsistent:

- **parse** (`getQueryFromSearchParams`) → decoded values
- **serialize** (`convertToQueryString`) → assumes already-encoded values, no re-encoding

As a result, any query value containing reserved characters (`&`, `=`, `+`, spaces, …) is corrupted when `req.url` is rebuilt from the parsed query in `requestHandler.ts`:

```ts
req.url =
  initialURL.pathname +
  convertToQueryString(routingResult.internalEvent.query);
```

A decoded value such as `https://example.com/auth?a=1&b=2` gets concatenated as-is, so the embedded `&`/`=` split the outer query string and everything after the first reserved char is lost or reinterpreted as separate params.

## Reproduction

This is the root cause of opennextjs/opennextjs-cloudflare#1134. It reliably breaks, for example, Sign in with Apple via `better-auth`'s Expo flow: the client hits `…/expo-authorization-proxy?authorizationURL=<percent-encoded URL>`, the encoded `%26`/`%3D` inside `authorizationURL` are decoded to `&`/`=`, the URL is truncated at the first `&`, the `state` param is lost, and the endpoint returns `400 "Unexpected error"`. It only manifests in production (Workers / any deployment that goes through this `req.url` reconstruction), not in `next dev`.

## Fix

Keep the parsed values **percent-encoded** so they round-trip correctly through `convertToQueryString`. This completes the model established in #817 (query records hold encoded values end-to-end) rather than reverting `convertToQueryString` — which would reintroduce the double-decode problem #817 fixed and break the existing "should respect existing query encoding" test.

Multi-value grouping and the empty-query case are preserved.

## Tests

Added unit tests for `getQueryFromSearchParams` covering the empty case, single value, repeated-key grouping, and the reserved-character round-trip from #1134. Full unit suite (`604 passed`), `biome check`, and `tsc --noEmit` all pass.
