### PR TITLE
Enhance cache interceptor for segment prefetching in Next 16

### DIFF
--- a/.changeset/silly-doors-listen.md
+++ b/.changeset/silly-doors-listen.md
@@ -1,0 +1,25 @@
+---
+"@opennextjs/aws": patch
+---
+
+fix: serve segment prefetches from the cache interceptor on Next 16
+
+The segment response branch was gated on `!NextConfig.experimental.prefetchInlining`.
+Next normalizes every truthy `prefetchInlining` into `{ maxSize, maxBundleSize }` and
+enables it by default since 16.2, so the negation was always `false` and the branch was
+unreachable: every `Next-Router-Segment-Prefetch` request was answered with the full page
+payload. The router never recorded the prefetch as satisfied and re-requested it
+indefinitely.
+
+The gate is gone. Inlining only changes *which* segments the build emits - an emitted
+segment then being a bundle that already holds its inlined ancestors - and `segmentData`
+holds exactly those, which is exactly the set the router asks for. When the entry holds
+segments but not the requested one, the interceptor now falls back to the server, which
+answers with the empty 404 Next would, instead of a payload of a different shape.
+
+Also fixed in the same expression: the header was template stringified, so a missing one
+became the literal `"undefined"` and the `Boolean()` guard was always true; and membership
+was tested with `in`, which matches inherited keys, so a
+`next-router-segment-prefetch: constructor` request resolved to a function off
+`Object.prototype`. `prefetchInlining` is now typed as
+`boolean | { maxSize: number; maxBundleSize: number }` to match what Next emits.

