### PR TITLE
fix: use --cpu instead of --arch/--target when installing sharp for the image optimizer

### DIFF
--- a/.changeset/fix-image-optimizer-npm-install-flags.md
+++ b/.changeset/fix-image-optimizer-npm-install-flags.md
@@ -1,0 +1,9 @@
+---
+"@opennextjs/aws": patch
+---
+
+Fix `npm install` flags used to install the image optimization function's dependencies (sharp)
+
+`installDependencies` built its cross-platform install command with `--arch` and `--target`, e.g. `npm install --os=linux --arch=arm64 --target=18 --libc=glibc sharp@0.32.6`. npm 11 dropped both flags in favor of `--cpu` (the current name for the `arch` config) and has no replacement for `--target`, since npm's package.json-based `os`/`cpu`/`libc` platform matching — which is what selects sharp's prebuilt binary — was never tied to a Node version. On npm 11+, the install now fails outright with `EUNKNOWNCONFIG: Unknown cli flags: --arch, --target`, so the image optimization function silently ships without `sharp`.
+
+The fix renames `--arch` to `--cpu` and stops passing `--target`. `nodeVersion` on `InstallOptions` is now a no-op and marked deprecated rather than removed, so it's non-breaking for anyone passing a custom `install` config.

--- a/packages/open-next/src/build/createImageOptimizationBundle.ts
+++ b/packages/open-next/src/build/createImageOptimizationBundle.ts
@@ -124,7 +124,6 @@ export async function createImageOptimizationBundle(
       arch: isDev ? undefined : "arm64",
       // Use the local platform in dev
       os: isDev ? os.platform() : "linux",
-      nodeVersion: "18",
       libc: "glibc",
     },
   );

--- a/packages/open-next/src/build/installDeps.ts
+++ b/packages/open-next/src/build/installDeps.ts
@@ -23,19 +23,21 @@ export function installDependencies(
     logger.info(`Installing dependencies for ${name}...`);
     // We then need to run install in the tempDir
     // We don't install in the output dir directly because it could contain a package.json, and npm would then try to reinstall not complete deps from tracing the files
-    const archOption = installOptions.arch
-      ? `--arch=${installOptions.arch}`
-      : "";
-    const targetOption = installOptions.nodeVersion
-      ? `--target=${installOptions.nodeVersion}`
-      : "";
+    //
+    // npm 11 removed the legacy `--arch`/`--target` flags (they now throw
+    // EUNKNOWNCONFIG) in favor of `--cpu`/`--os`/`--libc`, which is also the
+    // set of config keys that package.json `cpu`/`os`/`libc` fields (used by
+    // sharp's optional dependencies) match against. `nodeVersion` has no
+    // equivalent in the new mechanism, since prebuilt N-API binaries aren't
+    // tied to a specific Node version, so it's no longer forwarded.
+    const cpuOption = installOptions.arch ? `--cpu=${installOptions.arch}` : "";
     const libcOption = installOptions.libc
       ? `--libc=${installOptions.libc}`
       : "";
     const osOption = `--os=${installOptions.os ?? "linux"}`;
 
     const additionalArgs = installOptions.additionalArgs ?? "";
-    const installCommand = `npm install ${osOption} ${archOption} ${targetOption} ${libcOption} ${additionalArgs} ${installOptions.packages.join(" ")}`;
+    const installCommand = `npm install ${osOption} ${cpuOption} ${libcOption} ${additionalArgs} ${installOptions.packages.join(" ")}`;
     execSync(installCommand, {
       stdio: "pipe",
       cwd: tempInstallDir,

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -299,7 +299,12 @@ export interface InstallOptions {
   packages: string[];
   /** @default undefined */
   arch?: "x64" | "arm64";
-  /** @default undefined */
+  /**
+   * @default undefined
+   * @deprecated no longer forwarded to `npm install` — npm dropped the
+   * `--target` flag this relied on, and prebuilt N-API binaries aren't
+   * tied to a specific Node version.
+   */
   nodeVersion?: string;
   /** @default undefined */
   libc?: "glibc" | "musl";


### PR DESCRIPTION
## Summary

`installDependencies` (used to install `sharp` for the image optimization function) builds its `npm install` command with `--arch` and `--target`:

```
npm install --os=linux --arch=arm64 --target=18 --libc=glibc sharp@0.32.6
```

npm 11 dropped both flags. `--arch` was renamed to `--cpu`, and `--target` has no replacement — npm's `os`/`cpu`/`libc` package.json-based platform matching (what actually selects sharp's prebuilt binary via its `optionalDependencies`) was never tied to a specific Node version. On npm >=11 this now fails outright:

```
npm error code EUNKNOWNCONFIG
npm error Unknown cli flags:
npm error   - --arch
npm error   - --target
```

`installDependencies` catches and only logs the error, so builds don't fail — the image optimization function just silently ships without `sharp` installed, which surfaces later as broken `next/image` optimization at runtime.

## Changes

- `installDeps.ts`: emit `--cpu` instead of `--arch`, stop emitting `--target`.
- `createImageOptimizationBundle.ts`: drop the now-inert `nodeVersion: "18"` from the default install config.
- `open-next.ts` types: mark `InstallOptions.nodeVersion` as deprecated (kept, non-breaking, for anyone passing a custom `install` config).
- Added a changeset.

Verified locally against npm 12.0.2 that `npm install --os=linux --cpu=arm64 --libc=glibc sharp@0.32.6` succeeds and pulls the correct prebuilt binary, while the old `--arch`/`--target` flags fail as described above.

## Test plan

- [x] `tsc --noEmit` passes on `packages/open-next`
- [x] `biome check` passes on the changed files
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)