### PR TITLE
fix: persist runtime tags for APP_PAGE cache entries

### DIFF
--- a/.changeset/fix-page-cache-tag-associations.md
+++ b/.changeset/fix-page-cache-tag-associations.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Persist cache tag associations for `PAGES` and `APP_PAGE` entries so tag revalidation works with modern Next.js page cache kinds.

--- a/.changeset/fix-page-cache-tag-associations.md
+++ b/.changeset/fix-page-cache-tag-associations.md
@@ -2,4 +2,4 @@
 "@opennextjs/aws": patch
 ---
 
-Persist cache tag associations for `PAGES` and `APP_PAGE` entries so tag revalidation works with modern Next.js page cache kinds.
+Persist runtime cache tag associations for App Router `APP_PAGE` entries when using original-mode tag caches, including pages generated on demand and tags added after the build.

--- a/examples/app-router/app/revalidate-tag/on-demand/[id]/page.tsx
+++ b/examples/app-router/app/revalidate-tag/on-demand/[id]/page.tsx
@@ -1,0 +1,15 @@
+export const dynamicParams = true;
+
+export function generateStaticParams() {
+  return [];
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  return <p data-testid="on-demand-page">On-demand page: {id}</p>;
+}

--- a/examples/experimental/src/app/use-cache/on-demand/[id]/page.tsx
+++ b/examples/experimental/src/app/use-cache/on-demand/[id]/page.tsx
@@ -1,0 +1,23 @@
+import { FullyCachedComponentWithTag } from "@/components/cached";
+import { Suspense } from "react";
+
+export function generateStaticParams() {
+  return [];
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  return (
+    <main>
+      <p data-testid="on-demand-page">On-demand page: {id}</p>
+      <Suspense fallback={<p>Loading...</p>}>
+        <FullyCachedComponentWithTag />
+      </Suspense>
+    </main>
+  );
+}

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -531,9 +531,7 @@ export default class Cache {
     // Write derivedTags to the tag cache
     // If we use an in house version of getDerivedTags in build we should use it here instead of next's one
     const pageCacheTags =
-      data?.kind === "PAGE" ||
-      data?.kind === "PAGES" ||
-      data?.kind === "APP_PAGE"
+      data?.kind === "PAGE" || data?.kind === "APP_PAGE"
         ? data.headers?.["x-next-cache-tags"]
         : undefined;
     const derivedTags: string[] =

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -530,13 +530,19 @@ export default class Cache {
     }
     // Write derivedTags to the tag cache
     // If we use an in house version of getDerivedTags in build we should use it here instead of next's one
+    const pageCacheTags =
+      data?.kind === "PAGE" ||
+      data?.kind === "PAGES" ||
+      data?.kind === "APP_PAGE"
+        ? data.headers?.["x-next-cache-tags"]
+        : undefined;
     const derivedTags: string[] =
       data?.kind === "FETCH"
         ? //@ts-expect-error - On older versions of next, ctx was a number, but for these cases we use data?.data?.tags
           (ctx?.tags ?? data?.data?.tags ?? []) // before version 14 next.js used data?.data?.tags so we keep it for backward compatibility
-        : data?.kind === "PAGE"
-          ? (data.headers?.["x-next-cache-tags"]?.split(",") ?? [])
-          : [];
+        : Array.isArray(pageCacheTags)
+          ? pageCacheTags
+          : (pageCacheTags?.split(",") ?? []);
     debug("derivedTags", derivedTags);
 
     // Get all tags stored in dynamodb for the given key

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -554,6 +554,10 @@ export default class Cache {
     }
     // Write derivedTags to the tag cache
     // If we use an in house version of getDerivedTags in build we should use it here instead of next's one
+    // `x-next-cache-tags` is always a comma separated string: Next.js sets it from
+    // `metadata.fetchTags`, which is a string. The header type allows an array because it
+    // is shared with headers that can legitimately repeat, so we narrow on `typeof` here.
+    // Next.js guards the same way when it reads the header back.
     const pageCacheTags =
       data?.kind === "PAGE" || data?.kind === "APP_PAGE"
         ? data.headers?.["x-next-cache-tags"]
@@ -562,9 +566,9 @@ export default class Cache {
       data?.kind === "FETCH"
         ? //@ts-expect-error - On older versions of next, ctx was a number, but for these cases we use data?.data?.tags
           (ctx?.tags ?? data?.data?.tags ?? []) // before version 14 next.js used data?.data?.tags so we keep it for backward compatibility
-        : Array.isArray(pageCacheTags)
-          ? pageCacheTags
-          : (pageCacheTags?.split(",") ?? []);
+        : typeof pageCacheTags === "string"
+          ? pageCacheTags.split(",")
+          : [];
     debug("derivedTags", derivedTags);
 
     // Get all tags stored in dynamodb for the given key

--- a/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
+++ b/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
@@ -182,3 +182,38 @@ test("Revalidate path", async ({ page, request }) => {
   const newDate = await elLayout.textContent();
   expect(newDate).not.toEqual(initialDate);
 });
+
+test("Revalidate tag invalidates an App Router page generated on demand", async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(45000);
+  const path = `/revalidate-tag/on-demand/${Date.now()}`;
+
+  const initialResponse = await page.goto(path);
+  expect(initialResponse?.status()).toEqual(200);
+  await expect(page.getByTestId("on-demand-page")).toBeVisible();
+  const initialTime = await page.getByText("Fetched time:").textContent();
+
+  const result = await request.get("/api/revalidate-tag");
+  expect(result.status()).toEqual(200);
+  expect(await result.text()).toEqual("ok");
+
+  let refreshedResponse = initialResponse;
+  let refreshedTime = initialTime;
+  for (
+    let attempt = 0;
+    attempt < 10 && refreshedTime === initialTime;
+    attempt++
+  ) {
+    await page.waitForTimeout(1000);
+    refreshedResponse = await page.goto(path);
+    refreshedTime = await page.getByText("Fetched time:").textContent();
+  }
+
+  expect(refreshedTime).not.toEqual(initialTime);
+  const cacheHeader =
+    refreshedResponse?.headers()["x-nextjs-cache"] ??
+    refreshedResponse?.headers()["x-opennext-cache"];
+  expect(cacheHeader).toEqual("MISS");
+});

--- a/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
+++ b/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
@@ -187,11 +187,30 @@ test("Revalidate tag invalidates an App Router page generated on demand", async 
   page,
   request,
 }) => {
-  test.setTimeout(45000);
+  // Two bounded polling loops (warm-up then revalidation), so this needs more headroom
+  // than the single-loop tests above.
+  test.setTimeout(90000);
   const path = `/revalidate-tag/on-demand/${Date.now()}`;
 
-  const initialResponse = await page.goto(path);
-  expect(initialResponse?.status()).toEqual(200);
+  // The first request generates the page on demand, and the path/tag association is
+  // written during that `set` - behind a detached promise, into an eventually consistent
+  // store. Wait until the entry is actually served from the cache before revalidating,
+  // otherwise `revalidateTag` may not see the association yet and would leave the page
+  // untouched.
+  let warmupCache: string | undefined;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const warmupResponse = await page.goto(path);
+    expect(warmupResponse?.status()).toEqual(200);
+    const warmupHeaders = warmupResponse?.headers() ?? {};
+    warmupCache =
+      warmupHeaders["x-nextjs-cache"] ?? warmupHeaders["x-opennext-cache"];
+    if (warmupCache === "HIT" || warmupCache === "STALE") {
+      break;
+    }
+    await page.waitForTimeout(1000);
+  }
+  expect(warmupCache).toMatch(/^(HIT|STALE)$/);
+
   await expect(page.getByTestId("on-demand-page")).toBeVisible();
   const initialTime = await page.getByText("Fetched time:").textContent();
 
