### PR TITLE
fix: match `fallback: false` routes against decoded pathname equivalents

### DIFF
--- a/.changeset/decoded-fallback-false-paths.md
+++ b/.changeset/decoded-fallback-false-paths.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: match `fallback: false` routes against decoded pathname equivalents, so a prerendered page whose slug contains a space or a non-ASCII character is served from the prerender cache instead of returning a 404.

--- a/packages/open-next/src/core/routing/matcher.ts
+++ b/packages/open-next/src/core/routing/matcher.ts
@@ -462,7 +462,21 @@ export function handleFallbackFalse(
     ({ route }) => !prerenderedFallbackRoutesName.includes(route),
   );
 
-  const isPregenerated = Object.keys(routes).includes(localizedPath);
+  let decodedLocalizedPath: string | undefined;
+  try {
+    // The prerender manifest keys routes by their decoded path, while rawPath
+    // arrives percent-encoded. Decode the complete path atomically so a
+    // malformed escape cannot be partially decoded.
+    decodedLocalizedPath = decodeURIComponent(localizedPath);
+  } catch {
+    // A malformed escape sequence cannot name a prerendered route.
+  }
+  // Also match against the decoded path, so a prerendered page whose slug
+  // contains a space or a non-ASCII character is not treated as missing.
+  const isPregenerated =
+    Object.keys(routes).includes(localizedPath) ||
+    (decodedLocalizedPath !== undefined &&
+      Object.keys(routes).includes(decodedLocalizedPath));
   if (
     routeFallback &&
     !isPregenerated &&

--- a/packages/tests-unit/tests/core/routing/matcher.test.ts
+++ b/packages/tests-unit/tests/core/routing/matcher.test.ts
@@ -2,10 +2,12 @@ import { NextConfig } from "@opennextjs/aws/adapters/config/index.js";
 import {
   fixDataPage,
   getNextConfigHeaders,
+  handleFallbackFalse,
   handleRedirects,
   handleRewrites,
 } from "@opennextjs/aws/core/routing/matcher.js";
 import { convertFromQueryString } from "@opennextjs/aws/core/routing/util.js";
+import type { PrerenderManifest } from "@opennextjs/aws/types/next-types.js";
 import type { InternalEvent } from "@opennextjs/aws/types/open-next.js";
 import { vi } from "vitest";
 
@@ -690,5 +692,55 @@ describe("fixDataPage", () => {
     });
 
     NextConfig.basePath = undefined;
+  });
+});
+
+describe("handleFallbackFalse", () => {
+  // Next writes the prerender manifest with decoded keys, while rawPath
+  // arrives percent-encoded, so a slug with a space is keyed "Finance 101"
+  // but requested as "Finance%20101".
+  const prerenderManifest = {
+    routes: {
+      "/learn/Finance 101/bitcoin": { initialRevalidateSeconds: false },
+      "/learn/Finance/bitcoin": { initialRevalidateSeconds: false },
+    },
+    dynamicRoutes: {
+      "/learn/[...slug]": {
+        routeRegex: "^/learn/(.+?)(?:/)?$",
+        fallback: false,
+        dataRouteRegex: "^/_next/data/BUILD_ID/learn/(.+?)\\.json$",
+      },
+    },
+    preview: { previewModeId: "id" },
+  } satisfies PrerenderManifest;
+
+  it("should serve a prerendered route whose path is percent-encoded", () => {
+    const event = createEvent({
+      url: "https://on/learn/Finance%20101/bitcoin",
+    });
+
+    const response = handleFallbackFalse(event, prerenderManifest);
+
+    expect(response.event.rawPath).toBe("/learn/Finance%20101/bitcoin");
+    expect(response.isISR).toBe(true);
+  });
+
+  it("should serve a prerendered route whose path needs no decoding", () => {
+    const event = createEvent({ url: "https://on/learn/Finance/bitcoin" });
+
+    const response = handleFallbackFalse(event, prerenderManifest);
+
+    expect(response.event.rawPath).toBe("/learn/Finance/bitcoin");
+    expect(response.isISR).toBe(true);
+  });
+
+  it("should 404 a route that is not prerendered", () => {
+    const event = createEvent({ url: "https://on/learn/Missing%20101/page" });
+
+    const response = handleFallbackFalse(event, prerenderManifest);
+
+    expect(response.event.rawPath).toBe("/404");
+    expect(response.event.headers["x-invoke-status"]).toBe("404");
+    expect(response.isISR).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #1213.

## The bug

`handleFallbackFalse` looks up the prerender manifest with `localizedPath`, which derives from `internalEvent.rawPath` — the request path **as received**, so percent-encoded. The `routes` keys come from the prerender manifest, which Next writes **decoded**. The two never match for a path containing a space or a non-ASCII character, so `isPregenerated` is `false`, and with a `fallback: false` dynamic route matching the request the page is rewritten to `/404`.

The prerendered output is built correctly and is on disk under its decoded name — only the lookup is wrong. The same app under `next start` serves all of these paths correctly.

```
opennext=404  next start=200   /fr-ch/Présentation
opennext=404  next start=200   /learn/Academy/Finance%20101/bitcoin-portfolio
```

On a site where editors write the slugs this is not an edge case: on the site where I hit it, 195 of 476 URLs (41%) were affected.

## The fix

Also compare against the decoded path, guarded so a malformed escape sequence cannot throw. Checking both forms keeps the lookup correct whichever way a given Next version writes the manifest.

This mirrors the decoded-path matching @james-elicx added to the edge route lookup in #1200 — same class of bug, different lookup — and follows the same shape (decode the complete path atomically, leave `undefined` on a malformed escape, then match either form).

## Scope

`matcher.ts` is the only place in the routing layer that keys into the prerender manifest by path; the sibling `dynamicRoutes` checks go through `routeRegex`, which matches an encoded path fine. So this is the complete fix for this class in `routes` — that closes out the "I have not checked the other lookups nearby" caveat I left in #1213.

## Tests

`handleFallbackFalse` had no unit coverage, so this adds a `describe` block with three cases: the percent-encoded prerendered path (fails without the fix, returning `/404`), an ASCII prerendered path (guards against a regression in the common case), and a genuinely-absent path (still 404s, so the fix does not make the lookup permissive).

Verified failing-then-passing against the new tests; `packages/open-next` typechecks and `biome check` is clean on the changed files. The two unrelated suites that fail locally (`tagCache/dynamodb`, `adapters/image-optimization`) fail identically on an unmodified checkout.

This fix has been running in production as a `patch-package` patch since 2026-08-14 on the site described above, serving all 476 URLs correctly under workerd via `@opennextjs/cloudflare`.
