### PR TITLE
fix: handle encoded paths in edge route lookup

### DIFF
--- a/.changeset/decoded-middleware-paths.md
+++ b/.changeset/decoded-middleware-paths.md
@@ -2,4 +2,4 @@
 "@opennextjs/aws": patch
 ---
 
-Match middleware against decoded pathname equivalents and skip cache interception for malformed path encodings, in parity with Next.js, so percent-encoded routes cannot bypass middleware.
+Match middleware and its bundled route lookup against decoded pathname equivalents, while preserving the encoded request URL. Skip cache interception for malformed path encodings, in parity with Next.js, so percent-encoded routes cannot bypass middleware.

--- a/packages/open-next/src/core/edgeFunctionHandler.ts
+++ b/packages/open-next/src/core/edgeFunctionHandler.ts
@@ -9,8 +9,24 @@ export default async function edgeFunctionHandler(
 ): Promise<Response> {
   const path = new URL(request.url).pathname;
   const routes = globalThis._ROUTES;
+  let decodedPath: string | undefined;
+  try {
+    // Decode the complete pathname atomically so a malformed escape cannot be
+    // partially decoded.
+    decodedPath = decodeURIComponent(path);
+  } catch {
+    // A malformed pathname cannot provide a decoded route to match.
+  }
+  // Also match against the decoded pathname, while keeping the encoded URL in
+  // the request passed to middleware.
   const correspondingRoute = routes.find((route) =>
-    route.regex.some((r) => new RegExp(r).test(path)),
+    route.regex.some((r) => {
+      const regex = new RegExp(r);
+      return (
+        regex.test(path) ||
+        (decodedPath !== undefined && regex.test(decodedPath))
+      );
+    }),
   );
 
   if (!correspondingRoute) {

--- a/packages/tests-unit/tests/core/edgeFunctionHandler.test.ts
+++ b/packages/tests-unit/tests/core/edgeFunctionHandler.test.ts
@@ -1,0 +1,70 @@
+import edgeFunctionHandler from "@opennextjs/aws/core/edgeFunctionHandler.js";
+import { afterEach, beforeEach, vi } from "vitest";
+
+const middlewareEntry = vi.fn();
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "self", {
+    configurable: true,
+    value: globalThis,
+  });
+  globalThis._ROUTES = [
+    {
+      name: "middleware",
+      page: "/",
+      regex: ["^\\/protected(?:\\/.*)?$"],
+    },
+  ];
+  globalThis._ENTRIES = {
+    middleware_middleware: {
+      default: middlewareEntry,
+    },
+  };
+  globalThis.__openNextAls = {
+    getStore: () => undefined,
+  } as typeof globalThis.__openNextAls;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  Reflect.deleteProperty(globalThis, "self");
+});
+
+// handleMiddleware's default loader imports the bundle produced from this
+// handler, so this exercises the route lookup that a mocked loader bypasses.
+describe("edgeFunctionHandler bundled default middleware", () => {
+  it("retries route lookup with a decoded pathname and preserves the encoded request URL", async () => {
+    middlewareEntry.mockResolvedValue({
+      response: new Response("middleware auth required", { status: 401 }),
+      waitUntil: Promise.resolve(),
+    });
+
+    const response = await edgeFunctionHandler({
+      headers: {},
+      method: "GET",
+      signal: new AbortController().signal,
+      url: "https://example.com/%70rotected",
+    });
+
+    expect(response.status).toBe(401);
+    expect(middlewareEntry).toHaveBeenCalledWith({
+      page: "/",
+      request: expect.objectContaining({
+        page: { name: "middleware" },
+        url: "https://example.com/%70rotected",
+      }),
+    });
+  });
+
+  it("does not partially decode a malformed pathname", async () => {
+    await expect(
+      edgeFunctionHandler({
+        headers: {},
+        method: "GET",
+        signal: new AbortController().signal,
+        url: "https://example.com/%70rotected/%ZZ",
+      }),
+    ).rejects.toThrow("No route found for https://example.com/%70rotected/%ZZ");
+    expect(middlewareEntry).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- retry edge route lookup with an atomically decoded pathname when the encoded pathname does not match
- preserve the original encoded request URL passed to the edge entry
- add regression coverage for well-formed encoded paths and malformed encodings
- update the existing #1199 changeset to cover the bundled route lookup

This is a focused follow-up to #1199.

## Validation

- `pnpm --filter tests-unit exec vitest run packages/tests-unit/tests/core` (206 passed, 1 todo)
- `pnpm --filter @opennextjs/aws build`
- `pnpm exec biome check packages/open-next/src/core/edgeFunctionHandler.ts packages/tests-unit/tests/core/edgeFunctionHandler.test.ts`
- Cloudflare Worker fixture: the #1199 prerelease returned 500 for the encoded route; this branch invokes middleware and returns 401 for `/%70rotected` while `/%70rotected/%ZZ` remains un-decoded and returns 404