### PR TITLE
fix: scope composable cache pending writes to the request, not the isolate

### DIFF
--- a/.changeset/composable-cache-request-scope.md
+++ b/.changeset/composable-cache-request-scope.md
@@ -1,0 +1,7 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: scope the composable cache's pending writes to the request, not the isolate
+
+The map of in-flight `'use cache'` writes was module-scoped. On a runtime that serves many concurrent requests from one isolate (e.g. Cloudflare Workers) a pending write promise from one request could be handed to another; if the first request's context was torn down before the write settled, the second hung and the key stayed poisoned for the life of the isolate. The map now lives in the per-request `RequestCache`.

--- a/packages/open-next/src/adapters/composable-cache.ts
+++ b/packages/open-next/src/adapters/composable-cache.ts
@@ -4,17 +4,39 @@ import { isStale, writeTags } from "utils/cache";
 import { fromReadableStream, toReadableStream } from "utils/stream";
 import { debug } from "./logger";
 
-const pendingWritePromiseMap = new Map<
-  string,
-  Promise<CacheValue<"composable">>
->();
+/**
+ * In-flight writes are tracked per request, not per module.
+ *
+ * A module-scope map is per isolate. On a runtime that serves one request per
+ * sandbox that is the same as per request, but on a runtime that serves many
+ * concurrent requests from one isolate (e.g. Cloudflare Workers) a pending
+ * write promise created in request A would be handed to request B. If A's
+ * context is torn down before the write settles, B awaits a promise that never
+ * resolves, `.finally()` never runs, and the key stays poisoned for the life of
+ * the isolate.
+ *
+ * `RequestCache` is the per-request store the tag caches already use for this.
+ * Scoping the map to it keeps the read-coherence a `get` needs for a write in
+ * flight from the same render while making a cross-request share impossible.
+ * With no ALS store (e.g. at build time) the dedupe is skipped and `get` falls
+ * through to the incremental cache.
+ */
+const PENDING_WRITES_CACHE_KEY = "composable-cache:pending-writes";
+
+const getPendingWritePromiseMap = () =>
+  globalThis.__openNextAls
+    ?.getStore()
+    ?.requestCache?.getOrCreate<string, Promise<CacheValue<"composable">>>(
+      PENDING_WRITES_CACHE_KEY,
+    );
 
 export default {
   async get(cacheKey: string) {
     try {
       // We first check if we have a pending write for this cache key
       // If we do, we return the pending promise instead of fetching the cache
-      if (pendingWritePromiseMap.has(cacheKey)) {
+      const pendingWritePromiseMap = getPendingWritePromiseMap();
+      if (pendingWritePromiseMap?.has(cacheKey)) {
         const stored = pendingWritePromiseMap.get(cacheKey);
         if (stored) {
           return stored.then((entry) => ({
@@ -91,10 +113,11 @@ export default {
       ...entry,
       value: await fromReadableStream(entry.value),
     }));
-    pendingWritePromiseMap.set(cacheKey, promiseEntry);
+    const pendingWritePromiseMap = getPendingWritePromiseMap();
+    pendingWritePromiseMap?.set(cacheKey, promiseEntry);
 
     const entry = await promiseEntry.finally(() => {
-      pendingWritePromiseMap.delete(cacheKey);
+      pendingWritePromiseMap?.delete(cacheKey);
     });
     await globalThis.incrementalCache.set(
       cacheKey,

--- a/packages/tests-unit/tests/adapters/composable-cache.test.ts
+++ b/packages/tests-unit/tests/adapters/composable-cache.test.ts
@@ -1,4 +1,5 @@
 import ComposableCache from "@opennextjs/aws/adapters/composable-cache";
+import { RequestCache } from "@opennextjs/aws/utils/requestCache.js";
 import {
   fromReadableStream,
   toReadableStream,
@@ -50,19 +51,24 @@ describe("Composable cache handler", () => {
   globalThis.cdnInvalidationHandler = invalidateCdnHandler;
   const writtenTags = new Set();
 
+  const createStore = () => ({
+    pendingPromiseRunner: {
+      withResolvers: vi.fn().mockReturnValue({
+        resolve: vi.fn(),
+      }),
+    },
+    writtenTags,
+    requestCache: new RequestCache(),
+  });
+  let store = createStore();
+
   globalThis.__openNextAls = {
-    getStore: () => ({
-      pendingPromiseRunner: {
-        withResolvers: vi.fn().mockReturnValue({
-          resolve: vi.fn(),
-        }),
-      },
-      writtenTags,
-    }),
+    getStore: () => store,
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    store = createStore();
 
     globalThis.openNextConfig = {
       dangerous: {
@@ -267,6 +273,43 @@ describe("Composable cache handler", () => {
 
       // Wait for set to complete
       await setPromise;
+    });
+
+    it("should not return a pending write from another request", async () => {
+      // A write whose request context is torn down never settles.
+      const neverSettles = new Promise<never>(() => {});
+
+      // Request A starts the write...
+      void ComposableCache.set("pending-key", neverSettles);
+
+      // ...and request B asks for the same key. It must reach the store
+      // rather than attach to A's promise (which would hang this test).
+      store = createStore();
+      const result = await ComposableCache.get("pending-key");
+
+      expect(result).toBeDefined();
+      expect(incrementalCache.get).toHaveBeenCalledWith(
+        "pending-key",
+        "composable",
+      );
+    });
+
+    it("should fall through to the store when there is no request context", async () => {
+      const neverSettles = new Promise<never>(() => {});
+      void ComposableCache.set("pending-key", neverSettles);
+
+      const getStore = globalThis.__openNextAls.getStore;
+      globalThis.__openNextAls.getStore = () => undefined;
+      try {
+        const result = await ComposableCache.get("pending-key");
+        expect(result).toBeDefined();
+        expect(incrementalCache.get).toHaveBeenCalledWith(
+          "pending-key",
+          "composable",
+        );
+      } finally {
+        globalThis.__openNextAls.getStore = getStore;
+      }
     });
   });
 


### PR DESCRIPTION
Fixes #1218.

`adapters/composable-cache.ts` kept in-flight `'use cache'` write promises in a module-scope `Map`. Module scope is per isolate, so on a runtime that serves many concurrent requests from one isolate (Cloudflare Workers via `@opennextjs/cloudflare`) request A's pending write promise could be handed to request B. If A's context was torn down before the write settled, B awaited a promise that never resolved, `.finally()` never ran, and the key stayed poisoned for the life of the isolate. Full analysis and measurements are in the issue.

### Change

The map now lives in the per-request `RequestCache` (`utils/requestCache.ts`), which the DynamoDB tag caches already use for the same purpose. A `get` still sees a write in flight from the same render; two request contexts can no longer share a promise. With no ALS store (build time) the dedupe is skipped and `get` falls through to the incremental cache.

### Tests

- The existing "should return pending write promise if available" test now runs against a real `RequestCache` in the mock store.
- New: a write started in one request context is not returned to a `get` from another (the pre-fix behaviour hangs the test).
- New: with no request context, `get` falls through to the incremental cache instead of hanging.

Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tbi1NmauUu87Lp6m3dsPT1