### PR TITLE
fix: quote cache interceptor ETag values as HTTP entity-tags

### DIFF
--- a/.changeset/quote-cache-interceptor-etag.md
+++ b/.changeset/quote-cache-interceptor-etag.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: quote cache interceptor ETag values so they are valid HTTP entity-tags

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -65,7 +65,9 @@ async function computeCacheControl(
   // calculate age
   const age = Math.round((Date.now() - (lastModified ?? 0)) / 1000);
   const hash = (str: string) => createHash("md5").update(str).digest("hex");
-  const etag = hash(body);
+  // RFC 9110 entity-tag is a quoted opaque-tag. CloudFront drops unquoted ETags
+  // when serving compressed objects.
+  const etag = `"${hash(body)}"`;
   if (revalidate === 0) {
     // This one should never happen
     return {

--- a/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
+++ b/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
@@ -1,4 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
+import { createHash } from "node:crypto";
+
 import { NextConfig } from "@opennextjs/aws/adapters/config/index.js";
 import { cacheInterceptor } from "@opennextjs/aws/core/routing/cacheInterceptor.js";
 import { convertFromQueryString } from "@opennextjs/aws/core/routing/util.js";
@@ -196,6 +198,23 @@ describe("cacheInterceptor", () => {
         }),
       }),
     );
+  });
+
+  it("should quote the etag as an HTTP entity-tag", async () => {
+    const event = createEvent({
+      url: "/albums",
+    });
+    incrementalCache.get.mockResolvedValueOnce({
+      value: {
+        type: "app",
+        html: "Hello, world!",
+      },
+    });
+
+    const result = await cacheInterceptor(event);
+
+    const expectedEtag = `"${createHash("md5").update("Hello, world!").digest("hex")}"`;
+    expect(result.headers.etag).toBe(expectedEtag);
   });
 
   it("should retrieve index app router content from the index cache key", async () => {


### PR DESCRIPTION
Quote the interceptor-computed value at the existing assignment in `computeCacheControl`: `etag: "<md5>"`. With `dangerous.enableCacheInterception`, the interceptor served `etag: <md5>` (raw hex). RFC 9110 requires a quoted entity-tag, and CloudFront removes ETags that do not begin with `"` or `W/` when it compresses the object, so clients never see a validator. The reporter already tested the patch from #1183 via a local patch and a deployment (sst@4.14.3, @opennextjs/aws@4.0.3, next@16.2.6).

Fixes #1183

## Decision

The other option is to quote only the HTTP header and leave the SQS `eTag` / deduplication id as the raw hash. One assignment feeds the response header, the revalidation queue body, and the dedup id. Queue implementations only stringify / hash that field; the revalidate worker does not read `eTag`. Quoting at the assignment is the smallest change. Dedup ids will not collide with in-flight pre-upgrade messages, so a rolling deploy can fire one extra revalidation in the 5-minute SQS window.

Can switch to header-only quoting if you would rather leave the queue payload unchanged.

## Test plan

- [x] Unit test fails without the quotes (`6cd3556deb0da54bca060b4c39479839`) and passes with them (`"6cd3556deb0da54bca060b4c39479839"`).
- [x] Full `cacheInterceptor` unit file: 54 passed.
- [ ] Optional: deploy with `enableCacheInterception: true` in front of CloudFront compression and confirm the viewer still receives `etag: "<hex>"`.

The CloudFront deploy check was not run.
