### PR TITLE
fix(logger): emit structured contextual errors

### DIFF
--- a/.changeset/structured-error-logs.md
+++ b/.changeset/structured-error-logs.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Emit contextual errors as structured log objects so AWS Lambda JSON logging preserves error details.

--- a/packages/open-next/src/adapters/logger.ts
+++ b/packages/open-next/src/adapters/logger.ts
@@ -40,6 +40,42 @@ const isDownplayedErrorLog = (errorLog: AwsSdkClientCommandErrorLog) =>
         downplayedInput.errorName === errorLog?.error?.Code),
   );
 
+function serializeError(error: Error): Record<string, unknown> {
+  return {
+    ...error,
+    name: error.name,
+    message: error.message,
+    ...(error.stack ? { stack: error.stack } : {}),
+    ...(error.cause !== undefined
+      ? {
+          cause:
+            error.cause instanceof Error
+              ? serializeError(error.cause)
+              : error.cause,
+        }
+      : {}),
+  };
+}
+
+function writeError(args: any[]) {
+  const errorIndex = args.findIndex((arg) => arg instanceof Error);
+  if (args.length === 1 || errorIndex === -1) {
+    return console.error(...args);
+  }
+
+  const messageIndex = args.findIndex((arg) => typeof arg === "string");
+  const error = args[errorIndex] as Error;
+  const details = args.filter(
+    (_, index) => index !== messageIndex && index !== errorIndex,
+  );
+
+  console.error({
+    message: messageIndex === -1 ? error.message : args[messageIndex],
+    error: serializeError(error),
+    ...(details.length > 0 ? { details } : {}),
+  });
+}
+
 export function error(...args: any[]) {
   // we try to catch errors from the aws-sdk client and downplay some of them
   if (args.some((arg) => isDownplayedErrorLog(arg))) {
@@ -68,9 +104,9 @@ export function error(...args: any[]) {
         ),
       );
     }
-    return console.error(...args);
+    return writeError(args);
   }
-  console.error(...args);
+  writeError(args);
 }
 
 export const awsLogger = {

--- a/packages/tests-unit/tests/adapters/logger.test.ts
+++ b/packages/tests-unit/tests/adapters/logger.test.ts
@@ -7,17 +7,74 @@ import {
 import { vi } from "vitest";
 
 describe("logger adapter", () => {
-  describe("Open Next errors", () => {
-    const debug = vi.spyOn(console, "log").mockImplementation(() => null);
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => null);
-    const error = vi.spyOn(console, "error").mockImplementation(() => null);
+  const debug = vi.spyOn(console, "log").mockImplementation(() => null);
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => null);
+  const error = vi.spyOn(console, "error").mockImplementation(() => null);
 
-    beforeEach(() => {
-      debug.mockClear();
-      warn.mockClear();
-      error.mockClear();
+  beforeEach(() => {
+    debug.mockClear();
+    warn.mockClear();
+    error.mockClear();
+  });
+
+  describe("structured errors", () => {
+    it("logs a message and error as a single structured object", () => {
+      const cause = new Error("connection refused");
+      const cacheError = Object.assign(
+        new Error("The specified bucket does not exist", { cause }),
+        {
+          name: "NoSuchBucket",
+          Code: "NoSuchBucket",
+          BucketName: "cache-bucket",
+          $metadata: {
+            httpStatusCode: 404,
+            requestId: "request-id",
+          },
+        },
+      );
+
+      logger.error("Failed to set cache", cacheError);
+
+      expect(error).toHaveBeenCalledOnce();
+      expect(error).toHaveBeenCalledWith({
+        message: "Failed to set cache",
+        error: {
+          name: "NoSuchBucket",
+          message: "The specified bucket does not exist",
+          stack: cacheError.stack,
+          cause: {
+            name: "Error",
+            message: "connection refused",
+            stack: cause.stack,
+          },
+          Code: "NoSuchBucket",
+          BucketName: "cache-bucket",
+          $metadata: {
+            httpStatusCode: 404,
+            requestId: "request-id",
+          },
+        },
+      });
     });
 
+    it("preserves additional log details", () => {
+      const thrownError = new Error("boom");
+
+      logger.error("Failed operation", { operation: "cache.set" }, thrownError);
+
+      expect(error).toHaveBeenCalledWith({
+        message: "Failed operation",
+        error: {
+          name: "Error",
+          message: "boom",
+          stack: thrownError.stack,
+        },
+        details: [{ operation: "cache.set" }],
+      });
+    });
+  });
+
+  describe("Open Next errors", () => {
     const ignorableError = new IgnorableError("ignorable");
     const recoverableError = new RecoverableError("recoverable");
     const fatalError = new FatalError("fatal");


### PR DESCRIPTION
## Summary

- emit contextual errors as a single structured object
- preserve error name, message, stack, cause, and enumerable service fields
- keep existing single-error, severity, and AWS SDK downplay behavior

## Why

AWS Lambda preserves a single object argument in JSON logs but stringifies multiple console arguments. Calls such as `error("Failed to set cache", error)` therefore produce a mixed stack trace and object-inspection string instead of structured error data.

## Test plan

- `pnpm test`
- `pnpm lint`