@@ -199,8 +218,8 @@ test("Revalidate tag invalidates an App Router page generated on demand", async 
   expect(result.status()).toEqual(200);
   expect(await result.text()).toEqual("ok");
 
-  let refreshedResponse = initialResponse;
-  let refreshedTime = initialTime;
+  let refreshedResponse = await page.goto(path);
+  let refreshedTime = await page.getByText("Fetched time:").textContent();
   for (
     let attempt = 0;
     attempt < 10 && refreshedTime === initialTime;
@@ -211,9 +230,15 @@ test("Revalidate tag invalidates an App Router page generated on demand", async 
     refreshedTime = await page.getByText("Fetched time:").textContent();
   }
 
+  // The page embeds the layout's tagged `unstable_cache` value, so a changed time proves
+  // the enclosing page entry was invalidated and not just the inner cache entry.
   expect(refreshedTime).not.toEqual(initialTime);
   const cacheHeader =
     refreshedResponse?.headers()["x-nextjs-cache"] ??
     refreshedResponse?.headers()["x-opennext-cache"];
-  expect(cacheHeader).toEqual("MISS");
+  // `revalidateTag` is called with `expire: 0`, so the entry expires immediately and the
+  // request that returns the new content is normally a blocking MISS. If the revalidation
+  // marker lands late, an earlier request may be served from cache and the new content
+  // then surfaces on a later HIT.
+  expect(cacheHeader).toMatch(/^(MISS|HIT)$/);
 });

