### PR TITLE
fix: apply patchBackgroundRevalidation on Next 16

### DIFF
--- a/.changeset/fix-background-revalidation-next-16.md
+++ b/.changeset/fix-background-revalidation-next-16.md
@@ -1,0 +1,18 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix `patchBackgroundRevalidation` silently no-opping on Next.js 16
+
+The patch's ast-grep rule matched the unary expression `!cachedResponse.isStale`,
+but Next.js 16.0.0 renamed that local to `previousIncrementalCacheEntry`. The rule
+matched nothing, so `commitEdits([])` returned the source unchanged and the patch
+was skipped on every Next.js 16 build — while still being reported as applied in
+the `OPEN_NEXT_DEBUG` output, since the log line is emitted before the edit is
+attempted.
+
+The rule now matches `!$ENTRY.isStale` instead of hardcoding the identifier, which
+keeps working on Next.js 14 and 15 and fixes 16. The existing unit test used a
+frozen pre-16 snippet as its fixture, so it kept passing throughout; a Next 16
+fixture has been added alongside it, plus an assertion that the outer
+`isStale !== -1` guard introduced in 16 is not matched by mistake.

--- a/packages/open-next/src/build/patch/patches/patchBackgroundRevalidation.ts
+++ b/packages/open-next/src/build/patch/patches/patchBackgroundRevalidation.ts
@@ -8,7 +8,7 @@ rule:
   all:
     - has:
         kind: unary_expression
-        regex: "!cachedResponse.isStale"
+        pattern: "!$ENTRY.isStale"
     -  has:
          kind: member_expression
          regex: "context.isPrefetch"

--- a/packages/tests-unit/tests/build/patch/patches/patchBackgroundRevalidation.test.ts
+++ b/packages/tests-unit/tests/build/patch/patches/patchBackgroundRevalidation.test.ts
@@ -19,6 +19,17 @@ const codeToPatch = `if (cachedResponse && !isOnDemandRevalidate) {
                     }
                 }`;
 
+// Next 16 renamed the local from `cachedResponse` to
+// `previousIncrementalCacheEntry` and added the `isStale !== -1` guard.
+const codeToPatchNext16 = `if (previousIncrementalCacheEntry && !context.isOnDemandRevalidate && previousIncrementalCacheEntry.isStale !== -1) {
+                    resolve(previousIncrementalCacheEntry);
+                    resolved = true;
+                    if (!previousIncrementalCacheEntry.isStale || context.isPrefetch) {
+                        // The cached value is still valid, so we don't need to update it yet.
+                        return previousIncrementalCacheEntry;
+                    }
+                }`;
+
 describe("patchBackgroundRevalidation", () => {
   it("Should patch code", () => {
     expect(
@@ -39,5 +50,26 @@ describe("patchBackgroundRevalidation", () => {
                         return null;
                     }
                 }"`);
+  });
+
+  it("Should patch code on Next 16", () => {
+    expect(
+      patchCode(codeToPatchNext16, rule),
+    ).toMatchInlineSnapshot(`"if (previousIncrementalCacheEntry && !context.isOnDemandRevalidate && previousIncrementalCacheEntry.isStale !== -1) {
+                    resolve(previousIncrementalCacheEntry);
+                    resolved = true;
+                    if (true) {
+                        // The cached value is still valid, so we don't need to update it yet.
+                        return previousIncrementalCacheEntry;
+                    }
+                }"`);
+  });
+
+  it("Should not match the outer `isStale !== -1` guard", () => {
+    // The guard must survive: it is what makes Next fall through to a blocking
+    // revalidation for entries that are past their `expire`.
+    expect(patchCode(codeToPatchNext16, rule)).toContain(
+      "previousIncrementalCacheEntry.isStale !== -1",
+    );
   });
 });


### PR DESCRIPTION
Fixes #1210

## Problem

`patchBackgroundRevalidation`'s rule matches the unary expression `!cachedResponse.isStale`. Next.js **16.0.0** renamed that local to `previousIncrementalCacheEntry`, so the rule matches nothing, `commitEdits([])` returns the source unchanged, and the patch has been silently skipped on every Next.js 16 build.

It fails silently in both directions:

- `codePatcher.ts` logs `Applying code patch: <name>` *before* calling `patchCode`, so `OPEN_NEXT_DEBUG=true` reports the patch as applied either way.
- `astCodePatcher.ts` produces no edits and returns the code untouched, so the build exits 0.

Verified on a real build artifact (`@opennextjs/aws@4.1.0`, Next 16.3.0), where the built `response-cache/index.js` still contains the original condition instead of `if (true)`.

## Why the test didn't catch it

`patchBackgroundRevalidation.test.ts` used a frozen pre-16 snippet as its fixture, so it kept passing regardless of what Next actually emits — the rule was only ever exercised against code shaped the way it already expected.

## Change

Match `!$ENTRY.isStale` rather than hardcoding the identifier. One line, and backward compatible — checked with `patchCode` against the real `next/dist/server/response-cache/index.js` of each version:

| Next.js | rule on `main` | rule in this PR |
| --- | --- | --- |
| 14.2.33 | applied | applied |
| 15.0.0 | applied | applied |
| 15.3.0 | applied | applied |
| 15.5.7 | applied | applied |
| 16.0.0 | **no-op** | applied |
| 16.2.12 | **no-op** | applied |
| 16.3.0 | **no-op** | applied |

Tests: the pre-16 fixture is kept, a Next 16 fixture is added, and a third case asserts the outer `previousIncrementalCacheEntry.isStale !== -1` guard introduced in 16 is *not* matched by mistake — that guard is what makes Next fall through to a blocking revalidation for entries past their `expire`, so clobbering it would be a regression. The new Next 16 test fails on `main` and passes here.

`pnpm --filter tests-unit test`: 33 files, 611 tests passing. `biome check` clean.

## Relationship to #1207

#1207 fixed the *observable* symptom on 16.3 ("stale entries revalidated in a blocking way") at the incremental-cache layer, by reporting a `lastModified` that keeps stale entries inside their expire window. This PR is complementary and at a different layer: it restores the build-time patch that stops Next's response cache from revalidating in-process at all, so revalidation is left to the configured `queue`. Neither supersedes the other, and this one also covers 16.0–16.2.

## Note

The issue proposed a `regex: "!\\w+\\.isStale"` variant; both work, but `pattern: "!$ENTRY.isStale"` avoids the double escaping and reads closer to the other rules in `patches/`. Happy to switch if you prefer the regex form.

`patch-fetch-cache-set-missing-wait-until` no-ops the same way on 16.x — its rule expects the `arrayBuffer().then` call in a sequence/return shape, while 16.x assigns it to `const cacheSetPromise`. Left out of this PR to keep it focused; glad to follow up.
