### PR TITLE
Improve status code handling in cacheInterceptor

### DIFF
--- a/.changeset/long-webs-give.md
+++ b/.changeset/long-webs-give.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+Improve status code handling in cacheInterceptor

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -218,12 +218,10 @@ async function generateResult(
     lastModified,
     isStaleFromTagCache,
   );
-  // Sometimes other status codes can be cached, like 404. For these cases, we should return the correct status code
-  // Also set the status code to the rewriteStatusCode if defined
-  // This can happen in handleMiddleware in routingHandler.
-  // `NextResponse.rewrite(url, { status: xxx})
-  // The rewrite status code should take precedence over the cached one
-  const statusCode = event.rewriteStatusCode ?? cachedValue.meta?.status ?? 200;
+  const statusCode = computeStatusCode(
+    event.rewriteStatusCode,
+    cachedValue.meta?.status,
+  );
   const headers: Record<string, string | string[]> = {
     ...cacheControl,
     "content-type": type,
@@ -243,6 +241,30 @@ async function generateResult(
     isBase64Encoded: false,
     headers,
   };
+}
+
+/**
+ * Computes the status code to return for a cache hit.
+ *
+ * Sometimes other status codes can be cached, like 404. For these cases, we should return the correct status code.
+ * The rewrite status code can be set in handleMiddleware in routingHandler with
+ * `NextResponse.rewrite(url, { status: xxx })`.
+ *
+ * A meaningful cached status code (i.e. anything but the implicit 200) wins over the rewrite
+ * status code, otherwise a rewrite would turn a cached error page into a successful response.
+ *
+ * @param rewriteStatusCode The status code from the middleware rewrite, if any.
+ * @param cachedStatusCode The status code stored in the cache entry meta, if any.
+ * @returns The status code to return.
+ */
+function computeStatusCode(
+  rewriteStatusCode: number | undefined,
+  cachedStatusCode: number | undefined,
+): number {
+  if (cachedStatusCode !== undefined && cachedStatusCode !== 200) {
+    return cachedStatusCode;
+  }
+  return rewriteStatusCode ?? cachedStatusCode ?? 200;
 }
 
 /**
@@ -399,8 +421,10 @@ export async function cacheInterceptor(
             String(cachedData.value.meta?.headers?.["content-type"]),
           );
 
-          const statusCode =
-            event.rewriteStatusCode ?? cachedData.value.meta?.status ?? 200;
+          const statusCode = computeStatusCode(
+            event.rewriteStatusCode,
+            cachedData.value.meta?.status,
+          );
           const headers: Record<string, string | string[]> = {
             ...cacheControl,
             ...cachedData.value.meta?.headers,

--- a/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
+++ b/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
@@ -595,7 +595,7 @@ describe("cacheInterceptor", () => {
     expect(result.statusCode).toBe(403);
   });
 
-  it("should return the rewriteStatusCode if there is a cached status code", async () => {
+  it("should return the cached status code over the rewriteStatusCode", async () => {
     const event = createEvent({
       url: "/albums",
       rewriteStatusCode: 203,
@@ -606,6 +606,25 @@ describe("cacheInterceptor", () => {
         html: "Hello, world!",
         meta: {
           status: 404,
+        },
+      },
+    });
+
+    const result = await cacheInterceptor(event);
+    expect(result.statusCode).toBe(404);
+  });
+
+  it("should return the rewriteStatusCode if the cached status code is 200", async () => {
+    const event = createEvent({
+      url: "/albums",
+      rewriteStatusCode: 203,
+    });
+    incrementalCache.get.mockResolvedValueOnce({
+      value: {
+        type: "app",
+        html: "Hello, world!",
+        meta: {
+          status: 200,
         },
       },
     });


### PR DESCRIPTION
Enhance the status code handling logic in the cacheInterceptor to ensure the correct status code is returned for cached responses. Update related tests to verify the new behavior, ensuring cached status codes take precedence over rewrite status codes when applicable.
We now have the same behavior as `next start`