### PR TITLE
Fix route has-condition matching

### DIFF
--- a/.changeset/fix-route-has-matching.md
+++ b/.changeset/fix-route-has-matching.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix `has` condition matching to follow Next.js semantics.

--- a/packages/open-next/src/core/routing/matcher.ts
+++ b/packages/open-next/src/core/routing/matcher.ts
@@ -25,6 +25,15 @@ import {
   unescapeRegex,
 } from "./util";
 
+function matchHasValue(
+  value: string | string[] | undefined,
+  pattern?: string,
+): boolean {
+  const candidate = Array.isArray(value) ? value.at(-1) : value;
+  if (!candidate) return false;
+  return pattern ? new RegExp(`^${pattern}$`).test(candidate) : true;
+}
+
 const routeHasMatcher =
   (
     headers: Record<string, string>,
@@ -34,31 +43,18 @@ const routeHasMatcher =
   (redirect: RouteHas): boolean => {
     switch (redirect.type) {
       case "header":
-        return (
-          !!headers?.[redirect.key.toLowerCase()] &&
-          new RegExp(redirect.value ?? "").test(
-            headers[redirect.key.toLowerCase()] ?? "",
-          )
+        return matchHasValue(
+          headers[redirect.key.toLowerCase()],
+          redirect.value,
         );
       case "cookie":
-        return (
-          !!cookies?.[redirect.key] &&
-          new RegExp(redirect.value ?? "").test(cookies[redirect.key] ?? "")
-        );
+        return matchHasValue(cookies[redirect.key], redirect.value);
       case "query":
-        return query[redirect.key] && Array.isArray(redirect.value)
-          ? redirect.value.reduce(
-              (prev, current) =>
-                prev || new RegExp(current).test(query[redirect.key] as string),
-              false,
-            )
-          : new RegExp(redirect.value ?? "").test(
-              (query[redirect.key] as string | undefined) ?? "",
-            );
+        return matchHasValue(query[redirect.key], redirect.value);
       case "host":
-        return (
-          headers?.host !== "" &&
-          new RegExp(redirect.value ?? "").test(headers.host)
+        return matchHasValue(
+          headers.host?.split(":", 1)[0].toLowerCase(),
+          redirect.value,
         );
       default:
         return false;

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -6,6 +6,7 @@ import {
   handleRewrites,
 } from "@opennextjs/aws/core/routing/matcher.js";
 import { convertFromQueryString } from "@opennextjs/aws/core/routing/util.js";
+import type { RouteHas } from "@opennextjs/aws/types/next-types.js";
 import type { InternalEvent } from "@opennextjs/aws/types/open-next.js";
 import { vi } from "vitest";
 
@@ -209,6 +210,82 @@ describe("getNextConfigHeaders", () => {
     expect(result).toEqual({
       foo: "bar",
     });
+  });
+
+  it.each([
+    {
+      name: "header",
+      event: { headers: { "x-forwarded-proto": "https" } },
+      has: {
+        type: "header",
+        key: "x-forwarded-proto",
+        value: "http",
+      },
+    },
+    {
+      name: "cookie",
+      event: { cookies: { protocol: "https" } },
+      has: { type: "cookie", key: "protocol", value: "http" },
+    },
+    {
+      name: "query",
+      event: { url: "https://on/hello-world?protocol=https" },
+      has: { type: "query", key: "protocol", value: "http" },
+    },
+    {
+      name: "host",
+      event: { headers: { host: "not-on.example" } },
+      has: { type: "host", value: "on.example" },
+    },
+  ] satisfies {
+    name: string;
+    event: PartialEvent;
+    has: RouteHas;
+  }[])("should require an exact $name value match", ({ event, has }) => {
+    const result = getNextConfigHeaders(createEvent(event), [
+      {
+        source: "/(.*)",
+        regex: "^(?:/(.*))(?:/)?$",
+        headers: [{ key: "foo", value: "bar" }],
+        has: [has],
+      },
+    ]);
+
+    expect(result).toEqual({});
+  });
+
+  it("should not match an absent value-less query condition", () => {
+    const event = createEvent({
+      url: "https://on/hello-world",
+    });
+
+    const result = getNextConfigHeaders(event, [
+      {
+        source: "/(.*)",
+        regex: "^(?:/(.*))(?:/)?$",
+        headers: [{ key: "x-robots-tag", value: "noindex" }],
+        has: [{ type: "query", key: "preview" }],
+      },
+    ]);
+
+    expect(result).toEqual({});
+  });
+
+  it("should match a present value-less query condition", () => {
+    const event = createEvent({
+      url: "https://on/hello-world?preview=1",
+    });
+
+    const result = getNextConfigHeaders(event, [
+      {
+        source: "/(.*)",
+        regex: "^(?:/(.*))(?:/)?$",
+        headers: [{ key: "x-robots-tag", value: "noindex" }],
+        has: [{ type: "query", key: "preview" }],
+      },
+    ]);
+
+    expect(result).toEqual({ "x-robots-tag": "noindex" });
   });
 
   it("should return request headers for matching /* route with missing condition", () => {


### PR DESCRIPTION
Align `routeHasMatcher` with Next.js by requiring value-less conditions to be present and anchoring configured values. Repeated query values and hosts now follow Next.js matching behavior as well.

This prevents missing query parameters from applying headers such as `X-Robots-Tag: noindex`, and stops `http` from matching `https`.

Includes regression tests for header, cookie, query, and host conditions.

Fixes #1202.