### PR TITLE
fix: preserve existing x-forwarded-host in the edge converter

### DIFF
--- a/.changeset/preserve-x-forwarded-host.md
+++ b/.changeset/preserve-x-forwarded-host.md
@@ -1,0 +1,5 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: preserve existing `x-forwarded-host` in the edge converter

--- a/packages/open-next/src/overrides/converters/edge.ts
+++ b/packages/open-next/src/overrides/converters/edge.ts
@@ -61,7 +61,9 @@ const converter: Converter<InternalEvent, InternalResult | MiddlewareResult> = {
         method: result.internalEvent.method,
         headers: {
           ...result.internalEvent.headers,
-          "x-forwarded-host": result.internalEvent.headers.host,
+          "x-forwarded-host":
+            result.internalEvent.headers["x-forwarded-host"] ??
+            result.internalEvent.headers.host,
         },
       });
 

--- a/packages/tests-unit/tests/converters/edge.test.ts
+++ b/packages/tests-unit/tests/converters/edge.test.ts
@@ -1,0 +1,53 @@
+import converter from "@opennextjs/aws/overrides/converters/edge.js";
+
+function middlewarePassThrough(headers: Record<string, string>) {
+  return {
+    type: "middleware" as const,
+    internalEvent: {
+      type: "core" as const,
+      method: "GET",
+      rawPath: "/",
+      url: "https://bar.example/",
+      headers,
+      query: {},
+      cookies: {},
+      remoteAddress: "::1",
+    },
+    isExternalRewrite: false,
+    origin: false,
+    isISR: false,
+    initialURL: "https://bar.example/",
+    resolvedRoutes: [],
+  };
+}
+
+describe("edge converter convertTo", () => {
+  beforeEach(() => {
+    globalThis.__dangerous_ON_edge_converter_returns_request = true;
+  });
+
+  afterEach(() => {
+    globalThis.__dangerous_ON_edge_converter_returns_request = undefined;
+  });
+
+  it("preserves an existing x-forwarded-host instead of overwriting it with host", async () => {
+    const request = (await converter.convertTo(
+      middlewarePassThrough({
+        host: "bar",
+        "x-forwarded-host": "foo",
+      }),
+    )) as Request;
+
+    expect(request.headers.get("x-forwarded-host")).toBe("foo");
+  });
+
+  it("sets x-forwarded-host from host when it is not already present", async () => {
+    const request = (await converter.convertTo(
+      middlewarePassThrough({
+        host: "bar",
+      }),
+    )) as Request;
+
+    expect(request.headers.get("x-forwarded-host")).toBe("bar");
+  });
+});


### PR DESCRIPTION
## Summary

The edge converter now keeps an existing `x-forwarded-host` when reconstructing a `Request` from a middleware result. If `x-forwarded-host` is missing, the converter still fills it from `host` (previous behavior).

The edge converter previously always replaced `x-forwarded-host` with `host`. Behind a reverse proxy that discarded the original host (Cloudflare Worker: `x-forwarded-host: foo` / `host: bar` became `x-forwarded-host: bar`).

Fixes #1182.

## Decision

Preserve `x-forwarded-host` when present and fall back to `host`, rather than stop setting `x-forwarded-host` entirely. Same precedence as `extractHostFromHeaders`, and the fallback keeps requests that never sent the header working as before. Can drop the fallback if the header should stay unset when it was never sent.

The `foo` / `bar` values are the reporter's on #1182. On #753, when OpenNext is behind a reverse proxy the host should come from `x-forwarded-host`. A trust/config flag for non-proxy setups belongs on #753, not this preserve.

## Test plan

- [x] Unit test: existing `x-forwarded-host` is not overwritten by `host`
- [x] Unit test: missing `x-forwarded-host` is still set from `host`
- [ ] Optional: Worker with better-auth `trustedProxyHeaders` still sees the original host
