### PR TITLE
fix: align encoded path handling with Next.js

### DIFF
--- a/.changeset/decoded-middleware-paths.md
+++ b/.changeset/decoded-middleware-paths.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Match middleware against decoded pathname equivalents and skip cache interception for malformed path encodings, in parity with Next.js, so percent-encoded routes cannot bypass middleware.

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -221,18 +221,13 @@ function escapePathDelimiters(
  *
  * SSG cache key needs to be decoded, but some characters needs to be properly escaped
  * https://github.com/vercel/next.js/blob/34039551d2e5f611c0abde31a197d9985918adaf/packages/next/src/server/lib/router-utils/decode-path-params.ts#L11-L26
+ * Decoding must be atomic, as in Next.js. Partially decoding a malformed path
+ * could select a different cache route than the one evaluated by middleware.
  */
 function decodePathParams(pathname: string): string {
   return pathname
     .split("/")
-    .map((segment) => {
-      try {
-        return escapePathDelimiters(decodeURIComponent(segment), true);
-      } catch (e) {
-        // If decodeURIComponent fails, we return the original segment
-        return segment;
-      }
-    })
+    .map((segment) => escapePathDelimiters(decodeURIComponent(segment), true))
     .join("/");
 }
 
@@ -265,7 +260,13 @@ export async function cacheInterceptor(
   localizedPath = localizedPath.replace(/\/$/, "");
 
   // Then we decode the path params
-  localizedPath = decodePathParams(localizedPath) || "/";
+  try {
+    localizedPath = decodePathParams(localizedPath) || "/";
+  } catch {
+    // Next.js rejects malformed path params. Do not let cache interception
+    // partially decode the path and select a different route identity.
+    return event;
+  }
 
   // The route is keyed as `/` in the prerender manifest, but the generated
   // cache asset for the app index route is uploaded as `/index`.

--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -66,7 +66,19 @@ export async function handleMiddleware(
 
   // We only need the normalizedPath to check if the middleware should run
   const normalizedPath = localizePath(internalEvent);
-  const hasMatch = middleMatch.some((r) => r.test(normalizedPath));
+  let decodedPath: string | undefined;
+  try {
+    decodedPath = decodeURIComponent(normalizedPath);
+  } catch {
+    // An invalid encoding cannot provide a decoded pathname to match.
+  }
+  // Next.js also tries the decoded pathname for matching, while preserving the
+  // encoded pathname in the request passed to middleware.
+  const hasMatch = middleMatch.some(
+    (r) =>
+      r.test(normalizedPath) ||
+      (decodedPath !== undefined && r.test(decodedPath)),
+  );
   if (!hasMatch) return internalEvent;
 
   const initialUrl = new URL(normalizedPath, internalEvent.url);

--- a/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
+++ b/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
@@ -26,6 +26,11 @@ vi.mock("@opennextjs/aws/adapters/config/index.js", () => ({
         srcRoute: null,
         dataRoute: "/_next/data/abc/revalidate.json",
       },
+      "/admin/%ZZ": {
+        initialRevalidateSeconds: false,
+        srcRoute: "/admin/[slug]",
+        dataRoute: "/admin/%ZZ.rsc",
+      },
     },
     dynamicRoutes: {},
   },
@@ -121,6 +126,17 @@ describe("cacheInterceptor", () => {
     const result = await cacheInterceptor(event);
 
     expect(result).toEqual(event);
+  });
+
+  it("should not intercept a path containing a malformed escape", async () => {
+    const event = createEvent({
+      url: "/%61dmin/%ZZ",
+    });
+
+    const result = await cacheInterceptor(event);
+
+    expect(result).toEqual(event);
+    expect(incrementalCache.get).not.toHaveBeenCalled();
   });
 
   it("should take no action when incremental cache throws", async () => {

--- a/packages/tests-unit/tests/core/routing/middleware.encoded-path.test.ts
+++ b/packages/tests-unit/tests/core/routing/middleware.encoded-path.test.ts
@@ -1,0 +1,77 @@
+import { handleMiddleware } from "@opennextjs/aws/core/routing/middleware.js";
+import type { InternalEvent } from "@opennextjs/aws/types/open-next.js";
+import { vi } from "vitest";
+
+vi.mock("@opennextjs/aws/adapters/config/index.js", () => ({
+  NextConfig: {},
+  MiddlewareManifest: {
+    sortedMiddleware: ["/"],
+    middleware: {
+      "/": {
+        files: [],
+        name: "middleware",
+        page: "/",
+        matchers: [
+          {
+            regexp: "^\\/admin(?:\\/.*)?$",
+            originalSource: "/admin/:path*",
+          },
+        ],
+      },
+    },
+    functions: {},
+    version: 2,
+  },
+  FunctionsConfigManifest: undefined,
+  PrerenderManifest: {
+    preview: {
+      previewModeId: "preview",
+    },
+  },
+}));
+
+vi.mock("@opennextjs/aws/core/routing/i18n/index.js", () => ({
+  localizePath: (event: InternalEvent) => event.rawPath,
+}));
+
+function createEvent(rawPath: string): InternalEvent {
+  return {
+    type: "core",
+    method: "GET",
+    rawPath,
+    url: `https://example.com${rawPath}`,
+    body: Buffer.from(""),
+    headers: {},
+    query: {},
+    cookies: {},
+    remoteAddress: "::1",
+  };
+}
+
+describe("handleMiddleware encoded path matching", () => {
+  it.each(["/admin", "/%61dmin", "/adm%69n"])(
+    "applies protected route middleware to %s while preserving the request URL",
+    async (rawPath) => {
+      const middleware = vi
+        .fn()
+        .mockResolvedValue(
+          new Response("middleware auth required", { status: 401 }),
+        );
+      const middlewareLoader = vi.fn().mockResolvedValue({
+        default: middleware,
+      });
+
+      const result = await handleMiddleware(
+        createEvent(rawPath),
+        "",
+        middlewareLoader,
+      );
+
+      expect(middlewareLoader).toHaveBeenCalledOnce();
+      expect(middleware).toHaveBeenCalledWith(
+        expect.objectContaining({ url: `https://example.com${rawPath}` }),
+      );
+      expect(result).toEqual(expect.objectContaining({ statusCode: 401 }));
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- retry middleware matching with the decoded pathname while preserving the encoded request URL
- make cache path decoding atomic and bypass interception for malformed path encodings
- add regression coverage for encoded middleware routes and malformed cache paths
- add a patch changeset

## Validation

- pnpm --filter tests-unit test
- pnpm --filter @opennextjs/aws build
- pnpm lint
- verified behavior against Next.js 16.2.10