### PR TITLE
fix: mark sharp as external when bundling next-server

### DIFF
--- a/.changeset/externalize-sharp-next-server.md
+++ b/.changeset/externalize-sharp-next-server.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: mark `sharp` as external when bundling `next-server`

--- a/packages/open-next/src/build/bundleNextServer.ts
+++ b/packages/open-next/src/build/bundleNextServer.ts
@@ -40,6 +40,10 @@ const externals = [
   // We need to remove this since this is what webpack is building
   // Adding it cause to add a lot of unnecessary deps
   "next/dist/compiled/next-server",
+
+  // Next's image-optimizer does `require("sharp")`. When sharp is installed,
+  // esbuild tries to bundle its native `.node` binaries and the build fails.
+  "sharp",
 ];
 
 export async function bundleNextServer(

--- a/packages/tests-unit/tests/build/bundleNextServer.test.ts
+++ b/packages/tests-unit/tests/build/bundleNextServer.test.ts
@@ -1,0 +1,91 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { bundleNextServer } from "@opennextjs/aws/build/bundleNextServer.js";
+import { afterEach } from "vitest";
+
+function write(file: string, content: string) {
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+/**
+ * Next's compiled `next-server` graph includes a bare `require("sharp")` in
+ * `image-optimizer`. Recreate that here so the test does not depend on Next
+ * or sharp being present in this workspace.
+ */
+function createAppWithSharp(): string {
+  const appPath = mkdtempSync(
+    path.join(tmpdir(), "opennext-bundle-next-server-"),
+  );
+  write(
+    path.join(appPath, "package.json"),
+    JSON.stringify({ name: "test-app" }),
+  );
+  write(
+    path.join(appPath, "node_modules/next/package.json"),
+    JSON.stringify({ name: "next" }),
+  );
+  write(
+    path.join(appPath, "node_modules/next/dist/esm/server/next-server.js"),
+    `let _sharp;
+function getSharp() {
+  _sharp = require("sharp");
+  return _sharp;
+}
+export default class NextServer {
+  constructor() {
+    this.getSharp = getSharp;
+  }
+}
+`,
+  );
+  write(
+    path.join(appPath, "node_modules/sharp/package.json"),
+    JSON.stringify({ name: "sharp", main: "lib/index.js" }),
+  );
+  write(
+    path.join(appPath, "node_modules/sharp/lib/index.js"),
+    `module.exports = require("../build/sharp-linux-x64.node");
+`,
+  );
+  write(
+    path.join(appPath, "node_modules/sharp/build/sharp-linux-x64.node"),
+    "native-binary-placeholder",
+  );
+  return appPath;
+}
+
+describe("bundleNextServer", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not bundle sharp native binaries when sharp is resolvable", async () => {
+    const appPath = createAppWithSharp();
+    const outputDir = mkdtempSync(
+      path.join(tmpdir(), "opennext-bundle-next-server-out-"),
+    );
+    dirs.push(appPath, outputDir);
+
+    await bundleNextServer(outputDir, appPath, { minify: false });
+
+    const bundled = readFileSync(
+      path.join(outputDir, "next-server.runtime.prod.js"),
+      "utf8",
+    );
+    expect(bundled).toMatch(/require\(["']sharp["']\)/);
+    expect(bundled).not.toContain("native-binary-placeholder");
+  });
+});


### PR DESCRIPTION
Add `"sharp"` to the hardcoded `externals` array in `bundleNextServer` so esbuild leaves `sharp` as a runtime `require`.

`bundleNextServer` bundles `next/dist/esm/server/next-server.js`. Next's compiled `image-optimizer` still does `require("sharp")` from that graph, even when image optimization is unused. If `sharp` is resolvable (including as Next's optional dependency), the build fails with `Could not resolve require("../src/build/Release/sharp-*-*.node")` and `No loader is configured for ".node" files`. The same exclusion already exists for traced server files and for the image-optimization bundle.

Fixes #1238

## Decision

The other option is a user/adapter hook to extend esbuild externals, or a generic `.node` plugin. On #1116 a maintainer said esbuild here is meant for OpenNext's own code, not a new config surface for Next/user packages. The reporter's working workaround is this list entry. Can switch to a `.node` plugin or a narrow extra-externals option.

## Test plan

- [x] Unit test `bundleNextServer` with a fixture `next-server` that `require("sharp")`s a dummy `.node` file: build succeeds, output keeps `require("sharp")`, native bytes are not inlined.
- [ ] With `experimentalBundledNextServer: true` and `sharp` resolvable in `node_modules`, `open-next build` (or the Cloudflare adapter build that calls `bundleNextServer`) completes the "Building server function: default" step without `.node` loader errors.
- [ ] Default path (`experimentalBundledNextServer` unset) still traces/excludes `sharp` as before; image-optimization function still installs sharp separately.

The last two were not run.