--- a/examples/app-router/next.config.ts
+++ b/examples/app-router/next.config.ts
@@ -5,6 +5,11 @@ const nextConfig: NextConfig = {
   cleanDistDir: true,
   transpilePackages: ["@example/shared"],
   output: "standalone",
+  experimental: {
+    // Exercises the non-inlined segment layout (/_head, /_index, per-layout segments)
+    // against the cache interceptor. app-pages-router covers the inlined default.
+    prefetchInlining: false,
+  },
   // outputFileTracingRoot: "../sst",
   images: {
     remotePatterns: [

--- a/examples/app-router/open-next.config.local.ts
+++ b/examples/app-router/open-next.config.local.ts
@@ -13,6 +13,7 @@ export default {
 
   dangerous: {
     middlewareHeadersOverrideNextConfigHeaders: true,
+    enableCacheInterception: true,
   },
 
   imageOptimization: {

--- a/examples/app-router/open-next.config.ts
+++ b/examples/app-router/open-next.config.ts
@@ -10,6 +10,7 @@ const config = {
   functions: {},
   dangerous: {
     middlewareHeadersOverrideNextConfigHeaders: true,
+    enableCacheInterception: true,
   },
   buildCommand: "npx turbo build",
 };

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -138,20 +138,33 @@ function getBodyForAppRouter(
   if (cachedValue.type !== "app") {
     throw new Error("getBodyForAppRouter called with non-app cache value");
   }
-  const segmentHeader = `${event.headers[NEXT_SEGMENT_PREFETCH_HEADER]}`;
-  const isSegmentResponse =
-    Boolean(segmentHeader) &&
-    segmentHeader in (cachedValue.segmentData || {}) &&
-    !NextConfig.experimental?.prefetchInlining;
-
-  if (isSegmentResponse) {
-    return {
-      body: cachedValue.segmentData![segmentHeader],
-      additionalHeaders: {
-        [NEXT_PRERENDER_HEADER]: "1",
-        [NEXT_POSTPONED_HEADER]: "2",
-      },
-    };
+  const segmentHeader = event.headers[NEXT_SEGMENT_PREFETCH_HEADER];
+  // A request from the client Segment Cache has to be answered with the segment it asked
+  // for. The full page payload is not a different-but-valid answer: the router never
+  // records the prefetch as satisfied and re-requests it forever.
+  // This mirrors how Next serves a cached app page - see the `segmentPrefetchHeader`
+  // branch of `packages/next/src/build/templates/app-page.ts`, which responds with the
+  // matching segment or an empty 404, and never with the full page.
+  //
+  // `experimental.prefetchInlining` is deliberately not consulted. Next normalizes every
+  // truthy value - including the 16.2+ default - into `{ maxSize, maxBundleSize }`, so it
+  // must never be read as a flag. More importantly it has no say here: inlining only
+  // changes *which* segments the build emits (an emitted segment then being a bundle that
+  // already holds its inlined ancestors), and `segmentData` holds exactly the segments
+  // that were emitted, which is exactly the set the router asks for.
+  if (typeof segmentHeader === "string" && cachedValue.segmentData) {
+    if (Object.hasOwn(cachedValue.segmentData, segmentHeader)) {
+      return {
+        body: cachedValue.segmentData[segmentHeader],
+        additionalHeaders: {
+          [NEXT_PRERENDER_HEADER]: "1",
+          [NEXT_POSTPONED_HEADER]: "2",
+        },
+      };
+    }
+    // The entry holds segments, but not this one. Next answers with an empty 404 here -
+    // let the server do that rather than serving a payload of a different shape.
+    return undefined;
   }
   // `rsc` is absent when the build collected neither a `.rsc` nor a `.prefetch.rsc` file for
   // this entry - fallback shells, and postponed PPR routes on Next 16.2+, see `CachedFile`.

--- a/packages/open-next/src/types/next-types.ts
+++ b/packages/open-next/src/types/next-types.ts
@@ -84,9 +84,11 @@ export interface NextConfig {
     appDir?: boolean;
     optimizeCss?: boolean;
     // Used by Next to know if we should send a single RSC or split it into multiple ones.
-    // Can be an object but only the boolean is supported for now in OpenNext.
-    // Added in Next 16.2
-    prefetchInlining?: boolean;
+    // Added in Next 16.2.
+    // Next normalizes a truthy value into an object, so this is only ever `false`,
+    // `undefined` or an object - never `true` - in `required-server-files.json`.
+    // Do not test it for truthiness expecting a flag.
+    prefetchInlining?: boolean | { maxSize: number; maxBundleSize: number };
   };
   images: ImageConfig;
   poweredByHeader?: boolean;

--- a/packages/tests-e2e/tests/appPagesRouter/segmentPrefetch.test.ts
+++ b/packages/tests-e2e/tests/appPagesRouter/segmentPrefetch.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "@playwright/test";
+
+// This app runs with `dangerous.enableCacheInterception`, so these requests are answered
+// by the cache interceptor rather than by NextServer - `x-opennext-cache` asserts that.
+//
+// A request from the client Segment Cache has to be answered with the segment it asked
+// for. Answering with the full page payload is not a different-but-valid response: the
+// router never records the prefetch as satisfied and re-requests it forever.
+// See https://github.com/opennextjs/opennextjs-aws/issues/1212
+test.describe("Segment prefetch", () => {
+  const prefetchHeaders = { rsc: "1", "next-router-prefetch": "1" };
+
+  test("full prefetch returns the page payload without a segment marker", async ({
+    request,
+  }) => {
+    const res = await request.get("/albums", { headers: prefetchHeaders });
+
+    expect(res.status()).toEqual(200);
+    expect(res.headers()["x-opennext-cache"]).toEqual("HIT");
+    expect(res.headers()["content-type"]).toContain("text/x-component");
+    // Absent marker is how the router tells "this route has no segment cache" from
+    // "segment cache miss", so it must not be set on a full page response.
+    expect(res.headers()["x-nextjs-postponed"]).toBeUndefined();
+  });
+
+  test("segment prefetch returns that segment, not the full page", async ({
+    request,
+  }) => {
+    const full = await request.get("/albums", { headers: prefetchHeaders });
+    const fullBody = await full.body();
+
+    for (const segment of ["/_tree", "/albums/__PAGE__"]) {
+      const res = await request.get("/albums", {
+        headers: {
+          ...prefetchHeaders,
+          "next-router-segment-prefetch": segment,
+        },
+      });
+
+      expect(res.status()).toEqual(200);
+      expect(res.headers()["x-opennext-cache"]).toEqual("HIT");
+      expect(res.headers()["x-nextjs-postponed"]).toEqual("2");
+
+      // The regression served the full page payload here, byte for byte.
+      const body = await res.body();
+      expect(body.equals(fullBody)).toBe(false);
+      expect(body.length).toBeLessThan(fullBody.length);
+    }
+  });
+
+  test("each segment prefetch returns a distinct payload", async ({
+    request,
+  }) => {
+    const get = async (segment: string) =>
+      (
+        await request.get("/albums", {
+          headers: {
+            ...prefetchHeaders,
+            "next-router-segment-prefetch": segment,
+          },
+        })
+      ).body();
+
+    const [tree, page] = await Promise.all([
+      get("/_tree"),
+      get("/albums/__PAGE__"),
+    ]);
+
+    expect(tree.equals(page)).toBe(false);
+  });
+
+  test("unknown segment is not answered with the full page", async ({
+    request,
+  }) => {
+    const full = await request.get("/albums", { headers: prefetchHeaders });
+    const res = await request.get("/albums", {
+      headers: {
+        ...prefetchHeaders,
+        "next-router-segment-prefetch": "/does-not-exist",
+      },
+    });
+
+    // The interceptor holds segments for this route but not this one, so it falls back
+    // to the server, which answers the way Next does: an empty 404.
+    expect(res.status()).toEqual(404);
+    expect((await res.body()).length).toEqual(0);
+    expect((await full.body()).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/tests-e2e/tests/appRouter/segmentPrefetch.test.ts
+++ b/packages/tests-e2e/tests/appRouter/segmentPrefetch.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+
+// This app runs with `dangerous.enableCacheInterception` and
+// `experimental.prefetchInlining: false`, so Next outlines every segment instead of
+// bundling the small ones into their parent. That emits segment kinds the inlined
+// default never produces - `/_head`, `/_index` and one per layout - and each has to be
+// served from the cache entry rather than replaced by the full page payload.
+// appPagesRouter covers the same contract on the inlined (default) layout.
+// See https://github.com/opennextjs/opennextjs-aws/issues/1212
+test.describe("Segment prefetch with prefetchInlining disabled", () => {
+  const prefetchHeaders = { rsc: "1", "next-router-prefetch": "1" };
+
+  // Every segment `next build` outlines for /albums, except `/_full` which is by
+  // definition the whole page payload and is asserted separately below.
+  const segments = [
+    "/_tree",
+    "/_index",
+    "/_head",
+    "/albums",
+    "/albums/__PAGE__",
+    "/albums/@modal/__DEFAULT__",
+  ];
+
+  const prefetch = (request: any, segment?: string) =>
+    request.get("/albums", {
+      headers: segment
+        ? { ...prefetchHeaders, "next-router-segment-prefetch": segment }
+        : prefetchHeaders,
+    });
+
+  test("every outlined segment is served as itself", async ({ request }) => {
+    const full = await prefetch(request);
+    expect(full.status()).toEqual(200);
+    expect(full.headers()["x-nextjs-postponed"]).toBeUndefined();
+    const fullBody = await full.body();
+
+    const payloads = new Set<string>();
+    for (const segment of segments) {
+      const res = await prefetch(request, segment);
+
+      expect(res.status(), segment).toEqual(200);
+      expect(res.headers()["x-opennext-cache"], segment).toEqual("HIT");
+      expect(res.headers()["x-nextjs-postponed"], segment).toEqual("2");
+
+      // The regression served the full page payload for every one of these.
+      const body = await res.body();
+      expect(body.equals(fullBody), segment).toBe(false);
+      payloads.add(body.toString("base64"));
+    }
+
+    // Distinct payloads, not one response handed back over and over.
+    expect(payloads.size).toEqual(segments.length);
+  });
+
+  test("/_full serves the whole page payload", async ({ request }) => {
+    const full = await prefetch(request);
+    const res = await prefetch(request, "/_full");
+
+    expect(res.status()).toEqual(200);
+    expect(res.headers()["x-nextjs-postponed"]).toEqual("2");
+    expect((await res.body()).equals(await full.body())).toBe(true);
+  });
+
+  test("unknown segment is not answered with the full page", async ({
+    request,
+  }) => {
+    const res = await prefetch(request, "/does-not-exist");
+
+    // The interceptor holds segments for this route but not this one, so it falls back
+    // to the server, which answers the way Next does: an empty 404.
+    expect(res.status()).toEqual(404);
+    expect((await res.body()).length).toEqual(0);
+  });
+});

--- a/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
+++ b/packages/tests-unit/tests/core/routing/cacheInterceptor.test.ts
@@ -747,7 +747,8 @@ describe("cacheInterceptor", () => {
       );
     });
 
-    it("should fall back to RSC when segment key does not exist in segmentData", async () => {
+    // Never the full page: that is the response shape the router cannot accept.
+    it("should fall back to the server when the segment key does not exist in segmentData", async () => {
       const event = createEvent({
         url: "/albums",
         headers: {
@@ -766,13 +767,13 @@ describe("cacheInterceptor", () => {
 
       const result = await cacheInterceptor(event);
 
-      const body = await fromReadableStream(result.body);
-      expect(body).toEqual("RSC content");
-      expect((result as any).headers["x-nextjs-prerender"]).toBeUndefined();
-      expect((result as any).headers["x-nextjs-postponed"]).toBeUndefined();
+      expect(result).toEqual(event);
     });
 
-    it("should fall back to RSC when prefetchInlining is enabled", async () => {
+    // An entry with no segments at all is not a segment-cache route. Next serves the full
+    // payload and omits `x-nextjs-postponed`, which is how the router tells "no segment
+    // cache here" from "segment cache miss".
+    it("should return RSC content for a segment prefetch of an entry without segmentData", async () => {
       const event = createEvent({
         url: "/albums",
         headers: {
@@ -785,10 +786,8 @@ describe("cacheInterceptor", () => {
           type: "app",
           html: "HTML content",
           rsc: "RSC content",
-          segmentData: { "/layout": "Segment content" },
         },
       });
-      (NextConfig as any).experimental = { prefetchInlining: true };
 
       const result = await cacheInterceptor(event);
 
@@ -796,6 +795,73 @@ describe("cacheInterceptor", () => {
       expect(body).toEqual("RSC content");
       expect((result as any).headers["x-nextjs-prerender"]).toBeUndefined();
       expect((result as any).headers["x-nextjs-postponed"]).toBeUndefined();
+    });
+
+    // Inlining only changes which segments the build emits, and `segmentData` holds
+    // exactly those, so a cached segment is served whatever the setting. Next normalizes
+    // every truthy value to `{ maxSize, maxBundleSize }` and enables it by default since
+    // 16.2, which used to make this branch unreachable.
+    // See https://github.com/opennextjs/opennextjs-aws/issues/1212
+    it.each([
+      ["an object", { maxSize: 2048, maxBundleSize: 10240 }],
+      ["a boolean", true],
+      ["disabled", false],
+      ["absent", undefined],
+    ])(
+      "should return segment data when prefetchInlining is %s",
+      async (_, prefetchInlining) => {
+        const event = createEvent({
+          url: "/albums",
+          headers: {
+            rsc: "1",
+            "next-router-segment-prefetch": "/layout",
+          },
+        });
+        incrementalCache.get.mockResolvedValueOnce({
+          value: {
+            type: "app",
+            html: "HTML content",
+            rsc: "RSC content",
+            segmentData: { "/layout": "Segment content" },
+          },
+        });
+        (NextConfig as any).experimental = { prefetchInlining };
+
+        const result = await cacheInterceptor(event);
+
+        const body = await fromReadableStream(result.body);
+        expect(body).toEqual("Segment content");
+        expect(result).toEqual(
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              "x-nextjs-prerender": "1",
+              "x-nextjs-postponed": "2",
+            }),
+          }),
+        );
+      },
+    );
+
+    it("should fall back to the server for a segment inherited from Object.prototype", async () => {
+      const event = createEvent({
+        url: "/albums",
+        headers: {
+          rsc: "1",
+          "next-router-segment-prefetch": "constructor",
+        },
+      });
+      incrementalCache.get.mockResolvedValueOnce({
+        value: {
+          type: "app",
+          html: "HTML content",
+          rsc: "RSC content",
+          segmentData: { "/layout": "Segment content" },
+        },
+      });
+
+      const result = await cacheInterceptor(event);
+
+      expect(result).toEqual(event);
     });
 
     // `rsc` is absent from the cached value when the build collected neither a
@@ -883,7 +949,9 @@ describe("cacheInterceptor", () => {
         expect(result).toEqual(event);
       });
 
-      it("should take no action for an RSC request when rsc is missing and prefetchInlining is enabled", async () => {
+      // A segment prefetch is served from `segmentData` alone, the full page payload is
+      // not needed.
+      it("should serve the segment when rsc is missing and the segment key matches", async () => {
         const event = createEvent({
           url: "/albums",
           headers: {
@@ -898,11 +966,14 @@ describe("cacheInterceptor", () => {
             segmentData: { "/layout": "Segment content" },
           },
         });
-        (NextConfig as any).experimental = { prefetchInlining: true };
+        (NextConfig as any).experimental = {
+          prefetchInlining: { maxSize: 2048, maxBundleSize: 10240 },
+        };
 
         const result = await cacheInterceptor(event);
 
-        expect(result).toEqual(event);
+        const body = await fromReadableStream(result.body);
+        expect(body).toEqual("Segment content");
       });
 
       it("should not queue a revalidation when falling back to the server", async () => {


### PR DESCRIPTION
Improve the cache interceptor to correctly serve segment prefetches by removing the gating condition on `prefetchInlining`. This change ensures that segment requests return the appropriate segment data instead of the full page payload, addressing an issue where prefetch requests were not being satisfied correctly. Additionally, update the type definition for `prefetchInlining` to reflect its new behavior.