--- a/packages/tests-e2e/tests/experimental/use-cache.test.ts
+++ b/packages/tests-e2e/tests/experimental/use-cache.test.ts
@@ -50,11 +50,30 @@ test.describe("Composable Cache", () => {
     page,
     request,
   }) => {
-    test.setTimeout(45000);
+    // Two bounded polling loops (warm-up then revalidation), so this needs more headroom
+    // than the other tests in this file.
+    test.setTimeout(90000);
     const path = `/use-cache/on-demand/${Date.now()}`;
 
-    const initialResponse = await page.goto(path);
-    expect(initialResponse?.status()).toEqual(200);
+    // The first request generates the page on demand, and the path/tag association is
+    // written during that `set` - behind a detached promise, into an eventually consistent
+    // store. Wait until the entry is actually served from the cache before revalidating,
+    // otherwise `revalidateTag` may not see the association yet and would leave the page
+    // untouched.
+    let warmupCache: string | undefined;
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const warmupResponse = await page.goto(path);
+      expect(warmupResponse?.status()).toEqual(200);
+      const warmupHeaders = warmupResponse?.headers() ?? {};
+      warmupCache =
+        warmupHeaders["x-nextjs-cache"] ?? warmupHeaders["x-opennext-cache"];
+      if (warmupCache === "HIT" || warmupCache === "STALE") {
+        break;
+      }
+      await page.waitForTimeout(1000);
+    }
+    expect(warmupCache).toMatch(/^(HIT|STALE)$/);
+
     const taggedComponent = page.getByTestId("fully-cached-with-tag");
     await expect(taggedComponent).toBeVisible();
     const initialText = await taggedComponent.textContent();
