### PR TITLE
Fix handling of compound `set-cookie` headers in middleware

### DIFF
--- a/.changeset/split-compound-middleware-cookies.md
+++ b/.changeset/split-compound-middleware-cookies.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: split the compound `set-cookie` header set by `cookies()` in the middleware

--- a/examples/app-router/proxy.ts
+++ b/examples/app-router/proxy.ts
@@ -1,16 +1,24 @@
+import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-export default function proxy(request: NextRequest) {
+export default async function proxy(request: NextRequest) {
   const path = request.nextUrl.pathname; //new URL(request.url).pathname;
 
   const host = request.headers.get("host");
   const protocol = host?.startsWith("localhost") ? "http" : "https";
   if (path === "/redirect") {
     const u = new URL("/redirect-destination", `${protocol}://${host}`);
-    return NextResponse.redirect(u, {
-      headers: { "set-cookie": "test=success" },
+    // Next folds the cookies set through `cookies()` into a single comma-joined
+    // `set-cookie` header, they have to be split back.
+    // For: middleware.cookies.test.ts
+    const cookieStore = await cookies();
+    cookieStore.set("test", "success");
+    // `Expires` contains a comma, it must not be mistaken for a cookie separator.
+    cookieStore.set("test2", "success2", {
+      expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
     });
+    return NextResponse.redirect(u);
   }
   if (path === "/rewrite") {
     const u = new URL("/rewrite-destination", `${protocol}://${host}`);

--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -6,6 +6,7 @@ import {
   NextConfig,
   PrerenderManifest,
 } from "config/index.js";
+import { parseSetCookieHeader } from "http/util.js";
 import type {
   InternalEvent,
   InternalResult,
@@ -152,7 +153,14 @@ export async function handleMiddleware(
       }
     }
   });
-  const setCookies = responseHeaders.getSetCookie();
+  // Next folds the cookies set through `cookies()` in the middleware into a single
+  // comma-joined `set-cookie` header, so each entry here may be compound.
+  // Next itself splits them back in `runMiddleware` (`next-server.ts`).
+  const setCookies = responseHeaders
+    .getSetCookie()
+    .flatMap((maybeCompoundCookie) =>
+      parseSetCookieHeader(maybeCompoundCookie),
+    );
   if (setCookies.length > 0) {
     resHeaders["set-cookie"] = setCookies;
   }

--- a/packages/tests-e2e/tests/appRouter/middleware.cookies.test.ts
+++ b/packages/tests-e2e/tests/appRouter/middleware.cookies.test.ts
@@ -21,6 +21,22 @@ test.describe("Middleware Cookies", () => {
 
     expect(await page.getByTestId("foo").textContent()).toBe("bar");
   });
+  test("should split the compound cookies of a direct middleware response", async ({
+    page,
+    context,
+  }) => {
+    // Next folds the cookies set through `cookies()` into a single comma-joined
+    // `set-cookie` header, they have to be split back for the browser to accept them.
+    await page.goto("/redirect");
+    await page.waitForURL("/redirect-destination");
+
+    const cookies = await context.cookies();
+    const first = cookies.find(({ name }) => name === "test");
+    expect(first?.value).toEqual("success");
+
+    const second = cookies.find(({ name }) => name === "test2");
+    expect(second?.value).toEqual("success2");
+  });
   test("should not expose internal Next headers in response", async ({
     page,
     context,

--- a/packages/tests-unit/tests/core/routing/middleware.test.ts
+++ b/packages/tests-unit/tests/core/routing/middleware.test.ts
@@ -405,6 +405,41 @@ describe("handleMiddleware", () => {
     expect(result.headers.location).toEqual("https://example.com/");
   });
 
+  it("should split the compound set-cookie header Next uses for cookies() in the middleware", async () => {
+    // Next folds the cookies set through `cookies()` in the middleware into a
+    // single comma-joined `set-cookie` header.
+    const compoundCookie =
+      "compound1=value1; Path=/; Expires=Thu, 01 Jan 2026 00:00:00 GMT, compound2=value2; Path=/; HttpOnly";
+    const foldingHeaders = {
+      forEach(fn: (value: string, key: string) => void) {
+        fn(compoundCookie, "set-cookie");
+        fn("http://localhost/rewrite", "x-middleware-rewrite");
+      },
+      get(name: string) {
+        if (name.toLowerCase() === "x-middleware-rewrite")
+          return "http://localhost/rewrite";
+        return null;
+      },
+      getSetCookie() {
+        return [compoundCookie];
+      },
+    };
+
+    const event = createEvent({ headers: { host: "localhost" } });
+    middleware.mockResolvedValue({
+      status: 200,
+      headers: foldingHeaders,
+      body: null,
+    });
+
+    const result = await handleMiddleware(event, "", middlewareLoader);
+
+    expect(result.responseHeaders?.["set-cookie"]).toEqual([
+      "compound1=value1; Path=/; Expires=Thu, 01 Jan 2026 00:00:00 GMT",
+      "compound2=value2; Path=/; HttpOnly",
+    ]);
+  });
+
   it("should preserve multiple set-cookie headers when middleware returns next() with a rewrite", async () => {
     const foldingHeaders = {
       forEach(fn: (value: string, key: string) => void) {


### PR DESCRIPTION
Update middleware to properly split compound `set-cookie` headers set by the `cookies()` function. Enhance tests to verify correct behavior when handling multiple cookies.