### PR TITLE
fix: getBundlerRuntime should respect buildOutputPath

### DIFF
--- a/.changeset/bundler-runtime-build-output-path.md
+++ b/.changeset/bundler-runtime-build-output-path.md
@@ -1,0 +1,14 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix `getBundlerRuntime` ignoring `buildOutputPath`
+
+`getBundlerRuntime` looked for the Next.js server output under `appPath`, which
+is always the project root and does not follow the `buildOutputPath` config.
+Every other consumer of the Next.js build output (`getBuildId`,
+`copyEnvFile`, `createServerBundle`, …) resolves it from `appBuildOutputPath`.
+
+As a result, setting `buildOutputPath` to anything other than `.` failed the
+build with `Unable to determine Next.js runtime (webpack or turbopack)` as soon
+as the project root no longer contained a stale `.next` directory.

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -511,7 +511,10 @@ export function getPackagePath(options: BuildOptions) {
 export function getBundlerRuntime(
   options: BuildOptions,
 ): "webpack" | "turbopack" {
-  const dotNextServerPath = path.join(options.appPath, ".next/server");
+  const dotNextServerPath = path.join(
+    options.appBuildOutputPath,
+    ".next/server",
+  );
   if (fs.existsSync(path.join(dotNextServerPath, "webpack-runtime.js"))) {
     return "webpack";
   }


### PR DESCRIPTION
## What

`getBundlerRuntime` resolves the Next.js server output from `options.appPath`:

https://github.com/opennextjs/opennextjs-aws/blob/main/packages/open-next/src/build/helper.ts#L514

`appPath` is always the project root (`process.cwd()` + `config.appPath`) and does not follow the `buildOutputPath` config. Every other consumer of the Next.js build output resolves it from `appBuildOutputPath` — `getBuildId` (helper.ts#L277), `copyEnvFile`, `createServerBundle`, `createAssets`, `generateOutput`, and the Cloudflare adapter's `bundle-server`.

This changes that one call site to use `appBuildOutputPath`.

## Why

With `buildOutputPath` set to anything other than `.`, the build fails at the bundling stage:

```
Building server function: default...
Error: Unable to determine Next.js runtime (webpack or turbopack)
    at Module.getBundlerRuntime (.../build/helper.js:385:11)
    at Module.getEnvVarsPatch (.../build/patch/patches/patchEnvVar.js:23:37)
    at generateBundle (.../cli/build/open-next/createServerBundle.js:140:20)
```

The Next.js build itself succeeds and lands in `<buildOutputPath>/.next`, but `getBundlerRuntime` looks for `<projectRoot>/.next/server` and finds nothing.

This is easy to miss because a stale `.next` left in the project root from an earlier build satisfies the check — the failure only surfaces on a clean tree, or after the leftover directory is removed.

Reproduced with `@opennextjs/cloudflare` 1.20.2 / `@opennextjs/aws` 4.1.0 / Next.js 16.3.0 (Turbopack), on a monorepo app that sets `buildOutputPath: ".cache"` to keep build artifacts out of the project root. With the fix applied, the same build completes and emits the worker under the configured output path.

## Related

`@opennextjs/cloudflare` has the same class of bug in `retrieveCompiledConfig`, which breaks *deploy* (and `preview`/`upload`/`populateCache`) under a custom `buildOutputPath`. Fixed in opennextjs/opennextjs-cloudflare#1332. Both are needed for `buildOutputPath` to work end to end — with only this one applied the build succeeds and the deploy then fails on the compiled config lookup.

## Testing

`biome ci` and `pnpm test` pass locally.