@@ -63,8 +82,8 @@ test.describe("Composable Cache", () => {
     expect(response.status()).toEqual(200);
     expect(await response.text()).toEqual("DONE");
 
-    let refreshedResponse = initialResponse;
-    let refreshedText = initialText;
+    let refreshedResponse = await page.goto(path);
+    let refreshedText = await taggedComponent.textContent();
     for (
       let attempt = 0;
       attempt < 10 && refreshedText === initialText;
@@ -75,11 +94,18 @@ test.describe("Composable Cache", () => {
       refreshedText = await taggedComponent.textContent();
     }
 
+    // `cacheTag` inside a `use cache` function propagates to the enclosing page entry, so
+    // a changed value proves the page entry was invalidated and not just the inner
+    // composable cache entry.
     expect(refreshedText).not.toEqual(initialText);
     const cacheHeader =
       refreshedResponse?.headers()["x-nextjs-cache"] ??
       refreshedResponse?.headers()["x-opennext-cache"];
-    expect(cacheHeader).toEqual("MISS");
+    // `revalidateTag` expires the tag immediately, so the request that returns the new
+    // content is normally a blocking MISS. If the revalidation marker lands late, an
+    // earlier request may be served from cache and the new content then surfaces on a
+    // later HIT.
+    expect(cacheHeader).toMatch(/^(MISS|HIT)$/);
   });
 
   test("cached component should work in isr", async ({ page }) => {

--- a/packages/tests-e2e/tests/experimental/use-cache.test.ts
+++ b/packages/tests-e2e/tests/experimental/use-cache.test.ts
@@ -46,6 +46,42 @@ test.describe("Composable Cache", () => {
     expect(newFullyCachedText).not.toEqual(initialFullyCachedText);
   });
 
+  test("revalidateTag should invalidate an on-demand use cache page", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(45000);
+    const path = `/use-cache/on-demand/${Date.now()}`;
+
+    const initialResponse = await page.goto(path);
+    expect(initialResponse?.status()).toEqual(200);
+    const taggedComponent = page.getByTestId("fully-cached-with-tag");
+    await expect(taggedComponent).toBeVisible();
+    const initialText = await taggedComponent.textContent();
+
+    const response = await request.get("/api/revalidate");
+    expect(response.status()).toEqual(200);
+    expect(await response.text()).toEqual("DONE");
+
+    let refreshedResponse = initialResponse;
+    let refreshedText = initialText;
+    for (
+      let attempt = 0;
+      attempt < 10 && refreshedText === initialText;
+      attempt++
+    ) {
+      await page.waitForTimeout(1000);
+      refreshedResponse = await page.goto(path);
+      refreshedText = await taggedComponent.textContent();
+    }
+
+    expect(refreshedText).not.toEqual(initialText);
+    const cacheHeader =
+      refreshedResponse?.headers()["x-nextjs-cache"] ??
+      refreshedResponse?.headers()["x-opennext-cache"];
+    expect(cacheHeader).toEqual("MISS");
+  });
+
   test("cached component should work in isr", async ({ page }) => {
     await page.goto("/use-cache/isr");
 

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -852,19 +852,38 @@ describe("CacheHandler", () => {
       );
     });
 
+    // `x-next-cache-tags` carries the tags collected during the render. Only entries
+    // reachable by `revalidateTag` are covered here: an App Router page is a `PAGE` with a
+    // string `pageData` before Next 15 and an `APP_PAGE` from Next 15 on. A `PAGE` with an
+    // object `pageData` is a Pages Router entry, which `revalidateTag` never reaches.
     it.each([
       {
-        cacheKind: "PAGE",
+        // App Router entry before Next 15, where `pageData` holds the RSC payload.
+        name: "a PAGE with a comma separated header",
         data: {
           kind: "PAGE" as const,
           html: "<html></html>",
-          pageData: {},
+          pageData: "rsc",
           status: 200,
           headers: { "x-next-cache-tags": "existing-tag,new-tag" },
         },
       },
       {
-        cacheKind: "APP_PAGE",
+        // The shape Next.js actually produces: the header is set from
+        // `metadata.fetchTags`, typed as a string in `next/server/render-result`.
+        name: "an APP_PAGE with a comma separated header",
+        data: {
+          kind: "APP_PAGE" as const,
+          html: "<html></html>",
+          rscData: Buffer.from("rsc"),
+          status: 200,
+          headers: { "x-next-cache-tags": "existing-tag,new-tag" },
+        },
+      },
+      {
+        // `OutgoingHttpHeaders` allows an array, so the adapter accepts one even though
+        // Next.js only ever sets a string (it also reads the header back as a string only).
+        name: "an APP_PAGE with an array header",
         data: {
           kind: "APP_PAGE" as const,
           html: "<html></html>",
@@ -875,7 +894,7 @@ describe("CacheHandler", () => {
           },
         },
       },
-    ])("Should persist cache tags for $cacheKind entries", async ({ data }) => {
+    ])("Should persist cache tags for $name", async ({ data }) => {
       tagCache.getByPath.mockResolvedValueOnce(["existing-tag"]);
 
       await cache.set("key", data);

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -764,16 +764,6 @@ describe("CacheHandler", () => {
         },
       },
       {
-        cacheKind: "PAGES",
-        data: {
-          kind: "PAGES" as const,
-          html: "<html></html>",
-          pageData: "rsc",
-          status: 200,
-          headers: { "x-next-cache-tags": "existing-tag,new-tag" },
-        },
-      },
-      {
         cacheKind: "APP_PAGE",
         data: {
           kind: "APP_PAGE" as const,

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -752,6 +752,55 @@ describe("CacheHandler", () => {
       );
     });
 
+    it.each([
+      {
+        cacheKind: "PAGE",
+        data: {
+          kind: "PAGE" as const,
+          html: "<html></html>",
+          pageData: {},
+          status: 200,
+          headers: { "x-next-cache-tags": "existing-tag,new-tag" },
+        },
+      },
+      {
+        cacheKind: "PAGES",
+        data: {
+          kind: "PAGES" as const,
+          html: "<html></html>",
+          pageData: "rsc",
+          status: 200,
+          headers: { "x-next-cache-tags": "existing-tag,new-tag" },
+        },
+      },
+      {
+        cacheKind: "APP_PAGE",
+        data: {
+          kind: "APP_PAGE" as const,
+          html: "<html></html>",
+          rscData: Buffer.from("rsc"),
+          status: 200,
+          headers: {
+            "x-next-cache-tags": ["existing-tag", "new-tag"],
+          },
+        },
+      },
+    ])("Should persist cache tags for $cacheKind entries", async ({ data }) => {
+      tagCache.getByPath.mockResolvedValueOnce(["existing-tag"]);
+
+      await cache.set("key", data);
+
+      expect(tagCache.getByPath).toHaveBeenCalledWith("key");
+      expect(tagCache.writeTags).toHaveBeenCalledTimes(1);
+      expect(tagCache.writeTags).toHaveBeenCalledWith([
+        {
+          path: "key",
+          tag: "new-tag",
+          revalidatedAt: 1,
+        },
+      ]);
+    });
+
     it("Should set cache when for FETCH", async () => {
       await cache.set("key", {
         kind: "FETCH",

--- a/packages/tests-unit/tests/adapters/cache.test.ts
+++ b/packages/tests-unit/tests/adapters/cache.test.ts
@@ -852,14 +852,14 @@ describe("CacheHandler", () => {
       );
     });
 
-    // `x-next-cache-tags` carries the tags collected during the render. Only entries
-    // reachable by `revalidateTag` are covered here: an App Router page is a `PAGE` with a
-    // string `pageData` before Next 15 and an `APP_PAGE` from Next 15 on. A `PAGE` with an
-    // object `pageData` is a Pages Router entry, which `revalidateTag` never reaches.
+    // `x-next-cache-tags` carries the tags collected during the render, as a comma
+    // separated string. Only entries reachable by `revalidateTag` are covered here: an App
+    // Router page is a `PAGE` with a string `pageData` before Next 15 and an `APP_PAGE`
+    // from Next 15 on. A `PAGE` with an object `pageData` is a Pages Router entry, which
+    // `revalidateTag` never reaches.
     it.each([
       {
-        // App Router entry before Next 15, where `pageData` holds the RSC payload.
-        name: "a PAGE with a comma separated header",
+        cacheKind: "PAGE",
         data: {
           kind: "PAGE" as const,
           html: "<html></html>",
@@ -869,9 +869,7 @@ describe("CacheHandler", () => {
         },
       },
       {
-        // The shape Next.js actually produces: the header is set from
-        // `metadata.fetchTags`, typed as a string in `next/server/render-result`.
-        name: "an APP_PAGE with a comma separated header",
+        cacheKind: "APP_PAGE",
         data: {
           kind: "APP_PAGE" as const,
           html: "<html></html>",
@@ -880,21 +878,7 @@ describe("CacheHandler", () => {
           headers: { "x-next-cache-tags": "existing-tag,new-tag" },
         },
       },
-      {
-        // `OutgoingHttpHeaders` allows an array, so the adapter accepts one even though
-        // Next.js only ever sets a string (it also reads the header back as a string only).
-        name: "an APP_PAGE with an array header",
-        data: {
-          kind: "APP_PAGE" as const,
-          html: "<html></html>",
-          rscData: Buffer.from("rsc"),
-          status: 200,
-          headers: {
-            "x-next-cache-tags": ["existing-tag", "new-tag"],
-          },
-        },
-      },
-    ])("Should persist cache tags for $name", async ({ data }) => {
+    ])("Should persist cache tags for $cacheKind entries", async ({ data }) => {
       tagCache.getByPath.mockResolvedValueOnce(["existing-tag"]);
 
       await cache.set("key", data);


### PR DESCRIPTION
Fixes #1180

## Summary

- persist runtime `x-next-cache-tags` associations for legacy `PAGE` and modern `APP_PAGE` entries when using an original-mode tag cache
- normalize both string and string-array cache-tag headers
- add deployed E2E coverage for App Router on-demand pages and experimental `use cache` pages
- add focused unit coverage and a patch changeset for `@opennextjs/aws`

## Scope

This affects original-mode tag caches such as `dynamodb-lite`. Next-mode tag caches do not maintain path/tag associations on set. Build-time page associations are already populated from generated metadata, so this change covers pages generated on demand and tags added during runtime regeneration.

Cache Components exposed the reported symptom, but the missing association is in incremental page-cache handling rather than the composable-cache adapter.

## Root cause

`revalidateTag()` correctly wrote the revalidation marker, but `Cache.updateTagsOnSet()` only persisted page-cache tag associations for the legacy `PAGE` kind. Runtime `APP_PAGE` entries therefore had no path/tag association for original-mode tag-cache lookup and CDN invalidation.

## Validation

- Biome: 440 files passed
- Unit tests: 611 passed, 1 todo
- `@opennextjs/aws` TypeScript build passed
- App Router and experimental example production builds passed; both new fixtures were classified as on-demand SSG routes
- Playwright discovered all affected App Router and experimental tests