### PR TITLE
fix: register the router server context under the build-time project dir

### DIFF
--- a/.changeset/register-router-server-context.md
+++ b/.changeset/register-router-server-context.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/aws": patch
+---
+
+Register the router server context under the project directory the route modules actually read.
+
+Next.js delegates pages router `notFound` results to `routerServerContext.render404`, falling back to a bare `This page could not be found` body when that context is missing. `NextNodeServer` registers the context itself, but keys it on `path.relative(process.cwd(), server.dir)`, while the route modules read it back using the `relativeProjectDir` baked in at build time, which is always an empty string here. The two only line up because `server-adapter.ts` calls `process.chdir(__dirname)` on cold start, so the behaviour of a core rendering path depends on the working directory being changed by the adapter. Adapters that cannot change the working directory (Cloudflare Workers has no `process.chdir`) register the context under a key nothing reads and serve the fallback body instead of the app's 404 page.
+
+The core now registers the context upfront under the build-time key, so it no longer depends on the working directory. There is no behaviour change on AWS: the entry lands under the same key Next.js already used there, and Next.js still augments it per request.

--- a/examples/pages-router/src/pages/ssr-not-found/index.tsx
+++ b/examples/pages-router/src/pages/ssr-not-found/index.tsx
@@ -1,0 +1,14 @@
+/**
+ * A `notFound` result is not rendered by the route module itself, it is delegated to
+ * `routerServerContext.render404`. When that context is missing the route module falls back to a
+ * bare `This page could not be found` body instead of the app's 404 page.
+ *
+ * See tests-e2e/tests/pagesRouter/ssr-not-found.test.ts.
+ */
+export async function getServerSideProps() {
+  return { notFound: true };
+}
+
+export default function Page() {
+  return null;
+}

--- a/packages/open-next/src/core/util.ts
+++ b/packages/open-next/src/core/util.ts
@@ -66,6 +66,31 @@ const nextServer = new NextServer.default({
   dir: __dirname,
 });
 
+// WORKAROUND: Register the router server context ourselves.
+// The pages router renders `notFound: true` results through
+// `routerServerContext.render404` and falls back to a bare
+// "This page could not be found" body when the context is missing.
+// `NextNodeServer` does register that context, but it keys it on
+// `path.relative(process.cwd(), server.dir)` while the route modules read it
+// back using the `relativeProjectDir` baked in at build time, which is always
+// an empty string here. Those two only line up when the working directory is
+// the server directory, which not every deployment target can guarantee
+// (`process.chdir` is a no-op on Cloudflare Workers, for example).
+// Registering upfront under the build-time key removes that dependency.
+const RouterServerContextSymbol = Symbol.for("@next/router-server-methods");
+const routerServerGlobal = globalThis as unknown as Record<
+  symbol,
+  Record<string, Record<string, unknown>> | undefined
+>;
+const routerServerContexts = (routerServerGlobal[RouterServerContextSymbol] ??=
+  {});
+// The key the route modules read the context back with.
+const relativeProjectDir = "";
+routerServerContexts[relativeProjectDir] ??= {
+  render404: nextServer.render404.bind(nextServer),
+};
+routerServerContexts[relativeProjectDir].nextConfig = nextServer.nextConfig;
+
 let routesLoaded = false;
 
 globalThis.__next_route_preloader = async (stage) => {

--- a/packages/tests-e2e/tests/pagesRouter/ssr-not-found.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/ssr-not-found.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("should render the 404 page for a getServerSideProps `notFound` result", async ({
+  page,
+}) => {
+  const result = await page.goto("/ssr-not-found/");
+  expect(result).toBeDefined();
+  expect(result?.status()).toBe(404);
+
+  // The route module renders a bare `This page could not be found` body when it cannot reach
+  // `routerServerContext.render404`, so assert on the rendered 404 page rather than its text.
+  await expect(page.locator("#__next")).toBeAttached();
+});


### PR DESCRIPTION
## What

Register the Next.js router server context in the shared core, under the project directory key the route modules actually read.

## Why

Next.js does not render pages router `notFound` results in the route module itself. It delegates to `routerServerContext.render404`, and falls back to a bare `This page could not be found` body when that context is missing ([`pages-handler.js`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/pages/handler.ts)).

`NextNodeServer` does register that context, but the write key and the read key are computed differently:

- **Write**, in `handleCatchallRenderRequest`: `path.relative(process.cwd(), this.dir)`
- **Read**, in the route module: the `relativeProjectDir` baked in at build time, which is always `""` here

Those only agree when the working directory is the server directory. On AWS they do agree, because `adapters/server-adapter.ts` calls `process.chdir(__dirname)` on cold start. So the behaviour of a core rendering path depends on an adapter level `chdir` workaround.

Adapters that cannot change the working directory do not get that. On Cloudflare Workers there is no `process.chdir`, `__dirname` is bundled as `""`, and `setNextjsServerWorkingDirectory` is patched out (opennextjs/opennextjs-cloudflare#899). The context is written under `".."` while the route modules read `""`, so `render404` is never found and every `notFound` result serves the fallback body instead of the app's 404 page.

## What changed

`packages/open-next/src/core/util.ts` registers the context immediately after constructing `NextServer`, keyed on the build-time `relativeProjectDir`. It no longer depends on the working directory, and it runs before `server-adapter.ts` calls `chdir` rather than after.

Also adds a `ssr-not-found` page to the pages router example and an e2e test, so the 404 path is covered rather than only the "route does not exist" path that `404.test.ts` already covers.

## No behaviour change on AWS

The entry lands under `""`, the same key Next.js already resolves to there, and Next.js still augments it per request. In particular `isWrappedByNextServer` is unaffected: Next.js writes that flag onto the same entry on every render request, so pre-registering cannot suppress it.

## Verification

AWS, `examples/pages-router` built with `openbuild:local`:

- `/ssr-not-found/` returns `404 text/html`, 2278 bytes, containing `__NEXT_DATA__`, rather than the fallback body
- dynamic routes unchanged: `/api/dynamic/hello-world-123` returns `{"slug":"hello-world-123"}`, `/api/dynamic/catch-all/a/b` returns `{"slug":["a","b"]}`
- `tests-unit` green, biome and `tsc --noEmit` clean

Cloudflare, to confirm this fixes the adapter that is actually broken. I overlaid this build of `core/util.js` into `opennextjs-cloudflare`'s vendored `@opennextjs/aws`, **disabled the build patch from opennextjs/opennextjs-cloudflare#1346 entirely**, and rebuilt the worker:

- `/ssr-not-found` returns 404 HTML with `__NEXT_DATA__` on the first request into a fresh isolate
- full `pages-router` e2e suite: 37 passed, 1 skipped, including #1346's own test

So this change alone fixes Cloudflare and opennextjs/opennextjs-cloudflare#1346's ast-grep patch can be dropped once this lands. That PR is open against the Cloudflare adapter and I will close it in favour of this one.

Ref: opennextjs/opennextjs-cloudflare#1346, where @vicb suggested the fix belongs here.
