### PR TITLE
fix: forward images.dangerouslyAllowLocalIP to fetchExternalImage on Next 16

### DIFF
--- a/.changeset/forward-dangerously-allow-local-ip.md
+++ b/.changeset/forward-dangerously-allow-local-ip.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Forward `images.dangerouslyAllowLocalIP` to `fetchExternalImage` on Next.js 16 instead of hardcoding `false`, so external images served from hosts resolving to private IPs (e.g. an internal media proxy) can be optimized again when the user has explicitly opted out of the SSRF guard in their Next.js config.

--- a/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
+++ b/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
@@ -44,13 +44,13 @@ export async function optimizeImage(
   // Next 16 rejects upstream hosts resolving to private IPs unless the user
   // opts out with `images.dangerouslyAllowLocalIP` — forward their setting
   // instead of always disabling the opt-out.
-  const dangerouslyAllowLocalIP =
-    nextConfig.images?.dangerouslyAllowLocalIP ?? false;
+  const dangerouslyAllowLocalIP = Boolean(
+    nextConfig.images?.dangerouslyAllowLocalIP,
+  );
 
   const callFetchExternalImage = () => {
     const version = globalThis.nextVersion;
 
-    // v16.1.5+
     if (compareSemver(version, ">=", "16.1.5")) {
       return fetchExternalImage(
         href,
@@ -59,13 +59,11 @@ export async function optimizeImage(
       );
     }
 
-    // v16.0.0–v16.1.4
     if (compareSemver(version, ">=", "16")) {
       // @ts-expect-error - fetchExternalImage signature varies across Next.js versions
       return fetchExternalImage(href, dangerouslyAllowLocalIP);
     }
 
-    // v15.5.10–v15.x
     if (compareSemver(version, ">=", "15.5.10")) {
       // @ts-expect-error - fetchExternalImage signature varies across Next.js versions
       return fetchExternalImage(href, maximumResponseBody);

--- a/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
+++ b/packages/open-next/src/adapters/plugins/image-optimization/image-optimization.replacement.ts
@@ -41,18 +41,28 @@ export async function optimizeImage(
    *
    * https://github.com/vercel/next.js/blob/bfe2ab4/packages/next/src/server/image-optimizer.ts#L711
    */
+  // Next 16 rejects upstream hosts resolving to private IPs unless the user
+  // opts out with `images.dangerouslyAllowLocalIP` — forward their setting
+  // instead of always disabling the opt-out.
+  const dangerouslyAllowLocalIP =
+    nextConfig.images?.dangerouslyAllowLocalIP ?? false;
+
   const callFetchExternalImage = () => {
     const version = globalThis.nextVersion;
 
     // v16.1.5+
     if (compareSemver(version, ">=", "16.1.5")) {
-      return fetchExternalImage(href, false, maximumResponseBody);
+      return fetchExternalImage(
+        href,
+        dangerouslyAllowLocalIP,
+        maximumResponseBody,
+      );
     }
 
     // v16.0.0–v16.1.4
     if (compareSemver(version, ">=", "16")) {
       // @ts-expect-error - fetchExternalImage signature varies across Next.js versions
-      return fetchExternalImage(href, false);
+      return fetchExternalImage(href, dangerouslyAllowLocalIP);
     }
 
     // v15.5.10–v15.x

--- a/packages/tests-unit/tests/adapters/image-optimization.test.ts
+++ b/packages/tests-unit/tests/adapters/image-optimization.test.ts
@@ -40,13 +40,23 @@ function callOptimizeImage(
   overrides: {
     isAbsolute?: boolean;
     maximumResponseBody?: number;
+    dangerouslyAllowLocalIP?: boolean;
   } = {},
 ) {
-  const { isAbsolute = false, maximumResponseBody } = overrides;
+  const {
+    isAbsolute = false,
+    maximumResponseBody,
+    dangerouslyAllowLocalIP,
+  } = overrides;
   const headers = { "x-custom": "value" };
   const imageParams = { isAbsolute, href: HREF };
   const nextConfig = {
-    images: maximumResponseBody ? { maximumResponseBody } : {},
+    images: {
+      ...(maximumResponseBody ? { maximumResponseBody } : {}),
+      ...(dangerouslyAllowLocalIP !== undefined
+        ? { dangerouslyAllowLocalIP }
+        : {}),
+    },
   } as any;
 
   return optimizeImage(headers, imageParams, nextConfig, handleRequest);
@@ -127,6 +137,28 @@ describe("optimizeImage (replacement)", () => {
         maximumResponseBody: 1_234,
       });
       expect(mockFetchExternalImage).toHaveBeenCalledWith(HREF, false, 1_234);
+    });
+
+    it("forwards images.dangerouslyAllowLocalIP for v16.1.5+", async () => {
+      globalThis.nextVersion = "16.1.5";
+      await callOptimizeImage({
+        isAbsolute: true,
+        dangerouslyAllowLocalIP: true,
+      });
+      expect(mockFetchExternalImage).toHaveBeenCalledWith(
+        HREF,
+        true,
+        50_000_000,
+      );
+    });
+
+    it("forwards images.dangerouslyAllowLocalIP for v16.0.0–v16.1.4", async () => {
+      globalThis.nextVersion = "16.0.0";
+      await callOptimizeImage({
+        isAbsolute: true,
+        dangerouslyAllowLocalIP: true,
+      });
+      expect(mockFetchExternalImage).toHaveBeenCalledWith(HREF, true);
     });
 
     it("does not call fetchInternalImage", async () => {

--- a/packages/tests-unit/tests/adapters/image-optimization.test.ts
+++ b/packages/tests-unit/tests/adapters/image-optimization.test.ts
@@ -161,6 +161,36 @@ describe("optimizeImage (replacement)", () => {
       expect(mockFetchExternalImage).toHaveBeenCalledWith(HREF, true);
     });
 
+    it("forwards images.dangerouslyAllowLocalIP alongside a custom maximumResponseBody", async () => {
+      globalThis.nextVersion = "16.1.5";
+      await callOptimizeImage({
+        isAbsolute: true,
+        dangerouslyAllowLocalIP: true,
+        maximumResponseBody: 1_234,
+      });
+      expect(mockFetchExternalImage).toHaveBeenCalledWith(HREF, true, 1_234);
+    });
+
+    // `dangerouslyAllowLocalIP` only exists from v16 on, where it takes the
+    // argument slot that v15.5.10+ uses for `maximumResponseBody`. Leaking it
+    // into a pre-16 call would pass a boolean where Next.js expects a number.
+    it.each<[version: string, expectedArgs: unknown[]]>([
+      ["15.5.9", [HREF]],
+      ["15.5.10", [HREF, 50_000_000]],
+      ["15.5.16", [HREF, 50_000_000]],
+      ["15.9.99", [HREF, 50_000_000]],
+    ])(
+      "ignores images.dangerouslyAllowLocalIP for v%s",
+      async (version, expectedArgs) => {
+        globalThis.nextVersion = version;
+        await callOptimizeImage({
+          isAbsolute: true,
+          dangerouslyAllowLocalIP: true,
+        });
+        expect(mockFetchExternalImage).toHaveBeenCalledWith(...expectedArgs);
+      },
+    );
+
     it("does not call fetchInternalImage", async () => {
       globalThis.nextVersion = "16.2.5";
       await callOptimizeImage({ isAbsolute: true });
@@ -218,6 +248,23 @@ describe("optimizeImage (replacement)", () => {
     it("uses the new signature for v16.2.5+", async () => {
       globalThis.nextVersion = "16.2.5";
       await callOptimizeImage({ isAbsolute: false });
+      expect(mockFetchInternalImage).toHaveBeenCalledWith(
+        HREF,
+        { headers: { "x-custom": "value" } },
+        {},
+        50_000_000,
+        handleRequest,
+      );
+    });
+
+    // The private IP guard is an upstream-fetch concern only, so the flag must
+    // never reach the internal path.
+    it("ignores images.dangerouslyAllowLocalIP", async () => {
+      globalThis.nextVersion = "16.2.5";
+      await callOptimizeImage({
+        isAbsolute: false,
+        dangerouslyAllowLocalIP: true,
+      });
       expect(mockFetchInternalImage).toHaveBeenCalledWith(
         HREF,
         { headers: { "x-custom": "value" } },


### PR DESCRIPTION
Fixes #1225

Next.js 16's image optimizer rejects upstream hosts resolving to private IPs unless the user opts out via `images.dangerouslyAllowLocalIP`. The `optimizeImage` wrapper hardcoded that `fetchExternalImage` argument to `false`, so the user's config never reached the check and external images served from private-IP hosts (e.g. an internal media proxy behind a PrivateLink/VPC endpoint) always failed with a 400, even with the opt-out set.

The value is already present in the merged `nextConfig` the wrapper receives (loaded from `required-server-files.json`) — this PR forwards it:

- v16.1.5+: `fetchExternalImage(href, dangerouslyAllowLocalIP, maximumResponseBody)`
- v16.0.0–v16.1.4: `fetchExternalImage(href, dangerouslyAllowLocalIP)`

Pre-16 signatures are untouched (the parameter does not exist there). Default stays `false` (`?? false`), so behavior only changes for users who explicitly set the flag.

Verified on a real deployment (Next 16.3.3, `@opennextjs/aws` 4.1.1 on Lambda, media through an internal proxy resolving to 10.x): with the value forwarded, the previously failing `/_next/image?url=http%3A%2F%2Fproxy...` requests return `200 image/jpeg`; without it, `400 "url" parameter is not allowed`.

Includes a patch changeset.
